### PR TITLE
Fix mobile brew tracker dialogs

### DIFF
--- a/app/[locale]/account/brews/[brew_id]/page.tsx
+++ b/app/[locale]/account/brews/[brew_id]/page.tsx
@@ -19,6 +19,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "@/hooks/use-toast";
 
 import AddBrewEntryDialog, { EntryType, OpenAddEntryArgs } from "@/components/brews/AddBrewEntryDialog";
+import { BREW_TRACKER_DIALOG_CONTENT_CLASS, BREW_TRACKER_DIALOG_FOOTER_CLASS } from "@/components/brews/brewTrackerDialog";
 import { BrewTimelineCharts } from "@/components/brews/BrewTimelineCharts";
 import { RecordVolumeDialog } from "@/components/brews/RecordVolumeDialog";
 import { useRecipe } from "@/components/providers/RecipeProvider";
@@ -1070,7 +1071,7 @@ export default function BrewPageClient() {
         }
       />
       <Dialog open={startDateDialogOpen} onOpenChange={setStartDateDialogOpen}>
-        <DialogContent>
+        <DialogContent className={BREW_TRACKER_DIALOG_CONTENT_CLASS}>
           <DialogHeader>
             <DialogTitle>{t("start", "Start")}</DialogTitle>
           </DialogHeader>
@@ -1079,7 +1080,7 @@ export default function BrewPageClient() {
             onChange={(value) => setStartValue(value ? toDateTimeLocalValue(value.toISOString()) : "")}
             hourCycle={12}
           />
-          <DialogFooter>
+          <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
             <Button
               variant="secondary"
               onClick={() => {
@@ -1631,7 +1632,7 @@ function EditBrewEntryDialog({
 
   return (
     <Dialog open={Boolean(entry)} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[560px]">
+      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[560px]`}>
         <DialogHeader>
           <DialogTitle>{t("edit", "Edit")}</DialogTitle>
         </DialogHeader>
@@ -1894,7 +1895,7 @@ function EditBrewEntryDialog({
 
         </div>
 
-        <DialogFooter className="gap-2 sm:justify-between">
+        <DialogFooter className={`${BREW_TRACKER_DIALOG_FOOTER_CLASS} sm:justify-between`}>
           {canDelete ? (
             <AlertDialog>
               <AlertDialogTrigger asChild>
@@ -1903,7 +1904,7 @@ function EditBrewEntryDialog({
                   {t("delete", "Delete")}
                 </Button>
               </AlertDialogTrigger>
-              <AlertDialogContent>
+              <AlertDialogContent className={BREW_TRACKER_DIALOG_CONTENT_CLASS}>
                 <AlertDialogHeader>
                   <AlertDialogTitle>{t("brews.deleteEntryTitle", "Delete this entry?")}</AlertDialogTitle>
                   <AlertDialogDescription>
@@ -1913,7 +1914,7 @@ function EditBrewEntryDialog({
                     )}
                   </AlertDialogDescription>
                 </AlertDialogHeader>
-                <AlertDialogFooter>
+                <AlertDialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
                   <AlertDialogCancel disabled={isSaving}>{t("cancel", "Cancel")}</AlertDialogCancel>
                   <AlertDialogAction
                     className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
@@ -1931,7 +1932,7 @@ function EditBrewEntryDialog({
           ) : (
             <div />
           )}
-          <div className="flex gap-2">
+          <div className="flex gap-3">
             <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
               {t("cancel", "Cancel")}
             </Button>

--- a/components/brews/AddBrewEntryDialog.tsx
+++ b/components/brews/AddBrewEntryDialog.tsx
@@ -37,6 +37,7 @@ import { BREW_ENTRY_TYPE } from "@/lib/brewEnums";
 import type { TempUnits } from "@/lib/brewEnums";
 import { entryPayload } from "@/lib/utils/entryPayload";
 import type { GravityReadingRole } from "@/lib/utils/entryPayload";
+import { BREW_TRACKER_DIALOG_CONTENT_CLASS } from "@/components/brews/brewTrackerDialog";
 import { getUnitLabel } from "@/components/brews/stages/additionDialogShared";
 
 export type EntryType =
@@ -239,7 +240,7 @@ export default function AddBrewEntryDialog({
         </DialogTrigger>
       ) : null}
 
-      <DialogContent className="sm:max-w-[560px]">
+      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[560px]`}>
         <DialogHeader>
           <DialogTitle>{t("brew.addEntry", "Add entry")}</DialogTitle>
         </DialogHeader>
@@ -372,7 +373,7 @@ export default function AddBrewEntryDialog({
             </div>
           )}
 
-          <div className="flex justify-end gap-2 pt-2">
+          <div className="flex justify-end gap-3 pt-2">
             <Button
               type="button"
               variant="secondary"

--- a/components/brews/BrewStagePath.tsx
+++ b/components/brews/BrewStagePath.tsx
@@ -1,6 +1,7 @@
 import { BREW_ENTRY_TYPE, type BrewStage } from "@/lib/brewEnums";
 import { Path, PathActivePanel, PathContent, PathHeader, PathItem, PathList, PathTitle } from "@/components/ui/path";
 import { Button } from "@/components/ui/button";
+import { BREW_TRACKER_DIALOG_CONTENT_CLASS, BREW_TRACKER_DIALOG_FOOTER_CLASS } from "@/components/brews/brewTrackerDialog";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { DateTimePicker } from "@/components/ui/datetime-picker";
 import { useRouter } from "next/navigation";
@@ -449,7 +450,7 @@ function StageMoveDateDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[480px]">
+      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[480px]`}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
@@ -457,7 +458,7 @@ function StageMoveDateDialog({
           <div className="text-sm font-medium">{t("date", "Date")}</div>
           <DateTimePicker value={datetime} onChange={(value) => value && setDatetime(value)} hourCycle={12} />
         </div>
-        <DialogFooter>
+        <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
           <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
             {t("cancel", "Cancel")}
           </Button>
@@ -506,7 +507,7 @@ function StageMoveReviewDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[560px]">
+      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[560px]`}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
@@ -576,7 +577,7 @@ function StageMoveReviewDialog({
           </div>
         </div>
 
-        <DialogFooter>
+        <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
           <Button variant="secondary" onClick={() => onOpenChange(false)}>
             {t("cancel", "Cancel")}
           </Button>

--- a/components/brews/LogOriginalGravityDialog.tsx
+++ b/components/brews/LogOriginalGravityDialog.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { DateTimePicker } from "@/components/ui/datetime-picker";
+import { BREW_TRACKER_DIALOG_CONTENT_CLASS, BREW_TRACKER_DIALOG_FOOTER_CLASS } from "@/components/brews/brewTrackerDialog";
 
 export type LogOriginalGravityInput = {
   chosenOg: number;
@@ -105,7 +106,7 @@ export function LogOriginalGravityDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[520px]">
+      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[520px]`}>
         <DialogHeader>
           <DialogTitle>{t("brews.actions.logOg", "Log OG")}</DialogTitle>
           <DialogDescription>
@@ -172,7 +173,7 @@ export function LogOriginalGravityDialog({
           </div>
         </div>
 
-        <DialogFooter>
+        <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
           <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
             {t("cancel", "Cancel")}
           </Button>

--- a/components/brews/LogYeastDialog.tsx
+++ b/components/brews/LogYeastDialog.tsx
@@ -24,6 +24,7 @@ import {
 import SearchableInput from "@/components/ui/SearchableInput";
 import { DateTimePicker } from "@/components/ui/datetime-picker";
 import { AmountUnitField } from "@/components/brews/stages/additionDialogShared";
+import { BREW_TRACKER_DIALOG_CONTENT_CLASS, BREW_TRACKER_DIALOG_FOOTER_CLASS } from "@/components/brews/brewTrackerDialog";
 import { useYeastsQuery } from "@/hooks/reactQuery/useYeastsQuery";
 import type { BrewPlannedYeast } from "@/lib/utils/buildBrewRecipeStageData";
 import { isValidNumber } from "@/lib/utils/validateInput";
@@ -199,7 +200,7 @@ export function LogYeastDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[560px]">
+      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[560px]`}>
         <DialogHeader>
           <DialogTitle>{t("brews.actions.logYeast", "Log yeast")}</DialogTitle>
         </DialogHeader>
@@ -303,7 +304,7 @@ export function LogYeastDialog({
           </div>
         </div>
 
-        <DialogFooter>
+        <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
           <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
             {t("cancel", "Cancel")}
           </Button>

--- a/components/brews/RecordVolumeDialog.tsx
+++ b/components/brews/RecordVolumeDialog.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/ui/input-group";
 import { Separator } from "@/components/ui/separator";
 import { DateTimePicker } from "@/components/ui/datetime-picker";
+import { BREW_TRACKER_DIALOG_CONTENT_CLASS, BREW_TRACKER_DIALOG_FOOTER_CLASS } from "@/components/brews/brewTrackerDialog";
 import { getUnitLabel } from "@/components/brews/stages/additionDialogShared";
 
 type DialogVolumeUnit = VolumeUnit;
@@ -151,7 +152,7 @@ export function RecordVolumeDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent className={BREW_TRACKER_DIALOG_CONTENT_CLASS}>
         <DialogHeader>
           <DialogTitle>
             {isSecondaryVolume
@@ -287,7 +288,7 @@ export function RecordVolumeDialog({
           </div>
         </div>
 
-        <DialogFooter>
+        <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
           <Button
             variant="secondary"
             onClick={() => onOpenChange(false)}

--- a/components/brews/brewTrackerDialog.ts
+++ b/components/brews/brewTrackerDialog.ts
@@ -1,0 +1,7 @@
+export const BREW_TRACKER_DIALOG_CONTENT_CLASS =
+  "top-24 max-h-[calc(100dvh-10rem)] w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] translate-y-0 overflow-y-auto rounded-lg p-4 sm:top-[50%] sm:max-h-[calc(100dvh-2rem)] sm:w-full sm:translate-y-[-50%] sm:p-6";
+
+export const BREW_TRACKER_WIDE_DIALOG_CONTENT_CLASS =
+  "top-24 max-h-[calc(100dvh-10rem)] w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] translate-y-0 overflow-y-auto rounded-lg p-4 sm:top-[50%] sm:max-h-[calc(100dvh-2rem)] sm:w-full sm:max-w-[720px] sm:translate-y-[-50%] sm:p-5";
+
+export const BREW_TRACKER_DIALOG_FOOTER_CLASS = "gap-2";

--- a/components/brews/stages/SecondaryStagePanel.tsx
+++ b/components/brews/stages/SecondaryStagePanel.tsx
@@ -5,6 +5,11 @@ import { useTranslation } from "react-i18next";
 
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
+import {
+  BREW_TRACKER_DIALOG_CONTENT_CLASS,
+  BREW_TRACKER_DIALOG_FOOTER_CLASS,
+  BREW_TRACKER_WIDE_DIALOG_CONTENT_CLASS
+} from "@/components/brews/brewTrackerDialog";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { DateTimePicker } from "@/components/ui/datetime-picker";
 import { Input } from "@/components/ui/input";
@@ -1273,7 +1278,7 @@ function LogStabilizersDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="top-24 bottom-24 max-h-none w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] translate-y-0 overflow-y-auto p-4 sm:max-w-[720px] sm:p-5">
+      <DialogContent className={BREW_TRACKER_WIDE_DIALOG_CONTENT_CLASS}>
         <DialogHeader>
           <DialogTitle>{t("brews.secondary.logStabilizers", "Log stabilizers")}</DialogTitle>
         </DialogHeader>
@@ -1415,7 +1420,7 @@ function LogStabilizersDialog({
           </div>
         </div>
 
-        <DialogFooter>
+        <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
           <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
             {t("cancel", "Cancel")}
           </Button>
@@ -1465,7 +1470,7 @@ function ConfirmBulkAgeDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[480px]">
+      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[480px]`}>
         <DialogHeader>
           <DialogTitle>{t("brews.secondary.confirmBulkAgeTitle", "Move to bulk aging?")}</DialogTitle>
         </DialogHeader>
@@ -1476,7 +1481,7 @@ function ConfirmBulkAgeDialog({
           <Label>{t("date", "Date")}</Label>
           <DateTimePicker value={datetime} onChange={(value) => value && setDatetime(value)} hourCycle={12} />
         </div>
-        <DialogFooter>
+        <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
           <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
             {t("cancel", "Cancel")}
           </Button>
@@ -1517,7 +1522,7 @@ function ConfirmPackageDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[480px]">
+      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[480px]`}>
         <DialogHeader>
           <DialogTitle>{t("brews.secondary.confirmPackageTitle", "Move to packaging?")}</DialogTitle>
         </DialogHeader>
@@ -1531,7 +1536,7 @@ function ConfirmPackageDialog({
           <Label>{t("date", "Date")}</Label>
           <DateTimePicker value={datetime} onChange={(value) => value && setDatetime(value)} hourCycle={12} />
         </div>
-        <DialogFooter>
+        <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
           <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
             {t("cancel", "Cancel")}
           </Button>
@@ -1567,7 +1572,7 @@ function ConfirmSecondaryBeforeStabilizersDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[480px]">
+      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[480px]`}>
         <DialogHeader>
           <DialogTitle>{t("brews.secondary.secondaryBeforeStabilizersTitle", "Log additions before stabilizers?")}</DialogTitle>
         </DialogHeader>
@@ -1577,7 +1582,7 @@ function ConfirmSecondaryBeforeStabilizersDialog({
             "This recipe uses stabilizers. Secondary ingredients are usually logged after stabilizers so the dosage is based on the current volume and ABV."
           )}
         </div>
-        <DialogFooter>
+        <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
           <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
             {t("cancel", "Cancel")}
           </Button>

--- a/components/brews/stages/StagePanelShared.tsx
+++ b/components/brews/stages/StagePanelShared.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { BREW_TRACKER_DIALOG_CONTENT_CLASS, BREW_TRACKER_DIALOG_FOOTER_CLASS } from "@/components/brews/brewTrackerDialog";
 import { DateTimePicker } from "@/components/ui/datetime-picker";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
@@ -277,7 +278,7 @@ export function DateConfirmDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[480px]">
+      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[480px]`}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
@@ -286,7 +287,7 @@ export function DateConfirmDialog({
           <Label>{t("date", "Date")}</Label>
           <DateTimePicker value={datetime} onChange={(value) => value && setDatetime(value)} hourCycle={12} />
         </div>
-        <DialogFooter>
+        <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
           <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
             {t("cancel", "Cancel")}
           </Button>
@@ -327,7 +328,7 @@ export function LogRecipeNoteDialog({
 
   return (
     <Dialog open={Boolean(note)} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[520px]">
+      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[520px]`}>
         <DialogHeader>
           <DialogTitle>{note?.title ?? t("brews.primary.addNote", "Add note")}</DialogTitle>
         </DialogHeader>
@@ -342,7 +343,7 @@ export function LogRecipeNoteDialog({
             <DateTimePicker value={datetime} onChange={(value) => value && setDatetime(value)} hourCycle={12} />
           </div>
         </div>
-        <DialogFooter>
+        <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
           <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
             {t("cancel", "Cancel")}
           </Button>

--- a/components/brews/stages/additionDialogShared.tsx
+++ b/components/brews/stages/additionDialogShared.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import lodash from "lodash";
 
 import { Button } from "@/components/ui/button";
+import { BREW_TRACKER_DIALOG_CONTENT_CLASS, BREW_TRACKER_DIALOG_FOOTER_CLASS } from "@/components/brews/brewTrackerDialog";
 import { DateTimePicker } from "@/components/ui/datetime-picker";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { InputGroup, InputGroupAddon, InputGroupInput, InputGroupText } from "@/components/ui/input-group";
@@ -537,7 +538,7 @@ export function PlannedAdditionDialog({
 
   return (
     <Dialog open={Boolean(planned)} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[560px]">
+      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[560px]`}>
         <DialogHeader>
           <DialogTitle>{planned?.title ?? defaultTitle}</DialogTitle>
         </DialogHeader>
@@ -628,7 +629,7 @@ export function PlannedAdditionDialog({
           </div>
         </div>
 
-        <DialogFooter>
+        <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
           <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
             {t("cancel", "Cancel")}
           </Button>


### PR DESCRIPTION
## Summary

Fixes mobile layout pressure in brew tracker dialogs by giving the brew tracker modal content a scoped mobile layout class. The dialogs now sit below the fixed page navigation, leave room near the bottom of the viewport, and scroll internally when their forms are taller than the visible area.

Also adds consistent spacing between save and cancel actions across the brew tracker dialog footers.

## Validation

- npx tsc --noEmit
- npx eslint 'app/[locale]/account/brews/[brew_id]/page.tsx' components/brews/AddBrewEntryDialog.tsx components/brews/BrewStagePath.tsx components/brews/LogOriginalGravityDialog.tsx components/brews/LogYeastDialog.tsx components/brews/RecordVolumeDialog.tsx components/brews/brewTrackerDialog.ts components/brews/stages/SecondaryStagePanel.tsx components/brews/stages/StagePanelShared.tsx components/brews/stages/additionDialogShared.tsx