### PR TITLE
[codex] Fix public recipe search input sync

### DIFF
--- a/app/[locale]/public-recipes/RecipeList.tsx
+++ b/app/[locale]/public-recipes/RecipeList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
 import { Search } from "lucide-react";
@@ -125,9 +125,38 @@ export default function RecipeList({
   // --- Search state + debounce ---
   const [searchInput, setSearchInput] = useState(query ?? "");
   const debouncedSearch = useDebouncedValue(searchInput, 400);
+  const pendingSearchQueriesRef = useRef<Set<string>>(new Set());
+
+  const replaceSearchQuery = useCallback(
+    (value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      const trimmed = value.trim();
+
+      if (trimmed) {
+        params.set("query", trimmed);
+      } else {
+        params.delete("query");
+      }
+
+      // Always reset to first page when the search changes
+      params.delete("page");
+      pendingSearchQueriesRef.current.add(trimmed);
+
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname);
+    },
+    [pathname, router, searchParams]
+  );
 
   // Keep local input in sync if the URL/query prop changes (e.g. via back/forward)
   useEffect(() => {
+    const nextQuery = query ?? "";
+
+    if (pendingSearchQueriesRef.current.has(nextQuery)) {
+      pendingSearchQueriesRef.current.delete(nextQuery);
+      return;
+    }
+
     setSearchInput(query ?? "");
   }, [query]);
 
@@ -136,21 +165,8 @@ export default function RecipeList({
     // If the debounced value matches the current query param, nothing to do
     if ((debouncedSearch ?? "").trim() === (query ?? "").trim()) return;
 
-    const params = new URLSearchParams(searchParams.toString());
-
-    const trimmed = debouncedSearch.trim();
-    if (trimmed) {
-      params.set("query", trimmed);
-    } else {
-      params.delete("query");
-    }
-
-    // Always reset to first page when the search changes
-    params.delete("page");
-
-    const qs = params.toString();
-    router.replace(qs ? `${pathname}?${qs}` : pathname);
-  }, [debouncedSearch, query, pathname, router, searchParams]);
+    replaceSearchQuery(debouncedSearch);
+  }, [debouncedSearch, query, replaceSearchQuery]);
 
   const buildHref = (opts: { page?: number; query?: string }) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -209,18 +225,7 @@ export default function RecipeList({
           onSubmit={(e) => {
             e.preventDefault();
             // Immediate search on enter/click, using current input
-            const params = new URLSearchParams(searchParams.toString());
-            const trimmed = searchInput.trim();
-
-            if (trimmed) {
-              params.set("query", trimmed);
-            } else {
-              params.delete("query");
-            }
-            params.delete("page");
-
-            const qs = params.toString();
-            router.replace(qs ? `${pathname}?${qs}` : pathname);
+            replaceSearchQuery(searchInput);
           }}
         >
           <InputGroup>


### PR DESCRIPTION
## Summary

Fixes the public recipe search box dropping or reverting characters when typing quickly while debounced URL updates are still settling.

## Root Cause

The search input was controlled by local state, but the component also synced the URL `query` prop back into that same local state. When an older debounced `router.replace` completed after the user had typed more characters, the older `query` value could overwrite the newer input.

## Changes

- Centralized public recipe search URL updates through `replaceSearchQuery`.
- Track query values initiated by this component so their URL echoes do not overwrite active typing.
- Preserve external URL sync behavior for browser back/forward navigation.

## Validation

- Verified manually in browser by typing in `/public-recipes`.
- Checked `/yeasts` does not share the same debounce/URL sync bug.
- Ran `npx eslint 'app/[locale]/public-recipes/RecipeList.tsx'` successfully.

Note: `npx tsc --noEmit` is currently blocked by unrelated stale `.next/types` references to a missing `app/[locale]/account/brews/[brew_id]/link/page.js` route.