### PR TITLE
Add brew page metadata editing

### DIFF
--- a/app/[locale]/account/brews/[brew_id]/page.tsx
+++ b/app/[locale]/account/brews/[brew_id]/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import type { ComponentProps, ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
+import { Check, Pencil, PencilOff, Scale } from "lucide-react";
 
 import {
   useAccountBrew,
@@ -18,9 +20,25 @@ import AddBrewEntryDialog, {
   EntryType,
   OpenAddEntryArgs
 } from "@/components/brews/AddBrewEntryDialog";
+import { RecordVolumeDialog } from "@/components/brews/RecordVolumeDialog";
 import { useRecipe } from "@/components/providers/RecipeProvider";
 import { BrewStagePath } from "@/components/brews/BrewStagePath";
 import { Button } from "@/components/ui/button";
+import { DateTimePicker } from "@/components/ui/datetime-picker";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog";
+import { Switch } from "@/components/ui/switch";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput
+} from "@/components/ui/input-group";
 import { BREW_ENTRY_TYPE } from "@/lib/brewEnums";
 import { BrewAdditionData, entryPayload } from "@/lib/utils/entryPayload";
 import { useCreateBrewEntry } from "@/hooks/reactQuery/useCreateBrewEntry";
@@ -36,6 +54,13 @@ export default function BrewPageClient() {
 
   const { data: brew, isLoading, isError, error } = useAccountBrew(brewId);
   const { mutateAsync: patchMeta } = usePatchAccountBrewMetadata();
+  const [nameEditable, setNameEditable] = useState(false);
+  const [batchEditable, setBatchEditable] = useState(false);
+  const [nameValue, setNameValue] = useState("");
+  const [batchValue, setBatchValue] = useState("");
+  const [startValue, setStartValue] = useState("");
+  const [startDateDialogOpen, setStartDateDialogOpen] = useState(false);
+  const [recordVolumeOpen, setRecordVolumeOpen] = useState(false);
 
   const formatter = useMemo(
     () =>
@@ -48,6 +73,13 @@ export default function BrewPageClient() {
 
   const formatDate = (d?: string | null) =>
     d ? formatter.format(new Date(d)) : "—";
+
+  useEffect(() => {
+    if (!brew) return;
+    setNameValue(brew.name ?? "");
+    setBatchValue(brew.batch_number != null ? String(brew.batch_number) : "");
+    setStartValue(toDateTimeLocalValue(brew.start_date));
+  }, [brew]);
 
   const [preferredVolumeUnit, setPreferredVolumeUnit] =
     useState<HeaderVolumeUnit>("gal");
@@ -230,19 +262,6 @@ export default function BrewPageClient() {
 
   const batchSummaryItems = [
     {
-      label: t("batchNumber", "Batch"),
-      value:
-        brew?.batch_number != null ? `#${String(brew.batch_number)}` : "—"
-    },
-    {
-      label: t("start", "Start"),
-      value: formatDate(brew?.start_date)
-    },
-    {
-      label: t("brews.primary.currentVolume", "Current volume"),
-      value: formatVolume(brew?.current_volume_liters)
-    },
-    {
       label: t("iSpindelDashboard.brews.latestGrav", "Latest gravity"),
       value: formatGravity(displayLatestGravity)
     },
@@ -264,10 +283,63 @@ export default function BrewPageClient() {
   ].filter(Boolean);
 
   if (brew?.end_date) {
-    batchSummaryItems.splice(2, 0, {
+    batchSummaryItems.splice(0, 0, {
       label: t("end", "End"),
       value: formatDate(brew.end_date)
     });
+  }
+
+  async function saveMetadata(input: Parameters<typeof patchMeta>[0]["input"]) {
+    try {
+      await patchMeta({ brewId: brew!.id, input });
+      toast({ description: t("saved", "Saved.") });
+    } catch (err) {
+      console.error("Error updating brew metadata:", err);
+      toast({
+        description: t("error.generic", "Something went wrong."),
+        variant: "destructive"
+      });
+      throw err;
+    }
+  }
+
+  async function saveName() {
+    if (!brew) return;
+    await saveMetadata({ name: nameValue.trim() || null });
+    setNameEditable(false);
+  }
+
+  async function saveBatchNumber() {
+    if (!brew) return;
+    const trimmed = batchValue.trim();
+    if (trimmed && (!Number.isInteger(Number(trimmed)) || Number(trimmed) < 1)) {
+      toast({
+        description: t("error.generic", "Something went wrong."),
+        variant: "destructive"
+      });
+      return;
+    }
+
+    await saveMetadata({
+      batch_number: trimmed ? Number(trimmed) : null
+    });
+    setBatchEditable(false);
+  }
+
+  async function saveStartDate() {
+    if (!brew || !startValue) return;
+    const date = new Date(startValue);
+
+    if (Number.isNaN(date.getTime())) {
+      toast({
+        description: t("error.generic", "Something went wrong."),
+        variant: "destructive"
+      });
+      return;
+    }
+
+    await saveMetadata({ start_date: date.toISOString() });
+    setStartDateDialogOpen(false);
   }
 
   useEffect(() => {
@@ -328,7 +400,34 @@ export default function BrewPageClient() {
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="space-y-3">
             <div className="flex flex-wrap items-center gap-3">
-              <h1 className="text-2xl font-semibold">{brew.name ?? brew.id}</h1>
+              <InputGroup className="h-12 min-w-[280px] flex-1">
+                <InputGroupInput
+                  value={nameValue}
+                  onChange={(e) => setNameValue(e.target.value)}
+                  disabled={!nameEditable}
+                  placeholder={brew.id}
+                  className="h-11 text-xl"
+                />
+                <InputGroupAddon align="inline-end">
+                  <InputGroupButton
+                    type="button"
+                    title={
+                      nameEditable
+                        ? t("disableEdit", "Disable editing")
+                        : t("edit", "Edit")
+                    }
+                    onClick={() => {
+                      if (nameEditable) {
+                        void saveName();
+                      }
+                      setNameEditable(!nameEditable);
+                    }}
+                    className="h-full"
+                  >
+                    {nameEditable ? <Pencil /> : <PencilOff />}
+                  </InputGroupButton>
+                </InputGroupAddon>
+              </InputGroup>
               <span className="inline-flex items-center rounded-full border border-border bg-background px-3 py-1 text-sm text-muted-foreground">
                 {t(`brewStage.${brew.stage}`, brew.stage)}
               </span>
@@ -353,19 +452,107 @@ export default function BrewPageClient() {
           <section className="rounded-lg border border-border/70 bg-background/40 p-4 space-y-3">
             <h2 className="text-sm font-semibold">{t("brews.label", "Batch")}</h2>
             <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-2">
+              <ActionInputSummaryField
+                label={t("batchNumber", "Batch")}
+                editable={batchEditable}
+                displayValue={
+                  brew.batch_number != null ? `#${String(brew.batch_number)}` : "—"
+                }
+                inputValue={batchValue}
+                onInputChange={setBatchValue}
+                onSave={saveBatchNumber}
+                onToggle={() => {
+                  if (batchEditable) {
+                    setBatchValue(
+                      brew.batch_number != null ? String(brew.batch_number) : ""
+                    );
+                  }
+                  setBatchEditable(!batchEditable);
+                }}
+                inputProps={{
+                  inputMode: "numeric",
+                  placeholder: "1",
+                  onFocus: (e) => e.target.select()
+                }}
+              />
+              <ActionSummaryField
+                label={t("start", "Start")}
+                displayValue={formatDate(brew.start_date)}
+                onEdit={() => {
+                  setStartValue(toDateTimeLocalValue(brew.start_date));
+                  setStartDateDialogOpen(true);
+                }}
+              />
+              <SummaryField
+                label={t("brews.primary.currentVolume", "Current volume")}
+                value={formatVolume(brew.current_volume_liters)}
+                action={
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    onClick={() => setRecordVolumeOpen(true)}
+                    title={t("brews.primary.setVolume", "Record current volume")}
+                  >
+                    <Scale />
+                  </Button>
+                }
+              />
               {batchSummaryItems.map((item) => (
-                <div
-                  key={item.label}
-                  className="border-b border-border/60 py-2"
-                >
-                  <dt className="text-xs uppercase tracking-wide text-muted-foreground">
-                    {item.label}
-                  </dt>
-                  <dd className="mt-1 text-sm font-medium text-foreground">
-                    {item.value}
-                  </dd>
-                </div>
+                item.label === t("iSpindelDashboard.brews.latestGrav", "Latest gravity") ? (
+                  <SummaryField
+                    key={item.label}
+                    label={item.label}
+                    value={item.value}
+                    action={
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() =>
+                          openAddEntry({
+                            presetType: BREW_ENTRY_TYPE.GRAVITY as EntryType,
+                            allowedTypes: [BREW_ENTRY_TYPE.GRAVITY as EntryType]
+                          })
+                        }
+                        title={t("brew.addGravity", "Add gravity reading")}
+                      >
+                        <Scale />
+                      </Button>
+                    }
+                  />
+                ) : (
+                  <div
+                    key={item.label}
+                    className="border-b border-border/60 py-2"
+                  >
+                    <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+                      {item.label}
+                    </dt>
+                    <dd className="mt-1 text-sm font-medium text-foreground">
+                      {item.value}
+                    </dd>
+                  </div>
+                )
               ))}
+              <SummaryField
+                label={t("emailAlerts.title", "Email alerts")}
+                value={
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="text-sm font-medium text-foreground">
+                      {brew.requested_email_alerts
+                        ? t("on", "On")
+                        : t("off", "Off")}
+                    </span>
+                    <Switch
+                      checked={brew.requested_email_alerts}
+                      onCheckedChange={async (checked) => {
+                        await saveMetadata({
+                          requested_email_alerts: checked
+                        });
+                      }}
+                    />
+                  </div>
+                }
+              />
             </dl>
           </section>
 
@@ -394,19 +581,53 @@ export default function BrewPageClient() {
         stage={brew.stage}
         entries={allEntries}
         onMoveToStage={async (to) => {
-          await patchMeta({ brewId: brew.id, input: { stage: to } });
-          toast({ description: t("saved", "Saved.") });
+          await saveMetadata({ stage: to });
         }}
         openAddEntry={openAddEntry}
         addAddition={addAddition}
         addAdditions={addAdditions}
         current_volume_liters={brew.current_volume_liters}
         patchBrewMetadata={async (input) => {
-          await patchMeta({ brewId: brew.id, input });
-          toast({ description: t("saved", "Saved.") });
+          await saveMetadata(input);
         }}
         hasRecipeLinked={Boolean(brew.recipe_id)}
       />
+      <RecordVolumeDialog
+        t={t}
+        open={recordVolumeOpen}
+        onOpenChange={setRecordVolumeOpen}
+        currentVolumeLiters={brew.current_volume_liters}
+        onSave={(volume) => saveMetadata({ current_volume_liters: volume })}
+      />
+      <Dialog
+        open={startDateDialogOpen}
+        onOpenChange={setStartDateDialogOpen}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("start", "Start")}</DialogTitle>
+          </DialogHeader>
+          <DateTimePicker
+            value={startValue ? new Date(startValue) : new Date(brew.start_date)}
+            onChange={(value) =>
+              setStartValue(value ? toDateTimeLocalValue(value.toISOString()) : "")
+            }
+            hourCycle={12}
+          />
+          <DialogFooter>
+            <Button
+              variant="secondary"
+              onClick={() => {
+                setStartValue(toDateTimeLocalValue(brew.start_date));
+                setStartDateDialogOpen(false);
+              }}
+            >
+              {t("cancel", "Cancel")}
+            </Button>
+            <Button onClick={saveStartDate}>{t("save", "Save")}</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       <AddBrewEntryDialog
         brewId={brew.id}
         open={entryOpen}
@@ -544,4 +765,119 @@ function BrewPageSkeleton() {
       </div>
     </div>
   );
+}
+
+function SummaryField({
+  label,
+  value,
+  action
+}: {
+  label: string;
+  value: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="border-b border-border/60 py-2">
+      <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="text-sm font-medium text-foreground">{value}</div>
+          {action}
+        </div>
+      </dd>
+    </div>
+  );
+}
+
+function ActionInputSummaryField({
+  label,
+  editable,
+  displayValue,
+  inputValue,
+  onInputChange,
+  onSave,
+  onToggle,
+  inputProps
+}: {
+  label: string;
+  editable: boolean;
+  displayValue: string;
+  inputValue: string;
+  onInputChange: (value: string) => void;
+  onSave: () => Promise<void>;
+  onToggle: () => void;
+  inputProps?: ComponentProps<typeof InputGroupInput>;
+}) {
+  return (
+    <div className="border-b border-border/60 py-2">
+      <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1">
+        <InputGroup className="h-10">
+          <InputGroupInput
+            {...inputProps}
+            value={editable ? inputValue : displayValue}
+            onChange={(e) => {
+              if (!editable) return;
+              onInputChange(e.target.value);
+            }}
+            disabled={!editable}
+            className="h-full text-sm font-medium"
+          />
+          <InputGroupAddon align="inline-end">
+            {editable ? (
+              <InputGroupButton size="icon-xs" onClick={onSave}>
+                <Check />
+              </InputGroupButton>
+            ) : null}
+            <InputGroupButton size="icon-xs" onClick={onToggle}>
+              {editable ? <PencilOff /> : <Pencil />}
+            </InputGroupButton>
+          </InputGroupAddon>
+        </InputGroup>
+      </dd>
+    </div>
+  );
+}
+
+function ActionSummaryField({
+  label,
+  displayValue,
+  onEdit
+}: {
+  label: string;
+  displayValue: string;
+  onEdit: () => void;
+}) {
+  return (
+    <div className="border-b border-border/60 py-2">
+      <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-sm font-medium text-foreground">
+            {displayValue}
+          </span>
+          <Button size="icon" variant="ghost" className="h-8 w-8" onClick={onEdit}>
+            <Pencil />
+          </Button>
+        </div>
+      </dd>
+    </div>
+  );
+}
+
+function toDateTimeLocalValue(value?: string | null) {
+  if (!value) return "";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+
+  const offset = date.getTimezoneOffset();
+  const local = new Date(date.getTime() - offset * 60 * 1000);
+  return local.toISOString().slice(0, 16);
 }

--- a/hooks/reactQuery/useAccountBrews.ts
+++ b/hooks/reactQuery/useAccountBrews.ts
@@ -15,7 +15,9 @@ export type AccountBrewListItem = {
   end_date: string | null;
 
   stage: BrewStage;
+  batch_number: number | null;
   current_volume_liters: number | null;
+  requested_email_alerts: boolean;
 
   recipe_id: number | null;
   recipe_name: string | null;
@@ -53,6 +55,7 @@ export type AccountBrew = {
   stage: BrewStage;
   batch_number: number | null;
   current_volume_liters: number | null;
+  requested_email_alerts: boolean;
 
   latest_gravity: number | null;
 
@@ -184,6 +187,8 @@ export function useCreateAccountBrew() {
  */
 export type PatchAccountBrewMetadataInput = {
   name?: string | null;
+  batch_number?: number | null;
+  start_date?: string;
   stage?: BrewStage;
   current_volume_liters?: number | null;
   requested_email_alerts?: boolean;
@@ -225,6 +230,9 @@ export function usePatchAccountBrewMetadata() {
         accountBrewsQk.detail(updated.id),
         (old) => (old ? ({ ...old, ...updated } as AccountBrew) : old)
       );
+      queryClient.invalidateQueries({
+        queryKey: accountBrewsQk.list()
+      });
       queryClient.invalidateQueries({
         queryKey: accountBrewsQk.detail(vars.brewId)
       });

--- a/lib/db/brews.ts
+++ b/lib/db/brews.ts
@@ -13,7 +13,9 @@ export type BrewListItem = {
   end_date: Date | null;
 
   stage: brew_stage;
+  batch_number: number | null;
   current_volume_liters: number | null;
+  requested_email_alerts: boolean;
 
   recipe_id: number | null;
   recipe_name: string | null;
@@ -51,6 +53,7 @@ export type BrewForApp = {
   stage: brew_stage;
   batch_number: number | null;
   current_volume_liters: number | null;
+  requested_email_alerts: boolean;
 
   latest_gravity: number | null;
 
@@ -66,6 +69,8 @@ export type BrewForApp = {
 
 export type PatchBrewMetadataInput = {
   name?: string | null;
+  batch_number?: number | null;
+  start_date?: string | Date;
   stage?: brew_stage;
   current_volume_liters?: number | null;
   requested_email_alerts?: boolean;
@@ -114,7 +119,9 @@ export async function getBrewsForApp(userId: number): Promise<BrewListItem[]> {
       start_date: true,
       end_date: true,
       stage: true,
+      batch_number: true,
       current_volume_liters: true,
+      requested_email_alerts: true,
       latest_gravity: true,
       recipe_id: true,
       recipes: { select: { name: true } },
@@ -129,7 +136,9 @@ export async function getBrewsForApp(userId: number): Promise<BrewListItem[]> {
     end_date: b.end_date,
 
     stage: b.stage,
+    batch_number: b.batch_number,
     current_volume_liters: b.current_volume_liters,
+    requested_email_alerts: b.requested_email_alerts ?? false,
 
     recipe_id: b.recipe_id,
     recipe_name: b.recipes?.name ?? null,
@@ -269,6 +278,7 @@ export async function getBrewForApp(
       stage: true,
       batch_number: true,
       current_volume_liters: true,
+      requested_email_alerts: true,
       latest_gravity: true,
 
       recipe_id: true,
@@ -323,6 +333,7 @@ export async function getBrewForApp(
     stage: brew.stage,
     batch_number: brew.batch_number,
     current_volume_liters: brew.current_volume_liters,
+    requested_email_alerts: brew.requested_email_alerts ?? false,
 
     latest_gravity: brew.latest_gravity,
 
@@ -349,6 +360,7 @@ export async function patchBrewMetadata(
       select: {
         id: true,
         stage: true,
+        start_date: true,
         end_date: true
       }
     });
@@ -367,6 +379,29 @@ export async function patchBrewMetadata(
       const v = input.name;
       data.name =
         typeof v === "string" ? (v.trim() ? v.trim() : null) : v ?? null;
+    }
+
+    // batch_number
+    if ("batch_number" in input) {
+      const v = input.batch_number;
+      if (v === null) {
+        data.batch_number = null;
+      } else {
+        const n = Number(v);
+        if (!Number.isInteger(n) || n < 1) {
+          throw new Error("Invalid batch_number");
+        }
+        data.batch_number = n;
+      }
+    }
+
+    // start_date
+    if ("start_date" in input) {
+      const d = input.start_date instanceof Date
+        ? input.start_date
+        : new Date(input.start_date as any);
+      if (Number.isNaN(d.getTime())) throw new Error("Invalid start_date");
+      data.start_date = d;
     }
 
     // stage
@@ -424,6 +459,18 @@ export async function patchBrewMetadata(
     if (stageIsComplete && !endDateWasSet && !endDateWasCleared) {
       data.end_date = existing.end_date ?? new Date();
       // ^ keep existing end_date if already set, otherwise set now
+    }
+
+    if (endDateWasCleared && finalStageCandidate === brew_stage.COMPLETE) {
+      throw new Error("Cannot clear end_date while brew is complete");
+    }
+
+    const nextStartDate = (data.start_date ?? existing.start_date) as Date;
+    const nextEndDate =
+      "end_date" in data ? (data.end_date as Date | null) : existing.end_date;
+
+    if (nextEndDate && nextStartDate > nextEndDate) {
+      throw new Error("start_date must be before end_date");
     }
 
     if (Object.keys(data).length === 0) {


### PR DESCRIPTION
## Summary
- add brew-page metadata editing for name, batch number, start date, current volume, and email alerts
- keep metadata editing in the brew header and reuse the existing dialogs/entry flows for start date, volume, and gravity
- extend brew metadata patch/query handling so list and detail caches stay in sync

## Testing
- npm exec tsc --noEmit
- npm exec eslint -- 'app/[locale]/account/brews/[brew_id]/page.tsx'