### PR TITLE
Recipe integration: validate brew recipe stage contract

### DIFF
--- a/app/[locale]/account/brews/[brew_id]/page.tsx
+++ b/app/[locale]/account/brews/[brew_id]/page.tsx
@@ -44,6 +44,7 @@ import { BrewAdditionData, entryPayload } from "@/lib/utils/entryPayload";
 import { useCreateBrewEntry } from "@/hooks/reactQuery/useCreateBrewEntry";
 import { L_TO_VOLUME } from "@/lib/utils/recipeDataCalculations";
 import { normalizeNumberString } from "@/lib/utils/validateInput";
+import { buildBrewRecipeStageData } from "@/lib/utils/buildBrewRecipeStageData";
 
 type HeaderVolumeUnit = "gal" | "L";
 
@@ -134,9 +135,19 @@ export default function BrewPageClient() {
   };
 
   const {
-    derived: { ogPrimary, backsweetenedFg, abv, primaryVolumeL, totalVolumeL },
-    meta: { hydrate }
+    meta: { hydrate, reset }
   } = useRecipe();
+
+  const brewRecipe = useMemo(
+    () =>
+      buildBrewRecipeStageData({
+        recipeSnapshot: brew?.recipe_snapshot,
+        currentVolumeLiters: brew?.current_volume_liters,
+        latestGravity: brew?.latest_gravity,
+        entries: brew?.entries
+      }),
+    [brew?.recipe_snapshot, brew?.current_volume_liters, brew?.latest_gravity, brew?.entries]
+  );
 
   const [entryOpen, setEntryOpen] = useState(false);
   const [entryPresetType, setEntryPresetType] = useState<
@@ -213,28 +224,34 @@ export default function BrewPageClient() {
 
   const displayLatestGravity = brew?.latest_gravity ?? latestGravityEntry?.gravity;
   const displayEstimatedOg =
-    typeof ogPrimary === "number" && Number.isFinite(ogPrimary) && ogPrimary > 1
-      ? ogPrimary
+    typeof brewRecipe.derived?.gravity.ogPrimary === "number" &&
+    Number.isFinite(brewRecipe.derived.gravity.ogPrimary) &&
+    brewRecipe.derived.gravity.ogPrimary > 1
+      ? brewRecipe.derived.gravity.ogPrimary
       : null;
   const displayEstimatedFg =
-    typeof backsweetenedFg === "number" &&
-    Number.isFinite(backsweetenedFg) &&
-    backsweetenedFg > 0
-      ? backsweetenedFg
+    typeof brewRecipe.derived?.gravity.backsweetenedFg === "number" &&
+    Number.isFinite(brewRecipe.derived.gravity.backsweetenedFg) &&
+    brewRecipe.derived.gravity.backsweetenedFg > 0
+      ? brewRecipe.derived.gravity.backsweetenedFg
       : null;
   const displayEstimatedAbv =
-    typeof abv === "number" && Number.isFinite(abv) && abv >= 0 ? abv : null;
+    typeof brewRecipe.derived?.alcohol.abv === "number" &&
+    Number.isFinite(brewRecipe.derived.alcohol.abv) &&
+    brewRecipe.derived.alcohol.abv >= 0
+      ? brewRecipe.derived.alcohol.abv
+      : null;
   const displayTargetVolume =
-    typeof totalVolumeL === "number" &&
-    Number.isFinite(totalVolumeL) &&
-    totalVolumeL > 0
-      ? totalVolumeL
+    typeof brewRecipe.derived?.volume.totalL === "number" &&
+    Number.isFinite(brewRecipe.derived.volume.totalL) &&
+    brewRecipe.derived.volume.totalL > 0
+      ? brewRecipe.derived.volume.totalL
       : null;
   const displayPrimaryVolume =
-    typeof primaryVolumeL === "number" &&
-    Number.isFinite(primaryVolumeL) &&
-    primaryVolumeL > 0
-      ? primaryVolumeL
+    typeof brewRecipe.derived?.volume.primaryL === "number" &&
+    Number.isFinite(brewRecipe.derived.volume.primaryL) &&
+    brewRecipe.derived.volume.primaryL > 0
+      ? brewRecipe.derived.volume.primaryL
       : null;
 
   const recipeSummaryItems = [
@@ -345,8 +362,10 @@ export default function BrewPageClient() {
   useEffect(() => {
     if (brew?.recipe_snapshot?.dataV2) {
       hydrate(brew.recipe_snapshot.dataV2);
+      return;
     }
-  }, [brew, hydrate]);
+    reset();
+  }, [brew?.recipe_snapshot, hydrate, reset]);
   const { mutateAsync: createEntry } = useCreateBrewEntry();
   async function addAddition(input: {
     name: string;
@@ -587,10 +606,11 @@ export default function BrewPageClient() {
         addAddition={addAddition}
         addAdditions={addAdditions}
         current_volume_liters={brew.current_volume_liters}
+        recipe={brewRecipe}
         patchBrewMetadata={async (input) => {
           await saveMetadata(input);
         }}
-        hasRecipeLinked={Boolean(brew.recipe_id)}
+        hasRecipeLinked={Boolean(brewRecipe.recipeData)}
       />
       <RecordVolumeDialog
         t={t}

--- a/components/brews/BrewStagePath.tsx
+++ b/components/brews/BrewStagePath.tsx
@@ -17,11 +17,11 @@ import {
   STAGE_FLOW,
   type StageStatus
 } from "./stageConfig";
-import { useRecipe } from "@/components/providers/RecipeProvider";
 import { OpenAddEntryArgs } from "./AddBrewEntryDialog";
 import { useEffect, useState } from "react";
 import { PatchAccountBrewMetadataInput } from "@/hooks/reactQuery/useAccountBrews";
 import { RecordVolumeDialog } from "./RecordVolumeDialog";
+import type { BrewRecipeStageData } from "@/lib/utils/buildBrewRecipeStageData";
 
 function idxOf(stage: BrewStage) {
   const i = STAGE_FLOW.indexOf(stage);
@@ -39,6 +39,7 @@ export function BrewStagePath({
   onMoveToStage,
   entries,
   current_volume_liters,
+  recipe,
   patchBrewMetadata,
   openAddEntry,
   addAddition,
@@ -50,6 +51,7 @@ export function BrewStagePath({
   entries: BrewEntry[];
 
   current_volume_liters: number | null; // ✅ add
+  recipe: BrewRecipeStageData;
   patchBrewMetadata: (input: PatchAccountBrewMetadataInput) => Promise<void>; // ✅ add
 
   openAddEntry: (args?: OpenAddEntryArgs) => void;
@@ -74,10 +76,6 @@ export function BrewStagePath({
 }) {
   const { t } = useTranslation();
   const currentIdx = idxOf(stage);
-
-  const {
-    data: { ingredients }
-  } = useRecipe();
   const [activeId, setActiveId] = useState<BrewStage>(stage);
   const [recordVolumeOpen, setRecordVolumeOpen] = useState(false);
 
@@ -138,8 +136,20 @@ export function BrewStagePath({
             const ctx = {
               brewStage: stage,
               hasRecipeLinked,
-              recipe: { ingredients },
-              brew: { entries, current_volume_liters }
+              recipe: {
+                ...recipe.planned,
+                derived: recipe.derived,
+                snapshot: recipe.snapshot,
+                actual: recipe.actual,
+                effective: recipe.effective
+              },
+              brew: {
+                entries,
+                current_volume_liters,
+                effective_current_volume_liters: recipe.effective.currentVolumeL,
+                latest_gravity: recipe.actual.latestGravity,
+                effective_latest_gravity: recipe.effective.latestGravity
+              }
             };
             const helpers = {
               moveToStage: async (to: BrewStage) => {

--- a/components/brews/stageConfig.ts
+++ b/components/brews/stageConfig.ts
@@ -4,7 +4,6 @@ import {
   type BrewEntryType,
   type BrewStage
 } from "@/lib/brewEnums";
-import type { IngredientLine } from "@/types/recipeData";
 import type { TFunction } from "i18next";
 import type React from "react";
 
@@ -13,8 +12,8 @@ import type React from "react";
 import { PlannedStagePanel } from "./stages/PlannedStagePanel";
 import { OpenAddEntryArgs } from "./AddBrewEntryDialog";
 import { PrimaryStagePanel } from "./stages/PrimaryStagePanel";
-import { BrewAdditionData } from "@/lib/utils/entryPayload";
 import { PatchAccountBrewMetadataInput } from "@/hooks/reactQuery/useAccountBrews";
+import type { BrewRecipeStageData } from "@/lib/utils/buildBrewRecipeStageData";
 
 export type StageStatus = "past" | "current" | "future";
 export type BrewEntry = {
@@ -33,12 +32,18 @@ export type BrewStageContext = {
   hasRecipeLinked: boolean;
 
   // recipe snapshot/provider data that panels can render
-  recipe: {
-    ingredients: IngredientLine[];
+  recipe: BrewRecipeStageData["planned"] & {
+    derived: BrewRecipeStageData["derived"];
+    snapshot: BrewRecipeStageData["snapshot"];
+    actual: BrewRecipeStageData["actual"];
+    effective: BrewRecipeStageData["effective"];
   };
   brew: {
     entries: BrewEntry[];
     current_volume_liters: number | null;
+    effective_current_volume_liters: number | null;
+    latest_gravity: number | null;
+    effective_latest_gravity: number | null;
   };
 };
 
@@ -125,24 +130,14 @@ export type StageMoveDecision = {
 
 function getPlannedPrimaryIngredientIds(ctx: BrewStageContext) {
   return new Set(
-    (ctx.recipe.ingredients ?? [])
-      .filter((l) => !l.secondary)
+    (ctx.recipe.primaryIngredients ?? [])
       .filter((l) => (l.name ?? "").trim().length > 0)
       .map((l) => String(l.lineId))
   );
 }
 
 function getLoggedRecipeIngredientIds(ctx: BrewStageContext) {
-  const ids = new Set<string>();
-
-  for (const e of ctx.brew.entries ?? []) {
-    if (e.type !== BREW_ENTRY_TYPE.ADDITION) continue;
-    const rid = (e.data as Partial<BrewAdditionData> | null | undefined)
-      ?.recipeIngredientId;
-    if (rid) ids.add(String(rid));
-  }
-
-  return ids;
+  return new Set(ctx.recipe.actual.loggedRecipeIngredientIds ?? []);
 }
 
 function hasMissingPrimaryIngredients(ctx: BrewStageContext) {
@@ -325,7 +320,7 @@ export const STAGE_CONFIG: Record<BrewStage, StageConfig> = {
         hint: (t) =>
           t(
             "brews.prereq.volumeHint",
-            "When you rack to secondary, record the new volume."
+            "When the brew volume changes, record the actual amount here."
           ),
         actionLabel: (t) =>
           t("brews.actions.logVolume", "Log volume"),

--- a/components/brews/stages/PrimaryStagePanel.tsx
+++ b/components/brews/stages/PrimaryStagePanel.tsx
@@ -3,8 +3,6 @@
 import * as React from "react";
 import type { IngredientLine } from "@/types/recipeData";
 import type { StagePanelProps } from "../stageConfig";
-import { BREW_ENTRY_TYPE } from "@/lib/brewEnums";
-import type { BrewAdditionData } from "@/lib/utils/entryPayload";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -49,21 +47,6 @@ function ingredientDisplay(line: IngredientLine) {
   return { name, primary, secondary };
 }
 
-function getLoggedRecipeIds(
-  entries: StagePanelProps["ctx"]["brew"]["entries"]
-) {
-  const ids = new Set<string>();
-
-  for (const e of entries) {
-    if (e.type !== BREW_ENTRY_TYPE.ADDITION) continue;
-    const d = e.data as Partial<BrewAdditionData> | null | undefined;
-    const rid = d?.recipeIngredientId;
-    if (rid) ids.add(String(rid));
-  }
-
-  return ids;
-}
-
 function buildPrimaryLines(lines: IngredientLine[]) {
   return lines
     .filter((l) => !l.secondary)
@@ -78,13 +61,13 @@ export function PrimaryStagePanel({
   helpers
 }: StagePanelProps) {
   const primaryLines = React.useMemo(
-    () => buildPrimaryLines(ctx.recipe.ingredients),
-    [ctx.recipe.ingredients]
+    () => buildPrimaryLines(ctx.recipe.primaryIngredients),
+    [ctx.recipe.primaryIngredients]
   );
 
   const loggedIds = React.useMemo(
-    () => getLoggedRecipeIds(ctx.brew.entries),
-    [ctx.brew.entries]
+    () => new Set(ctx.recipe.actual.loggedRecipeIngredientIds),
+    [ctx.recipe.actual.loggedRecipeIngredientIds]
   );
 
   const missing = React.useMemo(() => {

--- a/hooks/reactQuery/useAccountBrews.ts
+++ b/hooks/reactQuery/useAccountBrews.ts
@@ -7,6 +7,7 @@ import { BREW_ENTRY_TYPE } from "@/lib/brewEnums";
 import type { TempUnits } from "@/lib/brewEnums";
 import { qk } from "@/lib/db/queryKeys";
 import { BrewAdditionData } from "@/lib/utils/entryPayload";
+import type { BrewRecipeSnapshot } from "@/lib/utils/buildBrewRecipeStageData";
 
 export type AccountBrewListItem = {
   id: string;
@@ -62,7 +63,7 @@ export type AccountBrew = {
   recipe_id: number | null;
   recipe_name: string | null;
 
-  recipe_snapshot: any | null;
+  recipe_snapshot: BrewRecipeSnapshot | null;
   entry_count: number;
 
   entries: AccountBrewEntry[];

--- a/lib/utils/buildBrewRecipeStageData.ts
+++ b/lib/utils/buildBrewRecipeStageData.ts
@@ -1,0 +1,310 @@
+import calculateRecipeDerivedApiResponse, {
+  type RecipeDerivedApiResponse
+} from "@/lib/utils/calculateRecipeDerivedApiResponse";
+import { BREW_ENTRY_TYPE } from "@/lib/brewEnums";
+import type { BrewAdditionData } from "@/lib/utils/entryPayload";
+import type { RecipeData, IngredientLine, AdditiveLine, Notes } from "@/types/recipeData";
+import { isRecipeData } from "@/types/recipeData";
+import {
+  calculateEffectiveNutrientData,
+  type NutrientDerivedState
+} from "@/lib/utils/calculateNutrientDerivedState";
+import type { NutrientData } from "@/types/nutrientData";
+
+export type BrewRecipeSnapshot = {
+  id: number;
+  name: string;
+  version: number;
+  dataV2: RecipeData | null;
+  snapshottedAt: string;
+  source?: string;
+};
+
+export type BrewRecipeStageData = {
+  snapshot: BrewRecipeSnapshot | null;
+  recipeData: RecipeData | null;
+  derived: RecipeDerivedApiResponse["derived"] | null;
+  planned: {
+    ingredients: IngredientLine[];
+    primaryIngredients: IngredientLine[];
+    secondaryIngredients: IngredientLine[];
+    additives: AdditiveLine[];
+    notes: Notes | null;
+    primaryNotes: Notes["primary"];
+    secondaryNotes: Notes["secondary"];
+    nutrients: NutrientData | null;
+    yeast: BrewPlannedYeast | null;
+    nutrientPlan: BrewPlannedNutrientPlan | null;
+    stabilizerPlan: BrewPlannedStabilizerPlan | null;
+  };
+  actual: {
+    currentVolumeL: number | null;
+    latestGravity: number | null;
+    additions: BrewLoggedAddition[];
+    recipeLinkedAdditions: BrewLoggedAddition[];
+    loggedRecipeIngredientIds: string[];
+    additionsByRecipeIngredientId: Record<string, BrewLoggedAddition[]>;
+  };
+  effective: {
+    currentVolumeL: number | null;
+    latestGravity: number | null;
+  };
+};
+
+export type BrewStageEntryInput = {
+  id: string;
+  datetime?: string;
+  type: string;
+  title: string | null;
+  note: string | null;
+  gravity: number | null;
+  data: unknown;
+};
+
+export type BrewLoggedAddition = {
+  entryId: string;
+  datetime: string | null;
+  title: string | null;
+  note: string | null;
+  name: string;
+  kind: BrewAdditionData["kind"] | null;
+  amount: number | null;
+  unit: string | null;
+  recipeIngredientId: string | null;
+};
+
+export type BrewPlannedYeast = {
+  brand: string;
+  strain: string;
+  yeastId: number | null;
+  nitrogenRequirement: NutrientData["selected"]["nitrogenRequirement"];
+  plannedAmountG: number | null;
+  source: "recipe_nutrients";
+};
+
+export type BrewPlannedNutrientPlan = {
+  data: NutrientData;
+  effectiveData: NutrientData;
+  derived: NutrientDerivedState;
+  source: "recipe_nutrients";
+};
+
+export type BrewPlannedStabilizerPlan = {
+  enabled: boolean;
+  type: RecipeData["stabilizers"]["type"];
+  phReading: string;
+  takingPh: boolean;
+  derived: RecipeDerivedApiResponse["derived"]["stabilizers"];
+  source: "recipe_stabilizers";
+};
+
+const EMPTY_STAGE_DATA: BrewRecipeStageData = {
+  snapshot: null,
+  recipeData: null,
+  derived: null,
+  planned: {
+    ingredients: [],
+    primaryIngredients: [],
+    secondaryIngredients: [],
+    additives: [],
+    notes: null,
+    primaryNotes: [],
+    secondaryNotes: [],
+    nutrients: null,
+    yeast: null,
+    nutrientPlan: null,
+    stabilizerPlan: null
+  },
+  actual: {
+    currentVolumeL: null,
+    latestGravity: null,
+    additions: [],
+    recipeLinkedAdditions: [],
+    loggedRecipeIngredientIds: [],
+    additionsByRecipeIngredientId: {}
+  },
+  effective: {
+    currentVolumeL: null,
+    latestGravity: null
+  }
+};
+
+function getLatestGravity(args: {
+  entries: BrewStageEntryInput[];
+  latestGravity: number | null | undefined;
+}) {
+  if (typeof args.latestGravity === "number" && Number.isFinite(args.latestGravity)) {
+    return args.latestGravity;
+  }
+
+  const latestEntry = args.entries
+    .filter((entry) => typeof entry.gravity === "number" && Number.isFinite(entry.gravity))
+    .sort((a, b) => {
+      const aTime = a.datetime ? new Date(a.datetime).getTime() : 0;
+      const bTime = b.datetime ? new Date(b.datetime).getTime() : 0;
+      return bTime - aTime;
+    })[0];
+
+  return latestEntry?.gravity ?? null;
+}
+
+function getLoggedAdditions(entries: BrewStageEntryInput[]) {
+  const additions: BrewLoggedAddition[] = [];
+
+  for (const entry of entries) {
+    if (entry.type !== BREW_ENTRY_TYPE.ADDITION) continue;
+
+    const data = entry.data as Partial<BrewAdditionData> | null | undefined;
+    const name = typeof data?.name === "string" && data.name.trim()
+      ? data.name.trim()
+      : (entry.title ?? "").trim();
+
+    if (!name) continue;
+
+    additions.push({
+      entryId: entry.id,
+      datetime: entry.datetime ?? null,
+      title: entry.title,
+      note: entry.note,
+      name,
+      kind: data?.kind ?? null,
+      amount:
+        typeof data?.amount === "number" && Number.isFinite(data.amount)
+          ? data.amount
+          : null,
+      unit: typeof data?.unit === "string" && data.unit.trim() ? data.unit : null,
+      recipeIngredientId:
+        typeof data?.recipeIngredientId === "string" && data.recipeIngredientId.trim()
+          ? data.recipeIngredientId
+          : null
+    });
+  }
+
+  return additions;
+}
+
+export function buildBrewRecipeStageData(args: {
+  recipeSnapshot: BrewRecipeSnapshot | null | undefined;
+  currentVolumeLiters: number | null | undefined;
+  latestGravity: number | null | undefined;
+  entries: BrewStageEntryInput[] | null | undefined;
+}): BrewRecipeStageData {
+  const entries = args.entries ?? [];
+  const actualCurrentVolume =
+    typeof args.currentVolumeLiters === "number" &&
+    Number.isFinite(args.currentVolumeLiters) &&
+    args.currentVolumeLiters > 0
+      ? args.currentVolumeLiters
+      : null;
+  const actualLatestGravity = getLatestGravity({
+    entries,
+    latestGravity: args.latestGravity
+  });
+  const additions = getLoggedAdditions(entries);
+  const recipeLinkedAdditions = additions.filter((addition) => addition.recipeIngredientId);
+  const additionsByRecipeIngredientId = recipeLinkedAdditions.reduce<Record<string, BrewLoggedAddition[]>>(
+    (acc, addition) => {
+      const recipeIngredientId = addition.recipeIngredientId!;
+      if (!acc[recipeIngredientId]) acc[recipeIngredientId] = [];
+      acc[recipeIngredientId].push(addition);
+      return acc;
+    },
+    {}
+  );
+  const loggedRecipeIngredientIds = Object.keys(additionsByRecipeIngredientId);
+
+  const snapshot = args.recipeSnapshot ?? null;
+  const snapshotData = snapshot?.dataV2;
+
+  if (!snapshot || !isRecipeData(snapshotData)) {
+    return {
+      ...EMPTY_STAGE_DATA,
+      actual: {
+        currentVolumeL: actualCurrentVolume,
+        latestGravity: actualLatestGravity,
+        additions,
+        recipeLinkedAdditions,
+        loggedRecipeIngredientIds,
+        additionsByRecipeIngredientId
+      },
+      effective: {
+        currentVolumeL: actualCurrentVolume,
+        latestGravity: actualLatestGravity
+      }
+    };
+  }
+
+  const derivedResponse = calculateRecipeDerivedApiResponse(snapshotData);
+  const nutrientData = derivedResponse.recipeData.nutrients ?? null;
+  const effectiveNutrientData = nutrientData
+    ? calculateEffectiveNutrientData(nutrientData)
+    : null;
+  const ingredients = derivedResponse.recipeData.ingredients;
+  const primaryIngredients = ingredients.filter((line) => !line.secondary);
+  const secondaryIngredients = ingredients.filter((line) => line.secondary);
+  const plannedCurrentVolume = derivedResponse.derived.volume.totalL;
+  const plannedYeast =
+    effectiveNutrientData &&
+    (effectiveNutrientData.selected.yeastBrand.trim().length > 0 ||
+      effectiveNutrientData.selected.yeastStrain.trim().length > 0)
+      ? {
+          brand: effectiveNutrientData.selected.yeastBrand,
+          strain: effectiveNutrientData.selected.yeastStrain,
+          yeastId: effectiveNutrientData.selected.yeastId ?? null,
+          nitrogenRequirement: effectiveNutrientData.selected.nitrogenRequirement,
+          plannedAmountG:
+            effectiveNutrientData.inputs.yeastAmountG.trim().length > 0 &&
+            Number.isFinite(Number(effectiveNutrientData.inputs.yeastAmountG))
+              ? Number(effectiveNutrientData.inputs.yeastAmountG)
+              : null,
+          source: "recipe_nutrients" as const
+        }
+      : null;
+  const plannedNutrientPlan = nutrientData && effectiveNutrientData
+    ? {
+        data: nutrientData,
+        effectiveData: effectiveNutrientData,
+        derived: derivedResponse.derived.nutrients,
+        source: "recipe_nutrients" as const
+      }
+    : null;
+  const plannedStabilizerPlan = {
+    enabled: derivedResponse.recipeData.stabilizers.adding,
+    type: derivedResponse.recipeData.stabilizers.type,
+    phReading: derivedResponse.recipeData.stabilizers.phReading,
+    takingPh: derivedResponse.recipeData.stabilizers.takingPh,
+    derived: derivedResponse.derived.stabilizers,
+    source: "recipe_stabilizers" as const
+  };
+
+  return {
+    snapshot,
+    recipeData: derivedResponse.recipeData,
+    derived: derivedResponse.derived,
+    planned: {
+      ingredients,
+      primaryIngredients,
+      secondaryIngredients,
+      additives: derivedResponse.recipeData.additives,
+      notes: derivedResponse.recipeData.notes,
+      primaryNotes: derivedResponse.recipeData.notes.primary,
+      secondaryNotes: derivedResponse.recipeData.notes.secondary,
+      nutrients: nutrientData,
+      yeast: plannedYeast,
+      nutrientPlan: plannedNutrientPlan,
+      stabilizerPlan: plannedStabilizerPlan
+    },
+    actual: {
+      currentVolumeL: actualCurrentVolume,
+      latestGravity: actualLatestGravity,
+      additions,
+      recipeLinkedAdditions,
+      loggedRecipeIngredientIds,
+      additionsByRecipeIngredientId
+    },
+    effective: {
+      currentVolumeL: actualCurrentVolume ?? plannedCurrentVolume,
+      latestGravity: actualLatestGravity
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- derive brew stage recipe data directly from the brew snapshot instead of ambient recipe provider state
- expose planned, actual, and effective brew recipe stage values for later stage work
- switch existing primary stage checklist logic to consume the shared contract

## What changed
- added a buildBrewRecipeStageData helper to normalize snapshot, derived recipe values, actual brew values, and effective values
- updated the brew page and stage path to pass explicit snapshot-based recipe stage data into stage panels
- exposed planned yeast, nutrient plan, and stabilizer plan for future stage tickets
- updated the current primary checklist and warning logic to use the shared contract instead of recomputing from raw entries

## Validation
- verified recipe-linked and no-recipe brews through the UI into secondary
- ran npx tsc --noEmit
- ran a temporary validation script against seeded brew data and a no-snapshot case