### PR TITLE
Fix brew tracking logging and units

### DIFF
--- a/app/[locale]/account/brews/[brew_id]/page.tsx
+++ b/app/[locale]/account/brews/[brew_id]/page.tsx
@@ -51,7 +51,7 @@ import { BrewAdditionData, BrewPackagingData, GravityReadingRole, entryPayload }
 import { useCreateBrewEntry, useDeleteBrewEntry, usePatchBrewEntry } from "@/hooks/reactQuery/useCreateBrewEntry";
 import { L_TO_VOLUME, VOLUME_TO_L } from "@/lib/utils/recipeDataCalculations";
 import { calcABV } from "@/lib/utils/unitConverter";
-import { normalizeNumberString, parseNumber } from "@/lib/utils/validateInput";
+import { isValidNumber, normalizeNumberString, parseNumber } from "@/lib/utils/validateInput";
 import { buildBrewRecipeStageData } from "@/lib/utils/buildBrewRecipeStageData";
 import {
   AdditiveUnitSelect,
@@ -64,7 +64,6 @@ import {
   type AdditionBasis
 } from "@/components/brews/stages/additionDialogShared";
 
-type HeaderVolumeUnit = "gal" | "L";
 type HistoryView = "stages" | "metrics" | "charts";
 type HistoryFilter = "readings" | "additions" | "volume" | "notes" | "stageChanges" | "packaging";
 type HistorySortOrder = "oldest" | "newest";
@@ -140,24 +139,13 @@ export default function BrewPageClient() {
     setStartValue(toDateTimeLocalValue(brew.start_date));
   }, [brew]);
 
-  const [preferredVolumeUnit, setPreferredVolumeUnit] = useState<HeaderVolumeUnit>("gal");
-
-  useEffect(() => {
-    try {
-      const storedUnits = localStorage.getItem("units");
-      setPreferredVolumeUnit(storedUnits === "METRIC" ? "L" : "gal");
-    } catch {
-      setPreferredVolumeUnit("gal");
-    }
-  }, []);
-
-  const formatVolume = (liters?: number | null) => {
+  const formatVolume = (liters?: number | null, unit: keyof typeof L_TO_VOLUME = "gal") => {
     if (typeof liters !== "number" || !Number.isFinite(liters) || liters <= 0) {
       return "—";
     }
 
-    const converted = liters * L_TO_VOLUME[preferredVolumeUnit];
-    return `${normalizeNumberString(converted, 2, i18n.resolvedLanguage)} ${preferredVolumeUnit}`;
+    const converted = liters * L_TO_VOLUME[unit];
+    return `${normalizeNumberString(converted, 2, i18n.resolvedLanguage)} ${unit}`;
   };
 
   const formatGravity = (gravity?: number | null) => {
@@ -231,12 +219,26 @@ export default function BrewPageClient() {
     if (!data?.name) return t("brews.entryTypes.ADDITION", "Addition");
     const nameKey = typeof data.meta?.nameKey === "string" ? data.meta.nameKey : null;
     const name = nameKey ? t(nameKey, data.name) : getBrewItemLabel(t, data.name);
+    const components = Array.isArray(data.meta?.components)
+      ? data.meta.components
+          .map((component: any) => {
+            const componentName = getBrewItemLabel(t, component?.name ?? component?.key ?? "");
+            const componentAmount =
+              typeof component?.amount === "number" && Number.isFinite(component.amount)
+                ? normalizeNumberString(component.amount, 2, i18n.resolvedLanguage)
+                : null;
+            const componentUnit = typeof component?.unit === "string" && component.unit ? component.unit : "";
+            return componentName && componentAmount ? `${componentName}: ${componentAmount} ${componentUnit}`.trim() : null;
+          })
+          .filter((component): component is string => Boolean(component))
+      : [];
 
     const amount =
       data.amount != null && Number.isFinite(Number(data.amount))
         ? `: ${normalizeNumberString(Number(data.amount), 2, i18n.resolvedLanguage)}`
         : "";
     const unit = data.unit ? ` ${data.unit}` : "";
+    const componentDetail = components.length ? ` · ${components.join(", ")}` : "";
     const goFermWater =
       data.source === "recipe_go_ferm" || data.meta?.goFerm === true
         ? typeof data.meta?.actualWaterAmount === "number" && Number.isFinite(data.meta.actualWaterAmount)
@@ -254,7 +256,7 @@ export default function BrewPageClient() {
           )} ${data.meta?.actualWaterUnit || data.meta?.plannedWaterUnit || "mL"}`
         : "";
 
-    return `${name}${amount}${unit}${goFermWaterDetail}`;
+    return `${name}${amount}${unit}${componentDetail}${goFermWaterDetail}`;
   };
 
   const formatVolumeEntry = (entry: AccountBrewEntry) => {
@@ -553,6 +555,7 @@ export default function BrewPageClient() {
     brewRecipe.derived.volume.secondaryL > 0
       ? brewRecipe.derived.volume.secondaryL
       : null;
+  const recipeVolumeUnit = brewRecipe.recipeData?.unitDefaults.volume ?? brewRecipe.derived?.volume.unit ?? "gal";
 
   const recipeSummaryItems = [
     {
@@ -569,15 +572,15 @@ export default function BrewPageClient() {
     },
     {
       label: t("brews.recipeTargetVolume", "Target volume"),
-      value: formatVolume(displayTargetVolume)
+      value: formatVolume(displayTargetVolume, recipeVolumeUnit)
     },
     {
       label: t("recipeBuilder.resultsLabels.totalPrimary"),
-      value: formatVolume(displayPrimaryVolume)
+      value: formatVolume(displayPrimaryVolume, recipeVolumeUnit)
     },
     {
       label: t("brews.recipeTotalSecondaryVolume", "Total secondary volume"),
-      value: formatVolume(displaySecondaryVolume)
+      value: formatVolume(displaySecondaryVolume, recipeVolumeUnit)
     }
   ];
 
@@ -943,7 +946,7 @@ export default function BrewPageClient() {
               />
               <SummaryField
                 label={t("brews.volume.currentVolume", "Current volume")}
-                value={formatVolume(brew.current_volume_liters)}
+                value={formatVolume(brew.current_volume_liters, recipeVolumeUnit)}
                 action={
                   <Button
                     size="icon"
@@ -1055,6 +1058,7 @@ export default function BrewPageClient() {
         open={recordVolumeOpen}
         onOpenChange={setRecordVolumeOpen}
         currentVolumeLiters={recordVolumeCurrentLiters}
+        defaultVolumeUnit={recipeVolumeUnit}
         onSave={(volume, meta) =>
           recordCurrentVolume({
             liters: volume,
@@ -1379,7 +1383,7 @@ function EditBrewEntryDialog({
   }) => Promise<void>;
   onDelete: (entryId: string) => Promise<void>;
 }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [datetime, setDatetime] = useState<Date>(new Date());
   const [title, setTitle] = useState("");
   const [note, setNote] = useState("");
@@ -1391,7 +1395,7 @@ function EditBrewEntryDialog({
   const [additionAmount, setAdditionAmount] = useState("");
   const [additionUnit, setAdditionUnit] = useState("");
   const [additionBasis, setAdditionBasis] = useState<AdditionBasis>("other");
-  const [additionComponents, setAdditionComponents] = useState<Array<{ key: string; name: string; amount: number; unit: string }>>([]);
+  const [additionComponents, setAdditionComponents] = useState<Array<{ key: string; name: string; amount: string; unit: string }>>([]);
   const [volume, setVolume] = useState("");
   const [volumeUnit, setVolumeUnit] = useState("");
   const [packagingRows, setPackagingRows] = useState<
@@ -1421,7 +1425,10 @@ function EditBrewEntryDialog({
             .map((component: any) => ({
               key: String(component?.key ?? ""),
               name: String(component?.name ?? component?.key ?? ""),
-              amount: typeof component?.amount === "number" && Number.isFinite(component.amount) ? component.amount : 0,
+              amount:
+                typeof component?.amount === "number" && Number.isFinite(component.amount)
+                  ? normalizeNumberString(component.amount, 2, i18n.resolvedLanguage)
+                  : "0",
               unit: typeof component?.unit === "string" && component.unit ? component.unit : "g"
             }))
             .filter((component) => component.key && component.name)
@@ -1505,15 +1512,18 @@ function EditBrewEntryDialog({
     }
 
     if (entry.type === BREW_ENTRY_TYPE.ADDITION) {
-      const nextComponents = additionComponents.map((component) => ({
-        ...component,
-        amount: Number(component.amount)
-      }));
+      const nextComponents = additionComponents.map((component) => {
+        const amount = parseNumber(component.amount);
+        return {
+          ...component,
+          amount: Number.isFinite(amount) ? amount : 0
+        };
+      });
       const componentTotal = nextComponents.reduce(
         (sum, component) => sum + (Number.isFinite(component.amount) ? component.amount : 0),
         0
       );
-      const amount = additionComponents.length ? componentTotal : additionAmount.trim() ? Number(additionAmount) : undefined;
+      const amount = additionComponents.length ? componentTotal : additionAmount.trim() ? parseNumber(additionAmount) : undefined;
       if (amount !== undefined && !Number.isFinite(amount)) throw new Error("Invalid amount");
       const existingMeta = ((entry.data as any) ?? {}).meta ?? {};
       const nextNameKey =
@@ -1692,14 +1702,14 @@ function EditBrewEntryDialog({
                       <div key={component.key} className="grid gap-2 sm:grid-cols-[1fr_minmax(11rem,14rem)]">
                         <div className="self-center text-sm">{getBrewItemLabel(t, component.name)}</div>
                         <AmountUnitField
-                          amount={String(component.amount)}
+                          amount={component.amount}
                           unit={component.unit}
                           onAmountChange={(value) => {
-                            const nextAmount = Number(value);
+                            if (!isValidNumber(value)) return;
                             setAdditionComponents((items) =>
                               items.map((item, itemIndex) =>
                                 itemIndex === index
-                                  ? { ...item, amount: Number.isFinite(nextAmount) ? nextAmount : item.amount }
+                                  ? { ...item, amount: value }
                                   : item
                               )
                             );

--- a/app/[locale]/account/brews/page.tsx
+++ b/app/[locale]/account/brews/page.tsx
@@ -191,11 +191,6 @@ export default function AccountBrews() {
             />
           )}
 
-          {isLoading && (
-            <div className="flex justify-center pt-2">
-              <Skeleton className="h-10 w-[260px]" />
-            </div>
-          )}
         </>
       )}
     </div>

--- a/components/brews/BrewStagePath.tsx
+++ b/components/brews/BrewStagePath.tsx
@@ -87,6 +87,7 @@ export function BrewStagePath({
     stage === "PRIMARY"
       ? (recipe.derived?.volume.primaryL ?? recipe.effective.currentVolumeL)
       : recipe.effective.currentVolumeL;
+  const recipeVolumeUnit = recipe.recipeData?.unitDefaults.volume ?? recipe.derived?.volume.unit ?? "gal";
 
   useEffect(() => {
     setActiveId(stage);
@@ -364,6 +365,7 @@ export function BrewStagePath({
           open={recordVolumeOpen}
           onOpenChange={setRecordVolumeOpen}
           currentVolumeLiters={current_volume_liters ?? fallbackRecordVolumeLiters}
+          defaultVolumeUnit={recipeVolumeUnit}
           intent={recordVolumeIntent}
           onSave={async (volume, meta) => {
             await patchBrewMetadata({ current_volume_liters: volume });

--- a/components/brews/RecordVolumeDialog.tsx
+++ b/components/brews/RecordVolumeDialog.tsx
@@ -31,8 +31,11 @@ import { Separator } from "@/components/ui/separator";
 import { DateTimePicker } from "@/components/ui/datetime-picker";
 import { getUnitLabel } from "@/components/brews/stages/additionDialogShared";
 
-type DialogVolumeUnit = Extract<VolumeUnit, "gal" | "qt" | "pt" | "L" | "mL">;
+type DialogVolumeUnit = VolumeUnit;
 type PreferredUnits = "US" | "METRIC";
+const US_VOLUME_UNITS: DialogVolumeUnit[] = ["gal", "qt", "pt", "fl_oz"];
+const METRIC_VOLUME_UNITS: DialogVolumeUnit[] = ["L", "mL"];
+const IMPERIAL_VOLUME_UNITS: DialogVolumeUnit[] = ["imp_gal", "imp_qt", "imp_pt", "imp_fl_oz"];
 
 function getPreferredVolumeUnit(preferred: PreferredUnits | null): DialogVolumeUnit {
   return preferred === "METRIC" ? "L" : "gal";
@@ -62,6 +65,7 @@ export function RecordVolumeDialog({
   open,
   onOpenChange,
   currentVolumeLiters,
+  defaultVolumeUnit,
   intent = "current",
   onSave
 }: {
@@ -69,6 +73,7 @@ export function RecordVolumeDialog({
   open: boolean;
   onOpenChange: (open: boolean) => void;
   currentVolumeLiters: number | null;
+  defaultVolumeUnit?: DialogVolumeUnit;
   intent?: "current" | "secondaryVolume";
   onSave: (
     currentVolumeLiters: number,
@@ -90,7 +95,7 @@ export function RecordVolumeDialog({
   React.useEffect(() => {
     try {
       const preferred = localStorage.getItem("units") as PreferredUnits | null;
-      const nextUnit = getPreferredVolumeUnit(preferred);
+      const nextUnit = defaultVolumeUnit ?? getPreferredVolumeUnit(preferred);
       setPreferredUnit(nextUnit);
       setDisplayUnit(nextUnit);
       setVolumeUnit(nextUnit);
@@ -99,7 +104,7 @@ export function RecordVolumeDialog({
       setDisplayUnit("gal");
       setVolumeUnit("gal");
     }
-  }, []);
+  }, [defaultVolumeUnit]);
 
   const currentVolumeDisplay = React.useMemo(
     () => formatDisplayVolume(currentVolumeLiters, displayUnit),
@@ -189,11 +194,23 @@ export function RecordVolumeDialog({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="gal">{getUnitLabel(t, "gal")}</SelectItem>
-                  <SelectItem value="qt">{getUnitLabel(t, "qt")}</SelectItem>
-                  <SelectItem value="pt">{getUnitLabel(t, "pt")}</SelectItem>
-                  <SelectItem value="L">{getUnitLabel(t, "L")}</SelectItem>
-                  <SelectItem value="mL">{getUnitLabel(t, "mL")}</SelectItem>
+                  {US_VOLUME_UNITS.map((unit) => (
+                    <SelectItem key={unit} value={unit}>
+                      {getUnitLabel(t, unit)}
+                    </SelectItem>
+                  ))}
+                  <SelectSeparator />
+                  {METRIC_VOLUME_UNITS.map((unit) => (
+                    <SelectItem key={unit} value={unit}>
+                      {getUnitLabel(t, unit)}
+                    </SelectItem>
+                  ))}
+                  <SelectSeparator />
+                  {IMPERIAL_VOLUME_UNITS.map((unit) => (
+                    <SelectItem key={unit} value={unit}>
+                      {getUnitLabel(t, unit)}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>
@@ -232,12 +249,23 @@ export function RecordVolumeDialog({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="gal">{getUnitLabel(t, "gal")}</SelectItem>
-                    <SelectItem value="qt">{getUnitLabel(t, "qt")}</SelectItem>
-                    <SelectItem value="pt">{getUnitLabel(t, "pt")}</SelectItem>
+                    {US_VOLUME_UNITS.map((unit) => (
+                      <SelectItem key={unit} value={unit}>
+                        {getUnitLabel(t, unit)}
+                      </SelectItem>
+                    ))}
                     <SelectSeparator />
-                    <SelectItem value="L">{getUnitLabel(t, "L")}</SelectItem>
-                    <SelectItem value="mL">{getUnitLabel(t, "mL")}</SelectItem>
+                    {METRIC_VOLUME_UNITS.map((unit) => (
+                      <SelectItem key={unit} value={unit}>
+                        {getUnitLabel(t, unit)}
+                      </SelectItem>
+                    ))}
+                    <SelectSeparator />
+                    {IMPERIAL_VOLUME_UNITS.map((unit) => (
+                      <SelectItem key={unit} value={unit}>
+                        {getUnitLabel(t, unit)}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </InputGroupAddon>

--- a/components/brews/stages/PrimaryStagePanel.tsx
+++ b/components/brews/stages/PrimaryStagePanel.tsx
@@ -166,6 +166,7 @@ export function PrimaryStagePanel({
     text: string;
     recipeNoteId: string;
   } | null>(null);
+  const [loggingMissingIngredients, setLoggingMissingIngredients] = React.useState(false);
   const primaryLines = React.useMemo(
     () => buildIngredientLines(ctx.recipe.primaryIngredients, { secondaryOnly: true }),
     [ctx.recipe.primaryIngredients]
@@ -231,7 +232,8 @@ export function PrimaryStagePanel({
   const locale = i18n.resolvedLanguage;
   const fmtNumber = (value?: number | null, decimals = 2) => formatNumber(value, decimals, locale);
   const fmtGravity = (value?: number | null) => formatGravity(value, locale);
-  const fmtVolume = (value?: number | null) => formatVolume(value, "gal", locale);
+  const primaryVolumeUnit = ctx.recipe.recipeData?.unitDefaults.volume ?? ctx.recipe.derived?.volume.unit ?? "gal";
+  const fmtVolume = (value?: number | null) => formatVolume(value, primaryVolumeUnit, locale);
   const fmtLoggedAmount = (addition?: { amount: number | null; unit: string | null } | null) =>
     formatLoggedAmount(addition, locale);
   const nutrientDisabledReason = !hasNutrientBasis
@@ -335,19 +337,25 @@ export function PrimaryStagePanel({
     });
   };
   const logMissingIngredients = async () => {
-    await helpers.addAdditions(
-      missingIngredients.map((item) => {
-        const { amount, unit } = getIngredientAmount(item.line);
-        return {
-          name: item.name,
-          amount,
-          unit,
-          recipeIngredientId: String(item.line.lineId),
-          source: "recipe_ingredient" as const,
-          meta: { plannedAmount: amount, plannedUnit: unit }
-        };
-      })
-    );
+    if (loggingMissingIngredients) return;
+    setLoggingMissingIngredients(true);
+    try {
+      await helpers.addAdditions(
+        missingIngredients.map((item) => {
+          const { amount, unit } = getIngredientAmount(item.line);
+          return {
+            name: item.name,
+            amount,
+            unit,
+            recipeIngredientId: String(item.line.lineId),
+            source: "recipe_ingredient" as const,
+            meta: { plannedAmount: amount, plannedUnit: unit }
+          };
+        })
+      );
+    } finally {
+      setLoggingMissingIngredients(false);
+    }
   };
   const pitchPending = !hasNutrientBasis || !hasLoggedYeast || (hasPlannedGoFerm && !hasLoggedGoFerm);
   const nutrientsPending = !pitchPending && hasRemainingNutrients;
@@ -413,7 +421,7 @@ export function PrimaryStagePanel({
           </div>
           <div className="flex flex-wrap gap-2">
             {missingIngredients.length > 0 ? (
-              <Button size="sm" variant="secondary" disabled={!canEdit} onClick={logMissingIngredients}>
+              <Button size="sm" variant="secondary" disabled={!canEdit || loggingMissingIngredients} onClick={logMissingIngredients}>
                 {t("brews.primary.logMissingIngredients", "Log missing ingredients")}
               </Button>
             ) : null}
@@ -552,7 +560,11 @@ export function PrimaryStagePanel({
           </AccordionTrigger>
           <AccordionContent>
             <div className="space-y-2">
-              <Button size="sm" disabled={!canEdit || missingIngredients.length === 0} onClick={logMissingIngredients}>
+              <Button
+                size="sm"
+                disabled={!canEdit || missingIngredients.length === 0 || loggingMissingIngredients}
+                onClick={logMissingIngredients}
+              >
                 {t("brews.primary.logMissing", "Log missing")}
               </Button>
               {primaryLines.length ? (

--- a/components/brews/stages/SecondaryStagePanel.tsx
+++ b/components/brews/stages/SecondaryStagePanel.tsx
@@ -19,6 +19,13 @@ import {
   VOLUME_TO_L,
   WEIGHT_TO_KG
 } from "@/lib/utils/recipeDataCalculations";
+import {
+  roundEditableAmount,
+  scaleAdditiveSuggestions,
+  scaleSecondaryIngredientSuggestions,
+  type ScaledAdditiveSuggestion,
+  type ScaledIngredientSuggestion
+} from "@/lib/utils/brewTrackingScaling";
 import { calcABV } from "@/lib/utils/unitConverter";
 import { isValidNumber, parseNumber } from "@/lib/utils/validateInput";
 import type { IngredientLine, RecipeUnitDefaults, VolumeUnit, WeightUnit } from "@/types/recipeData";
@@ -410,6 +417,15 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
     text: string;
     recipeNoteId: string;
   } | null>(null);
+  const [scaledSecondarySuggestions, setScaledSecondarySuggestions] = React.useState<
+    Map<string, ScaledIngredientSuggestion>
+  >(new Map());
+  const [scaledAdditiveSuggestions, setScaledAdditiveSuggestions] = React.useState<
+    Map<string, ScaledAdditiveSuggestion>
+  >(new Map());
+  const [loggingMissingSecondary, setLoggingMissingSecondary] = React.useState(false);
+  const [loggingMissingAdditives, setLoggingMissingAdditives] = React.useState(false);
+  const [loggingSupplementalStabilizers, setLoggingSupplementalStabilizers] = React.useState(false);
   const pendingSecondaryIngredientAction = React.useRef<(() => void | Promise<void>) | null>(null);
 
   const secondaryLines = React.useMemo(
@@ -435,6 +451,10 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
   );
 
   const canEdit = status === "current";
+  const recipeBaseVolumeL =
+    typeof ctx.recipe.derived?.volume.totalL === "number" && Number.isFinite(ctx.recipe.derived.volume.totalL)
+      ? ctx.recipe.derived.volume.totalL
+      : null;
   const locale = i18n.resolvedLanguage;
   const fmtNumber = (value?: number | null, decimals = 2) => formatNumber(value, decimals, locale);
   const fmtGravity = (value?: number | null) => formatGravity(value, locale);
@@ -451,6 +471,7 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
     typeof ctx.brew.current_volume_liters === "number" &&
     Number.isFinite(ctx.brew.current_volume_liters) &&
     ctx.brew.current_volume_liters > 0;
+  const canScaleSuggestions = canEdit && hasCurrentVolume && recipeBaseVolumeL != null && recipeBaseVolumeL > 0;
   const readyForBulkAge = hasCurrentVolume;
   const stabilizerPlan = getStabilizerPlan(ctx, locale);
   const usesRecipeStabilizers = Boolean(ctx.recipe.stabilizerPlan?.enabled);
@@ -459,28 +480,112 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
   const supplementalStabilizerPlan =
     usesRecipeStabilizers && hasLoggedStabilizers ? getSupplementalStabilizerPlan(ctx, stabilizerPlan) : null;
 
-  const logMissingSecondary = async () => {
-    await helpers.addAdditions(
-      missingSecondary.map((item) => {
-        const { amount, unit } = getIngredientAmount(item.line);
-        return {
-          name: item.name,
-          amount,
-          unit,
-          recipeIngredientId: String(item.line.lineId),
-          kind: "INGREDIENT" as const,
-          source: "recipe_ingredient" as const,
-          meta: {
-            plannedAmount: amount,
-            plannedUnit: unit,
-            stage: "SECONDARY"
-          }
-        };
+  const getScaledIngredientSuggestion = (lineId: string) => scaledSecondarySuggestions.get(String(lineId));
+  const getScaledAdditiveSuggestion = (lineId: string) => scaledAdditiveSuggestions.get(String(lineId));
+
+  const getSecondaryIngredientAmount = (line: IngredientLine) => {
+    const scaled = getScaledIngredientSuggestion(line.lineId);
+    if (scaled) return { amount: scaled.basisAmount, unit: scaled.basisUnit };
+    return getIngredientAmount(line);
+  };
+
+  const getSecondaryIngredientPlannedAmounts = (line: IngredientLine) => {
+    const planned = getPlannedIngredientAmounts(line);
+    const scaled = getScaledIngredientSuggestion(line.lineId);
+    if (!scaled) return planned;
+
+    return {
+      basis: planned.basis,
+      weightAmount: scaled.weightAmount,
+      weightUnit: scaled.weightUnit,
+      volumeAmount: scaled.volumeAmount,
+      volumeUnit: scaled.volumeUnit
+    };
+  };
+
+  const getSecondaryIngredientDisplay = (item: (typeof secondaryLines)[number]) => {
+    const scaled = getScaledIngredientSuggestion(item.line.lineId);
+    if (!scaled) {
+      return {
+        amount: item.primary,
+        detail: item.secondary ? `${t("brews.planned.altAmount", "Alt")}: ${item.secondary}` : null
+      };
+    }
+
+    const alternate =
+      item.line.amounts.basis === "volume"
+        ? `${fmtNumber(scaled.weightAmount)} ${scaled.weightUnit}`
+        : `${fmtNumber(scaled.volumeAmount)} ${scaled.volumeUnit}`;
+
+    return {
+      amount: `${fmtNumber(scaled.basisAmount)} ${scaled.basisUnit}`,
+      detail: `${t("brews.planned.altAmount", "Alt")}: ${alternate}`
+    };
+  };
+
+  const getSecondaryAdditiveAmount = (lineId: string, fallback: ReturnType<typeof getAdditiveAmount>) => {
+    const scaled = getScaledAdditiveSuggestion(lineId);
+    if (scaled) return { amount: scaled.amount, unit: scaled.unit };
+    return fallback;
+  };
+
+  const getSecondaryAdditiveDisplay = (item: (typeof additiveLines)[number]) => {
+    const scaled = getScaledAdditiveSuggestion(item.line.lineId);
+    return scaled ? `${fmtNumber(scaled.amount)} ${scaled.unit}` : item.amount;
+  };
+
+  const scaleSecondaryToCurrentVolume = () => {
+    setScaledSecondarySuggestions(
+      scaleSecondaryIngredientSuggestions({
+        lines: ctx.recipe.secondaryIngredients,
+        loggedIds: loggedIngredientIds,
+        currentVolumeL: ctx.brew.current_volume_liters,
+        recipeBaseVolumeL
       })
     );
   };
 
+  const scaleAdditivesToCurrentVolume = () => {
+    setScaledAdditiveSuggestions(
+      scaleAdditiveSuggestions({
+        lines: ctx.recipe.additives,
+        loggedIds: loggedAdditiveIds,
+        currentVolumeL: ctx.brew.current_volume_liters,
+        recipeBaseVolumeL
+      })
+    );
+  };
+
+  const logMissingSecondary = async () => {
+    if (loggingMissingSecondary) return;
+    setLoggingMissingSecondary(true);
+    try {
+      await helpers.addAdditions(
+        missingSecondary.map((item) => {
+          const { amount, unit } = getSecondaryIngredientAmount(item.line);
+          return {
+            name: item.name,
+            amount,
+            unit,
+            recipeIngredientId: String(item.line.lineId),
+            kind: "INGREDIENT" as const,
+            source: "recipe_ingredient" as const,
+            meta: {
+              plannedAmount: amount,
+              plannedUnit: unit,
+              ...getSecondaryIngredientPlannedAmounts(item.line),
+              stage: "SECONDARY"
+            }
+          };
+        })
+      );
+    } finally {
+      setLoggingMissingSecondary(false);
+    }
+  };
+
   const runSecondaryIngredientAction = (action: () => void | Promise<void>) => {
+    if (loggingMissingSecondary) return;
     if (usesRecipeStabilizers && !hasLoggedStabilizers) {
       pendingSecondaryIngredientAction.current = action;
       setSecondaryBeforeStabilizersOpen(true);
@@ -491,120 +596,132 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
   };
 
   const logMissingAdditives = async () => {
-    await helpers.addAdditions(
-      missingAdditives.map((item) => {
-        const { amount, unit } = getAdditiveAmount(item.line);
-        return {
-          name: item.name,
-          amount,
-          unit,
-          recipeAdditiveId: String(item.line.lineId),
-          kind: "OTHER" as const,
-          source: "recipe_additive" as const,
-          meta: {
-            plannedAmount: amount,
-            plannedUnit: unit,
-            stage: "SECONDARY"
-          }
-        };
-      })
-    );
+    if (loggingMissingAdditives) return;
+    setLoggingMissingAdditives(true);
+    try {
+      await helpers.addAdditions(
+        missingAdditives.map((item) => {
+          const { amount, unit } = getSecondaryAdditiveAmount(item.line.lineId, getAdditiveAmount(item.line));
+          return {
+            name: item.name,
+            amount,
+            unit,
+            recipeAdditiveId: String(item.line.lineId),
+            kind: "OTHER" as const,
+            source: "recipe_additive" as const,
+            meta: {
+              plannedAmount: amount,
+              plannedUnit: unit,
+              stage: "SECONDARY"
+            }
+          };
+        })
+      );
+    } finally {
+      setLoggingMissingAdditives(false);
+    }
   };
 
   const logSupplementalStabilizers = async () => {
     if (!supplementalStabilizerPlan || !stabilizerPlan) return;
+    if (loggingSupplementalStabilizers) return;
+    setLoggingSupplementalStabilizers(true);
 
-    const sulfiteName =
-      supplementalStabilizerPlan.sulfiteForm === "campden"
-        ? "Campden tablets"
-        : supplementalStabilizerPlan.stabilizerType === "kmeta"
-          ? "Potassium metabisulfite"
-          : "Sodium metabisulfite";
-    const sulfiteAmount =
-      supplementalStabilizerPlan.sulfiteForm === "campden"
-        ? supplementalStabilizerPlan.additional.campden
-        : supplementalStabilizerPlan.additional.sulfite;
-    const sulfiteUnit = supplementalStabilizerPlan.sulfiteForm === "campden" ? "tablets" : "g";
-    const inputs = [
-      supplementalStabilizerPlan.additional.sorbate > SUPPLEMENTAL_GRAM_THRESHOLD
-        ? {
-            name: "Potassium sorbate",
-            amount: supplementalStabilizerPlan.additional.sorbate,
-            unit: "g",
-            kind: "OTHER" as const,
-            source: "manual" as const,
-            note: t(
-              "brews.secondary.supplementalStabilizerNote",
-              "Supplemental stabilizer addition after secondary dilution changed."
-            ),
-            meta: {
-              stage: "SECONDARY",
-              stabilizer: true,
-              supplemental: true,
-              stabilizerKind: "sorbate",
-              stabilizerType: supplementalStabilizerPlan.stabilizerType,
-              volumeLiters: stabilizerPlan.volumeL,
-              adjustedTotalVolumeLiters: stabilizerPlan.adjustedTotalVolumeL,
-              secondaryVolumeLiters: stabilizerPlan.secondaryVolumeL,
-              abv: stabilizerPlan.abv,
-              dilutedAbv: stabilizerPlan.dilutedAbv,
-              recalculatedRequiredAmount: supplementalStabilizerPlan.required.sorbate,
-              priorLoggedAmount: supplementalStabilizerPlan.logged.sorbate,
-              additionalAmount: supplementalStabilizerPlan.additional.sorbate,
-              calculatedUnit: "g",
-              plannedAmount: supplementalStabilizerPlan.additional.sorbate,
-              plannedUnit: "g"
+    try {
+      const sulfiteName =
+        supplementalStabilizerPlan.sulfiteForm === "campden"
+          ? "Campden tablets"
+          : supplementalStabilizerPlan.stabilizerType === "kmeta"
+            ? "Potassium metabisulfite"
+            : "Sodium metabisulfite";
+      const sulfiteAmount =
+        supplementalStabilizerPlan.sulfiteForm === "campden"
+          ? supplementalStabilizerPlan.additional.campden
+          : supplementalStabilizerPlan.additional.sulfite;
+      const sulfiteUnit = supplementalStabilizerPlan.sulfiteForm === "campden" ? "tablets" : "g";
+      const inputs = [
+        supplementalStabilizerPlan.additional.sorbate > SUPPLEMENTAL_GRAM_THRESHOLD
+          ? {
+              name: "Potassium sorbate",
+              amount: supplementalStabilizerPlan.additional.sorbate,
+              unit: "g",
+              kind: "OTHER" as const,
+              source: "manual" as const,
+              note: t(
+                "brews.secondary.supplementalStabilizerNote",
+                "Supplemental stabilizer addition after secondary dilution changed."
+              ),
+              meta: {
+                stage: "SECONDARY",
+                stabilizer: true,
+                supplemental: true,
+                stabilizerKind: "sorbate",
+                stabilizerType: supplementalStabilizerPlan.stabilizerType,
+                volumeLiters: stabilizerPlan.volumeL,
+                adjustedTotalVolumeLiters: stabilizerPlan.adjustedTotalVolumeL,
+                secondaryVolumeLiters: stabilizerPlan.secondaryVolumeL,
+                abv: stabilizerPlan.abv,
+                dilutedAbv: stabilizerPlan.dilutedAbv,
+                recalculatedRequiredAmount: supplementalStabilizerPlan.required.sorbate,
+                priorLoggedAmount: supplementalStabilizerPlan.logged.sorbate,
+                additionalAmount: supplementalStabilizerPlan.additional.sorbate,
+                calculatedUnit: "g",
+                plannedAmount: supplementalStabilizerPlan.additional.sorbate,
+                plannedUnit: "g"
+              }
             }
-          }
-        : null,
-      sulfiteAmount >
-      (supplementalStabilizerPlan.sulfiteForm === "campden"
-        ? SUPPLEMENTAL_CAMPDEN_THRESHOLD
-        : SUPPLEMENTAL_GRAM_THRESHOLD)
-        ? {
-            name: sulfiteName,
-            amount: sulfiteAmount,
-            unit: sulfiteUnit,
-            kind: "OTHER" as const,
-            source: "manual" as const,
-            note: t(
-              "brews.secondary.supplementalStabilizerNote",
-              "Supplemental stabilizer addition after secondary dilution changed."
-            ),
-            meta: {
-              stage: "SECONDARY",
-              stabilizer: true,
-              supplemental: true,
-              stabilizerKind: "sulfite",
-              sulfiteForm: supplementalStabilizerPlan.sulfiteForm,
-              stabilizerType: supplementalStabilizerPlan.stabilizerType,
-              volumeLiters: stabilizerPlan.volumeL,
-              adjustedTotalVolumeLiters: stabilizerPlan.adjustedTotalVolumeL,
-              secondaryVolumeLiters: stabilizerPlan.secondaryVolumeL,
-              abv: stabilizerPlan.abv,
-              dilutedAbv: stabilizerPlan.dilutedAbv,
-              recalculatedRequiredAmount:
-                supplementalStabilizerPlan.sulfiteForm === "campden"
-                  ? supplementalStabilizerPlan.required.campden
-                  : supplementalStabilizerPlan.required.sulfite,
-              priorLoggedAmount:
-                supplementalStabilizerPlan.sulfiteForm === "campden"
-                  ? supplementalStabilizerPlan.logged.campden
-                  : supplementalStabilizerPlan.logged.sulfite,
-              additionalAmount: sulfiteAmount,
-              calculatedUnit: sulfiteUnit,
-              plannedAmount: sulfiteAmount,
-              plannedUnit: sulfiteUnit,
-              sulfiteAmount: supplementalStabilizerPlan.required.sulfite,
-              sulfiteUnit: "g",
-              campdenAmount: supplementalStabilizerPlan.required.campden,
-              campdenUnit: "tablets"
+          : null,
+        sulfiteAmount >
+        (supplementalStabilizerPlan.sulfiteForm === "campden"
+          ? SUPPLEMENTAL_CAMPDEN_THRESHOLD
+          : SUPPLEMENTAL_GRAM_THRESHOLD)
+          ? {
+              name: sulfiteName,
+              amount: sulfiteAmount,
+              unit: sulfiteUnit,
+              kind: "OTHER" as const,
+              source: "manual" as const,
+              note: t(
+                "brews.secondary.supplementalStabilizerNote",
+                "Supplemental stabilizer addition after secondary dilution changed."
+              ),
+              meta: {
+                stage: "SECONDARY",
+                stabilizer: true,
+                supplemental: true,
+                stabilizerKind: "sulfite",
+                sulfiteForm: supplementalStabilizerPlan.sulfiteForm,
+                stabilizerType: supplementalStabilizerPlan.stabilizerType,
+                volumeLiters: stabilizerPlan.volumeL,
+                adjustedTotalVolumeLiters: stabilizerPlan.adjustedTotalVolumeL,
+                secondaryVolumeLiters: stabilizerPlan.secondaryVolumeL,
+                abv: stabilizerPlan.abv,
+                dilutedAbv: stabilizerPlan.dilutedAbv,
+                recalculatedRequiredAmount:
+                  supplementalStabilizerPlan.sulfiteForm === "campden"
+                    ? supplementalStabilizerPlan.required.campden
+                    : supplementalStabilizerPlan.required.sulfite,
+                priorLoggedAmount:
+                  supplementalStabilizerPlan.sulfiteForm === "campden"
+                    ? supplementalStabilizerPlan.logged.campden
+                    : supplementalStabilizerPlan.logged.sulfite,
+                additionalAmount: sulfiteAmount,
+                calculatedUnit: sulfiteUnit,
+                plannedAmount: sulfiteAmount,
+                plannedUnit: sulfiteUnit,
+                sulfiteAmount: supplementalStabilizerPlan.required.sulfite,
+                sulfiteUnit: "g",
+                campdenAmount: supplementalStabilizerPlan.required.campden,
+                campdenUnit: "tablets"
+              }
             }
-          }
-        : null
-    ].filter((input): input is NonNullable<typeof input> => Boolean(input));
+          : null
+      ].filter((input): input is NonNullable<typeof input> => Boolean(input));
 
-    if (inputs.length > 0) await helpers.addAdditions(inputs);
+      if (inputs.length > 0) await helpers.addAdditions(inputs);
+    } finally {
+      setLoggingSupplementalStabilizers(false);
+    }
   };
 
   return (
@@ -652,7 +769,7 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
               <Button
                 size="sm"
                 variant="secondary"
-                disabled={!canEdit}
+                disabled={!canEdit || loggingMissingSecondary}
                 onClick={() => runSecondaryIngredientAction(logMissingSecondary)}
               >
                 {t("brews.secondary.logMissingAdditions", "Log missing additions")}
@@ -676,6 +793,12 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
             ) : null}
             <Button size="sm" variant="secondary" disabled={!canEdit} onClick={() => helpers.openRecordVolume?.()}>
               {t("brews.actions.logVolume", "Record volume")}
+            </Button>
+            <Button size="sm" variant="secondary" disabled={!canScaleSuggestions} onClick={scaleSecondaryToCurrentVolume}>
+              {t("brews.secondary.scaleSecondaryIngredients", "Scale secondary ingredients")}
+            </Button>
+            <Button size="sm" variant="secondary" disabled={!canScaleSuggestions} onClick={scaleAdditivesToCurrentVolume}>
+              {t("brews.secondary.scaleAdditives", "Scale additives")}
             </Button>
           </div>
         </div>
@@ -722,7 +845,12 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
             />
           </div>
           <div className="mt-3 flex flex-wrap gap-2">
-            <Button size="sm" variant="destructive" disabled={!canEdit} onClick={logSupplementalStabilizers}>
+            <Button
+              size="sm"
+              variant="destructive"
+              disabled={!canEdit || loggingSupplementalStabilizers}
+              onClick={logSupplementalStabilizers}
+            >
               {t("brews.secondary.logSupplementalStabilizers", "Log supplemental stabilizers")}
             </Button>
           </div>
@@ -740,7 +868,7 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
             <div className="space-y-2">
               <Button
                 size="sm"
-                disabled={!canEdit || missingSecondary.length === 0}
+                disabled={!canEdit || missingSecondary.length === 0 || loggingMissingSecondary}
                 onClick={() => runSecondaryIngredientAction(logMissingSecondary)}
               >
                 {t("brews.secondary.logMissing", "Log missing")}
@@ -752,13 +880,14 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
                     const loggedAddition = latestLoggedItem(
                       ctx.recipe.actual.additionsByRecipeIngredientId[String(item.line.lineId)]
                     );
-                    const { amount, unit } = getIngredientAmount(item.line);
+                    const { amount, unit } = getSecondaryIngredientAmount(item.line);
+                    const display = getSecondaryIngredientDisplay(item);
                     return (
                       <WorkRow
                         key={item.line.lineId}
                         title={getBrewItemLabel(t, loggedAddition?.name || item.name)}
-                        detail={item.secondary ? `${t("brews.planned.altAmount", "Alt")}: ${item.secondary}` : null}
-                        amount={fmtLoggedAmount(loggedAddition) ?? item.primary}
+                        detail={display.detail}
+                        amount={fmtLoggedAmount(loggedAddition) ?? display.amount}
                         isLogged={isLogged}
                         disabled={!canEdit}
                         loggedLabel={t("brews.primary.logged", "Logged")}
@@ -772,7 +901,7 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
                               source: "recipe_ingredient",
                               amount,
                               unit,
-                              ...getPlannedIngredientAmounts(item.line),
+                              ...getSecondaryIngredientPlannedAmounts(item.line),
                               recipeIngredientId: String(item.line.lineId),
                               meta: { plannedAmount: amount, plannedUnit: unit, stage: "SECONDARY" }
                             })
@@ -797,22 +926,26 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
           </AccordionTrigger>
           <AccordionContent>
             <div className="space-y-2">
-              <Button size="sm" disabled={!canEdit || missingAdditives.length === 0} onClick={logMissingAdditives}>
+              <Button
+                size="sm"
+                disabled={!canEdit || missingAdditives.length === 0 || loggingMissingAdditives}
+                onClick={logMissingAdditives}
+              >
                 {t("brews.secondary.logMissingAdditives", "Log missing additives")}
               </Button>
               {additiveLines.length ? (
                 <ul className="space-y-1">
                   {additiveLines.map((item) => {
                     const isLogged = loggedAdditiveIds.has(String(item.line.lineId));
-                  const loggedAddition = latestLoggedItem(
+                    const loggedAddition = latestLoggedItem(
                       ctx.recipe.actual.additionsByRecipeAdditiveId[String(item.line.lineId)]
                     );
-                    const { amount, unit } = getAdditiveAmount(item.line);
+                    const { amount, unit } = getSecondaryAdditiveAmount(item.line.lineId, getAdditiveAmount(item.line));
                     return (
                       <WorkRow
                         key={item.line.lineId}
                         title={getBrewItemLabel(t, loggedAddition?.name || item.name)}
-                        amount={fmtLoggedAmount(loggedAddition) ?? item.amount}
+                        amount={fmtLoggedAmount(loggedAddition) ?? getSecondaryAdditiveDisplay(item)}
                         isLogged={isLogged}
                         disabled={!canEdit}
                         loggedLabel={t("brews.primary.logged", "Logged")}
@@ -1032,18 +1165,20 @@ function LogStabilizersDialog({
   const sulfiteAdditionName = sulfiteForm === "powder" ? sulfiteName : "Campden tablets";
   const sulfiteAmount = sulfiteForm === "powder" ? results.sulfite : results.campden;
   const sulfiteUnit = sulfiteForm === "powder" ? "g" : "tablets";
+  const editableSorbateAmount = roundEditableAmount(results.sorbate);
+  const editableSulfiteAmount = roundEditableAmount(sulfiteAmount);
   const actualSorbateAmount = parseNumber(sorbateAmount);
   const actualSulfiteAmount = parseNumber(sulfiteActualAmount);
   const sorbateChanged =
-    Number.isFinite(actualSorbateAmount) && Math.abs(actualSorbateAmount - results.sorbate) > 0.0005;
+    Number.isFinite(actualSorbateAmount) && Math.abs(actualSorbateAmount - editableSorbateAmount) > 0.0005;
   const sulfiteChanged =
-    Number.isFinite(actualSulfiteAmount) && Math.abs(actualSulfiteAmount - sulfiteAmount) > 0.0005;
+    Number.isFinite(actualSulfiteAmount) && Math.abs(actualSulfiteAmount - editableSulfiteAmount) > 0.0005;
 
   React.useEffect(() => {
     if (!open || !plan) return;
-    if (!sorbateTouched) setSorbateAmount(fmtNumber(results.sorbate, 3));
-    if (!sulfiteTouched) setSulfiteActualAmount(fmtNumber(sulfiteAmount, sulfiteForm === "powder" ? 3 : 2));
-  }, [open, plan, results.sorbate, sorbateTouched, sulfiteAmount, sulfiteForm, sulfiteTouched]);
+    if (!sorbateTouched) setSorbateAmount(fmtNumber(editableSorbateAmount, 2));
+    if (!sulfiteTouched) setSulfiteActualAmount(fmtNumber(editableSulfiteAmount, 2));
+  }, [open, plan, editableSorbateAmount, sorbateTouched, editableSulfiteAmount, sulfiteForm, sulfiteTouched]);
 
   if (!plan) return null;
 

--- a/components/brews/stages/additionDialogShared.tsx
+++ b/components/brews/stages/additionDialogShared.tsx
@@ -63,6 +63,14 @@ export type PlannedAdditionDialogItem = {
   }>;
 };
 
+type EditableAdditionComponent = {
+  key: string;
+  name: string;
+  amount: string;
+  unit: string;
+  plannedAmount: number;
+};
+
 export type PlannedAdditionSaveInput = {
   name: string;
   amount?: number;
@@ -365,20 +373,25 @@ export function PlannedAdditionDialog({
   const [amountDim, setAmountDim] = React.useState<UnitDim>("unknown");
   const [note, setNote] = React.useState("");
   const [datetime, setDatetime] = React.useState<Date>(new Date());
-  const [components, setComponents] = React.useState<PlannedAdditionDialogItem["components"]>([]);
+  const [components, setComponents] = React.useState<EditableAdditionComponent[]>([]);
   const [isSaving, setIsSaving] = React.useState(false);
 
   React.useEffect(() => {
     if (!planned) return;
     setName(planned.source === "recipe_go_ferm" ? planned.name : getBrewItemLabel(t, planned.name));
-    setAmount(typeof planned.amount === "number" ? String(planned.amount) : "");
+    setAmount(typeof planned.amount === "number" ? fmtNumber(planned.amount) : "");
     setUnit(planned.unit ?? "");
     setBasis(planned.source === "recipe_ingredient" ? (planned.basis ?? "weight") : "other");
     setAmountTouched(false);
     setAmountDim(inferAdditiveAmountDimFromUnit(planned.unit ?? ""));
     setNote("");
     setDatetime(new Date());
-    setComponents(planned.components ?? []);
+    setComponents(
+      (planned.components ?? []).map((component) => ({
+        ...component,
+        amount: fmtNumber(component.amount)
+      }))
+    );
   }, [planned, t]);
 
   const usesIngredientUnits = planned?.source === "recipe_ingredient";
@@ -465,8 +478,14 @@ export function PlannedAdditionDialog({
     const trimmedName = name.trim();
     if (!trimmedName) return;
 
-    const parsedAmount = amount.trim() ? Number(amount) : undefined;
-    const actualComponents = components ?? [];
+    const parsedAmount = amount.trim() ? parseNumber(amount) : undefined;
+    const actualComponents = (components ?? []).map((component) => {
+      const parsed = parseNumber(component.amount);
+      return {
+        ...component,
+        amount: Number.isFinite(parsed) ? parsed : 0
+      };
+    });
     const componentTotal = actualComponents.reduce((sum, component) => {
       const value = Number(component.amount);
       return sum + (Number.isFinite(value) ? value : 0);
@@ -565,7 +584,7 @@ export function PlannedAdditionDialog({
                         const next = [...components];
                         next[index] = {
                           ...component,
-                          amount: Number(value)
+                          amount: value
                         };
                         setComponents(next);
                       }}

--- a/lib/utils/brewTrackingScaling.test.ts
+++ b/lib/utils/brewTrackingScaling.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getBrewTrackingScaleRatio,
+  scaleAdditiveSuggestions,
+  scaleSecondaryIngredientSuggestions
+} from "@/lib/utils/brewTrackingScaling";
+import type { AdditiveLine, IngredientLine } from "@/types/recipeData";
+
+const secondaryIngredient: IngredientLine = {
+  lineId: "secondary-honey",
+  name: "Honey",
+  ref: { kind: "custom" },
+  category: "sugar",
+  brix: "79.6",
+  secondary: true,
+  amounts: {
+    basis: "weight",
+    weight: { value: "2.5", unit: "lb" },
+    volume: { value: "0.75", unit: "gal" }
+  }
+};
+
+const additive: AdditiveLine = {
+  lineId: "tannin",
+  name: "Tannin",
+  amount: "1.234",
+  unit: "g",
+  amountTouched: false,
+  amountDim: "weight"
+};
+
+test("getBrewTrackingScaleRatio requires positive current and recipe volumes", () => {
+  assert.equal(getBrewTrackingScaleRatio(null, 4), null);
+  assert.equal(getBrewTrackingScaleRatio(2, 0), null);
+  assert.equal(getBrewTrackingScaleRatio(2, 4), 0.5);
+});
+
+test("scaleSecondaryIngredientSuggestions scales only unlogged secondary rows", () => {
+  const scaled = scaleSecondaryIngredientSuggestions({
+    lines: [
+      secondaryIngredient,
+      { ...secondaryIngredient, lineId: "logged-secondary" },
+      { ...secondaryIngredient, lineId: "primary", secondary: false }
+    ],
+    loggedIds: new Set(["logged-secondary"]),
+    currentVolumeL: 2,
+    recipeBaseVolumeL: 4
+  });
+
+  assert.deepEqual(Array.from(scaled.keys()), ["secondary-honey"]);
+  assert.equal(scaled.get("secondary-honey")?.basisAmount, 1.25);
+  assert.equal(scaled.get("secondary-honey")?.volumeAmount, 0.38);
+});
+
+test("scaleAdditiveSuggestions scales only unlogged additives", () => {
+  const scaled = scaleAdditiveSuggestions({
+    lines: [additive, { ...additive, lineId: "logged-additive" }],
+    loggedIds: new Set(["logged-additive"]),
+    currentVolumeL: 2,
+    recipeBaseVolumeL: 4
+  });
+
+  assert.deepEqual(Array.from(scaled.keys()), ["tannin"]);
+  assert.equal(scaled.get("tannin")?.amount, 0.62);
+});

--- a/lib/utils/brewTrackingScaling.ts
+++ b/lib/utils/brewTrackingScaling.ts
@@ -1,0 +1,109 @@
+import type { AdditiveLine, IngredientLine } from "@/types/recipeData";
+import { parseNumber } from "@/lib/utils/validateInput";
+
+const EDITABLE_AMOUNT_DECIMALS = 2;
+
+export type ScaledIngredientSuggestion = {
+  lineId: string;
+  weightAmount: number;
+  weightUnit: string;
+  volumeAmount: number;
+  volumeUnit: string;
+  basisAmount: number;
+  basisUnit: string;
+};
+
+export type ScaledAdditiveSuggestion = {
+  lineId: string;
+  amount: number;
+  unit: string;
+};
+
+export function roundEditableAmount(value: number, decimals = EDITABLE_AMOUNT_DECIMALS) {
+  if (!Number.isFinite(value)) return 0;
+  const factor = 10 ** decimals;
+  const rounded = Math.round(value * factor) / factor;
+  return Object.is(rounded, -0) ? 0 : rounded;
+}
+
+export function getBrewTrackingScaleRatio(currentVolumeL: number | null | undefined, recipeBaseVolumeL: number | null | undefined) {
+  if (
+    typeof currentVolumeL !== "number" ||
+    !Number.isFinite(currentVolumeL) ||
+    currentVolumeL <= 0 ||
+    typeof recipeBaseVolumeL !== "number" ||
+    !Number.isFinite(recipeBaseVolumeL) ||
+    recipeBaseVolumeL <= 0
+  ) {
+    return null;
+  }
+
+  return currentVolumeL / recipeBaseVolumeL;
+}
+
+export function scaleSecondaryIngredientSuggestions({
+  lines,
+  loggedIds,
+  currentVolumeL,
+  recipeBaseVolumeL
+}: {
+  lines: IngredientLine[];
+  loggedIds: Set<string>;
+  currentVolumeL: number | null | undefined;
+  recipeBaseVolumeL: number | null | undefined;
+}) {
+  const ratio = getBrewTrackingScaleRatio(currentVolumeL, recipeBaseVolumeL);
+  if (ratio == null) return new Map<string, ScaledIngredientSuggestion>();
+
+  const scaled = new Map<string, ScaledIngredientSuggestion>();
+
+  for (const line of lines) {
+    if (!line.secondary || !(line.name ?? "").trim() || loggedIds.has(String(line.lineId))) continue;
+
+    const weightAmount = roundEditableAmount(parseNumber(line.amounts.weight.value) * ratio);
+    const volumeAmount = roundEditableAmount(parseNumber(line.amounts.volume.value) * ratio);
+    const basisAmount = line.amounts.basis === "volume" ? volumeAmount : weightAmount;
+    const basisUnit = line.amounts.basis === "volume" ? line.amounts.volume.unit : line.amounts.weight.unit;
+
+    scaled.set(String(line.lineId), {
+      lineId: String(line.lineId),
+      weightAmount,
+      weightUnit: line.amounts.weight.unit,
+      volumeAmount,
+      volumeUnit: line.amounts.volume.unit,
+      basisAmount,
+      basisUnit
+    });
+  }
+
+  return scaled;
+}
+
+export function scaleAdditiveSuggestions({
+  lines,
+  loggedIds,
+  currentVolumeL,
+  recipeBaseVolumeL
+}: {
+  lines: AdditiveLine[];
+  loggedIds: Set<string>;
+  currentVolumeL: number | null | undefined;
+  recipeBaseVolumeL: number | null | undefined;
+}) {
+  const ratio = getBrewTrackingScaleRatio(currentVolumeL, recipeBaseVolumeL);
+  if (ratio == null) return new Map<string, ScaledAdditiveSuggestion>();
+
+  const scaled = new Map<string, ScaledAdditiveSuggestion>();
+
+  for (const line of lines) {
+    if (!(line.name ?? "").trim() || loggedIds.has(String(line.lineId))) continue;
+
+    scaled.set(String(line.lineId), {
+      lineId: String(line.lineId),
+      amount: roundEditableAmount(parseNumber(line.amount) * ratio),
+      unit: line.unit
+    });
+  }
+
+  return scaled;
+}

--- a/locales/de/default.json
+++ b/locales/de/default.json
@@ -581,6 +581,8 @@
       "recipeAdditives": "Rezeptzusätze",
       "recipeNotes": "Sekundäre Rezeptnotizen",
       "recipeNoteTitle": "Sekundäre Rezeptnotiz hinzufügen",
+      "scaleAdditives": "Skalierungszusätze",
+      "scaleSecondaryIngredients": "Skalierung sekundärer Zutaten",
       "secondaryBeforeStabilizersHelp": "Dieses Rezept verwendet Stabilisatoren. Sekundäre Zutaten werden normalerweise nach den Stabilisatoren protokolliert, damit die Dosierung auf aktuellem Volumen und ABV basiert.",
       "secondaryBeforeStabilizersTitle": "Zugaben vor Stabilisatoren protokollieren?",
       "secondaryVolumeForStabilizers": "Sekundärvolumen",

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -581,6 +581,8 @@
       "recipeAdditives": "Recipe additives",
       "recipeNotes": "Recipe secondary notes",
       "recipeNoteTitle": "Add recipe secondary note",
+      "scaleAdditives": "Scale additives",
+      "scaleSecondaryIngredients": "Scale secondary ingredients",
       "secondaryBeforeStabilizersHelp": "This recipe uses stabilizers. Secondary ingredients are usually logged after stabilizers so the dosage is based on the current volume and ABV.",
       "secondaryBeforeStabilizersTitle": "Log additions before stabilizers?",
       "secondaryVolumeForStabilizers": "Secondary volume",


### PR DESCRIPTION
## Summary
- Fix decimal editing for brew tracking addition and nutrient amount fields.
- Use linked recipe volume units in brew summaries, stage panels, and volume dialogs.
- Add in-memory secondary ingredient/additive scaling to recorded batch volume.
- Prevent duplicate bulk logs while multi-entry submissions are in flight.
- Improve nutrient addition history summaries with component details.

## Validation
- `npx tsc --noEmit`
- `npx tsx --test lib/utils/brewTrackingScaling.test.ts`