### PR TITLE
Add Brix gravity readings to brew tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ next-env.d.ts
 AGENTS.md
 # Sentry Config File
 .env.sentry-build-plugin
+# next-agents-md
+.next-docs/

--- a/app/[locale]/account/brews/[brew_id]/page.tsx
+++ b/app/[locale]/account/brews/[brew_id]/page.tsx
@@ -47,13 +47,15 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger
 } from "@/components/ui/alert-dialog";
-import { BREW_ENTRY_TYPE, BREW_STAGE, type BrewStage } from "@/lib/brewEnums";
+import { BREW_ENTRY_TYPE, BREW_STAGE, GRAVITY_UNITS, type BrewStage, type GravityUnit } from "@/lib/brewEnums";
 import { BrewAdditionData, BrewPackagingData, GravityReadingRole, entryPayload } from "@/lib/utils/entryPayload";
 import { useCreateBrewEntry, useDeleteBrewEntry, usePatchBrewEntry } from "@/hooks/reactQuery/useCreateBrewEntry";
 import { L_TO_VOLUME, VOLUME_TO_L } from "@/lib/utils/recipeDataCalculations";
-import { calcABV } from "@/lib/utils/unitConverter";
+import { calcABV, refractometerCorrectedSg, toBrix, toSG } from "@/lib/utils/unitConverter";
 import { isValidNumber, normalizeNumberString, parseNumber } from "@/lib/utils/validateInput";
 import { buildBrewRecipeStageData } from "@/lib/utils/buildBrewRecipeStageData";
+import { formatBrixDisplay, formatSgAsBrixDisplay, formatSgDisplay } from "@/lib/utils/gravityFormatting";
+import TooltipHelper from "@/components/Tooltips";
 import {
   AdditiveUnitSelect,
   AmountUnitField,
@@ -150,11 +152,7 @@ export default function BrewPageClient() {
   };
 
   const formatGravity = (gravity?: number | null) => {
-    if (typeof gravity !== "number" || !Number.isFinite(gravity)) {
-      return "—";
-    }
-
-    return normalizeNumberString(gravity, 3, i18n.resolvedLanguage, true);
+    return formatSgDisplay(gravity, i18n.resolvedLanguage);
   };
 
   const formatAbv = (value?: number | null) => {
@@ -211,8 +209,18 @@ export default function BrewPageClient() {
   const formatGravityEntry = (entry: AccountBrewEntry) => {
     const role = (entry.data as any)?.readingRole;
     const source = (entry.data as any)?.source;
+    const display = (entry.data as any)?.display;
     const label = role === "OG" ? "OG" : role === "FG" ? "FG" : "SG";
-    return `${label}: ${formatGravity(entry.gravity)}${source === "recipe" ? ` (${t("recipe", "Recipe").toLowerCase()})` : ""}`;
+    const brixDetail =
+      display?.enteredUnit === GRAVITY_UNITS.BRIX &&
+      typeof display.enteredValue === "number" &&
+      Number.isFinite(display.enteredValue)
+        ? ` (${formatBrixDisplay(display.enteredValue, t("BRIX"), i18n.resolvedLanguage)})`
+        : "";
+    const correctedDetail = display?.refractometerCorrectionApplied
+      ? ` ${t("brews.gravity.corrected", "corrected")}`
+      : "";
+    return `${label}: ${formatGravity(entry.gravity)}${brixDetail}${correctedDetail}${source === "recipe" ? ` (${t("recipe", "Recipe").toLowerCase()})` : ""}`;
   };
 
   const formatAdditionEntry = (entry: AccountBrewEntry) => {
@@ -1044,6 +1052,7 @@ export default function BrewPageClient() {
                 await patchEntry({ brewId: brew.id, entryId, input });
               }}
               current_volume_liters={brew.current_volume_liters}
+              gravity_unit_preference={brew.gravity_unit_preference}
               recipe={brewRecipe}
               patchBrewMetadata={async (input) => {
                 await saveMetadata(input);
@@ -1103,6 +1112,15 @@ export default function BrewPageClient() {
         gravityRole={entryGravityRole}
         gravityDefaultValue={entryGravityDefaultValue}
         gravitySource={entryGravitySource}
+        gravityUnitPreference={brew.gravity_unit_preference}
+        correctionOg={displayActualOg}
+        onGravityUnitPreferenceChange={async (unit) => {
+          if (unit === brew.gravity_unit_preference) return;
+          await patchMeta({
+            brewId: brew.id,
+            input: { gravity_unit_preference: unit }
+          });
+        }}
         hideTrigger
       />
       <Tabs value={historyView} onValueChange={(value) => setHistoryView(value as HistoryView)} className="space-y-3">
@@ -1316,6 +1334,7 @@ export default function BrewPageClient() {
       </Tabs>
       <EditBrewEntryDialog
         entry={editingEntry}
+        correctionOg={displayActualOg}
         onOpenChange={(open) => {
           if (!open) setEditingEntry(null);
         }}
@@ -1366,11 +1385,13 @@ function inferAdditionBasis(unit?: string | null): AdditionBasis {
 
 function EditBrewEntryDialog({
   entry,
+  correctionOg,
   onOpenChange,
   onSave,
   onDelete
 }: {
   entry: AccountBrewEntry | null;
+  correctionOg?: number | null;
   onOpenChange: (open: boolean) => void;
   formatGravity: (gravity?: number | null) => string;
   onSave: (entryId: string, input: {
@@ -1389,6 +1410,9 @@ function EditBrewEntryDialog({
   const [title, setTitle] = useState("");
   const [note, setNote] = useState("");
   const [gravity, setGravity] = useState("");
+  const [gravityUnit, setGravityUnit] = useState<GravityUnit>(GRAVITY_UNITS.SG);
+  const [applyRefractometerCorrection, setApplyRefractometerCorrection] = useState(false);
+  const [correctionFactor, setCorrectionFactor] = useState("1");
   const [temperature, setTemperature] = useState("");
   const [tempUnits, setTempUnits] = useState("F");
   const [ph, setPh] = useState("");
@@ -1410,7 +1434,25 @@ function EditBrewEntryDialog({
     setDatetime(Number.isNaN(parsedDate.getTime()) ? new Date() : parsedDate);
     setTitle(entry.title ?? "");
     setNote(entry.note ?? "");
-    setGravity(entry.gravity != null ? String(entry.gravity) : "");
+    const gravityDisplay = (entry.data as any)?.display;
+    const enteredUnit = gravityDisplay?.enteredUnit === GRAVITY_UNITS.BRIX ? GRAVITY_UNITS.BRIX : GRAVITY_UNITS.SG;
+    setGravityUnit(enteredUnit);
+    setGravity(
+      enteredUnit === GRAVITY_UNITS.BRIX &&
+        typeof gravityDisplay?.enteredValue === "number" &&
+        Number.isFinite(gravityDisplay.enteredValue)
+        ? formatBrixDisplay(gravityDisplay.enteredValue, "", i18n.resolvedLanguage).trim()
+        : entry.gravity != null
+          ? formatSgDisplay(entry.gravity, i18n.resolvedLanguage)
+          : ""
+    );
+    setApplyRefractometerCorrection(Boolean(gravityDisplay?.refractometerCorrectionApplied));
+    setCorrectionFactor(
+      typeof gravityDisplay?.correctionFactor === "number" &&
+        Number.isFinite(gravityDisplay.correctionFactor)
+        ? String(gravityDisplay.correctionFactor)
+        : "1"
+    );
     setTemperature(entry.temperature != null ? String(entry.temperature) : "");
     setTempUnits(entry.temp_units ?? "F");
     setPh(typeof (entry.data as any)?.ph === "number" ? String((entry.data as any).ph) : "");
@@ -1461,6 +1503,24 @@ function EditBrewEntryDialog({
 
   const isStageChange = entry.type === BREW_ENTRY_TYPE.STAGE_CHANGE;
   const canDelete = !isStageChange;
+  const hasCorrectionOg =
+    typeof correctionOg === "number" &&
+    Number.isFinite(correctionOg) &&
+    correctionOg > 1;
+  const canApplyRefractometerCorrection =
+    gravityUnit === GRAVITY_UNITS.BRIX && hasCorrectionOg;
+  const gravityPreview = (() => {
+    if (entry.type !== BREW_ENTRY_TYPE.GRAVITY) return null;
+    const enteredValue = Number(gravity);
+    if (!Number.isFinite(enteredValue)) return null;
+    if (gravityUnit === GRAVITY_UNITS.SG) return enteredValue;
+    const factor = Number(correctionFactor);
+    if (applyRefractometerCorrection && hasCorrectionOg) {
+      if (!Number.isFinite(factor) || factor <= 0) return null;
+      return refractometerCorrectedSg(toBrix(correctionOg!), enteredValue, factor);
+    }
+    return toSG(enteredValue);
+  })();
   const withoutVersion = (data: any) => {
     const rest = { ...(data ?? {}) };
     delete rest.v;
@@ -1489,10 +1549,43 @@ function EditBrewEntryDialog({
     }
 
     if (entry.type === BREW_ENTRY_TYPE.GRAVITY) {
-      const n = Number(gravity);
-      if (!Number.isFinite(n)) throw new Error("Invalid gravity");
-      patch.gravity = n;
-      patch.data = withoutVersion(entry.data);
+      const enteredValue = Number(gravity);
+      if (!Number.isFinite(enteredValue)) throw new Error("Invalid gravity");
+      const factor = Number(correctionFactor);
+      if (
+        gravityUnit === GRAVITY_UNITS.BRIX &&
+        applyRefractometerCorrection &&
+        (!Number.isFinite(factor) || factor <= 0)
+      ) {
+        throw new Error("Invalid correction factor");
+      }
+      const sg =
+        gravityUnit === GRAVITY_UNITS.SG
+          ? enteredValue
+          : applyRefractometerCorrection && hasCorrectionOg
+            ? refractometerCorrectedSg(toBrix(correctionOg!), enteredValue, factor)
+            : toSG(enteredValue);
+      patch.gravity = sg;
+      patch.data = {
+        ...withoutVersion(entry.data),
+        display: {
+          enteredValue,
+          enteredUnit: gravityUnit,
+          convertedGravity: sg,
+          refractometerCorrectionApplied:
+            gravityUnit === GRAVITY_UNITS.BRIX && applyRefractometerCorrection,
+          correctionFactor:
+            gravityUnit === GRAVITY_UNITS.BRIX && applyRefractometerCorrection
+              ? factor
+              : undefined,
+          ogUsed:
+            gravityUnit === GRAVITY_UNITS.BRIX &&
+            applyRefractometerCorrection &&
+            hasCorrectionOg
+              ? correctionOg!
+              : undefined
+        }
+      };
       return patch;
     }
 
@@ -1657,7 +1750,92 @@ function EditBrewEntryDialog({
           {entry.type === BREW_ENTRY_TYPE.GRAVITY ? (
             <div className="space-y-2">
               <Label>{t("brew.gravity", "Gravity")}</Label>
-              <Input inputMode="decimal" value={gravity} onChange={(event) => setGravity(event.target.value)} />
+              <div className="grid gap-3 sm:grid-cols-[1fr_7rem]">
+                <Input inputMode="decimal" value={gravity} onChange={(event) => setGravity(event.target.value)} />
+                <Select
+                  value={gravityUnit}
+                  onValueChange={(value) => {
+                    const nextUnit = value as GravityUnit;
+                    const currentValue = Number(gravity);
+                    if (Number.isFinite(currentValue) && nextUnit !== gravityUnit) {
+                      setGravity(
+                        nextUnit === GRAVITY_UNITS.BRIX
+                          ? toBrix(currentValue).toFixed(2)
+                          : toSG(currentValue).toFixed(3)
+                      );
+                    }
+                    setGravityUnit(nextUnit);
+                    if (nextUnit === GRAVITY_UNITS.SG) {
+                      setApplyRefractometerCorrection(false);
+                    }
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={GRAVITY_UNITS.SG}>{t("SG", "SG")}</SelectItem>
+                    <SelectItem value={GRAVITY_UNITS.BRIX}>{t("BRIX")}</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              {gravityUnit === GRAVITY_UNITS.BRIX ? (
+                <div className="space-y-3 rounded-md border border-border bg-background/40 p-3">
+                  {canApplyRefractometerCorrection ? (
+                    <div className="flex items-center justify-between gap-3">
+                      <Label htmlFor="edit-refractometer-correction" className="text-sm">
+                        {t(
+                          "brews.gravity.applyRefractometerCorrection",
+                          "Apply refractometer correction"
+                        )}
+                      </Label>
+                      <Switch
+                        id="edit-refractometer-correction"
+                        checked={applyRefractometerCorrection}
+                        onCheckedChange={setApplyRefractometerCorrection}
+                      />
+                    </div>
+                  ) : null}
+                  {applyRefractometerCorrection && canApplyRefractometerCorrection ? (
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-1">
+                        <Label>{t("brews.gravity.correctionFactor", "Correction factor")}</Label>
+                        <TooltipHelper
+                          body={t("tiptext.refractometerWarning")}
+                          link="https://www.brewersfriend.com/how-to-determine-your-refractometers-wort-correction-factor/"
+                          variant={correctionFactor !== "1" ? "warning" : "muted"}
+                        />
+                      </div>
+                      <Input
+                        inputMode="decimal"
+                        value={correctionFactor}
+                        onChange={(event) => setCorrectionFactor(event.target.value)}
+                      />
+                      <div className="text-xs text-muted-foreground">
+                        {t("brews.gravity.correctionOg", "OG: {{og}}", {
+                          og: formatSgDisplay(correctionOg, i18n.resolvedLanguage)
+                        })}
+                      </div>
+                    </div>
+                  ) : null}
+                  {gravityPreview != null ? (
+                    <div className="text-sm text-muted-foreground">
+                      {applyRefractometerCorrection && canApplyRefractometerCorrection
+                        ? t("brews.gravity.correctedSgPreview", "Corrected SG: {{sg}}", {
+                            sg: formatSgDisplay(gravityPreview, i18n.resolvedLanguage)
+                          })
+                        : t("brews.gravity.convertedSgPreview", "Converted SG: {{sg}}", {
+                            sg: formatSgDisplay(gravityPreview, i18n.resolvedLanguage)
+                          })}
+                    </div>
+                  ) : null}
+                  {gravityPreview != null ? (
+                    <div className="text-xs text-muted-foreground">
+                      {formatSgAsBrixDisplay(gravityPreview, t("BRIX"), i18n.resolvedLanguage)}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
           ) : null}
 

--- a/app/[locale]/account/hydrometer/brews/page.tsx
+++ b/app/[locale]/account/hydrometer/brews/page.tsx
@@ -41,7 +41,7 @@ import { X, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 import Tooltip from "@/components/Tooltips";
-import { normalizeNumberString } from "@/lib/utils/validateInput";
+import { formatSgDisplay } from "@/lib/utils/gravityFormatting";
 import Link from "next/link";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -240,12 +240,7 @@ function BrewRow({
   const { mutateAsync: updateEmailAlerts } = useUpdateEmailAlerts();
   const [checked, setChecked] = useState(brew.requested_email_alerts);
 
-  const gravity = normalizeNumberString(
-    brew.latest_gravity ?? 0,
-    3,
-    i18n.resolvedLanguage,
-    true
-  );
+  const gravity = formatSgDisplay(brew.latest_gravity, i18n.resolvedLanguage);
 
   return (
     <TableRow>
@@ -270,7 +265,7 @@ function BrewRow({
         {brew.end_date ? formatDate(brew.end_date) : t("ongoing", "Ongoing")}
       </TableCell>
 
-      <TableCell>{gravity !== "0.000" ? gravity : "—"}</TableCell>
+      <TableCell>{gravity}</TableCell>
 
       <TableCell>
         <div className="w-full flex items-center">

--- a/components/brews/AddBrewEntryDialog.tsx
+++ b/components/brews/AddBrewEntryDialog.tsx
@@ -29,16 +29,21 @@ import {
   InputGroupText
 } from "@/components/ui/input-group";
 import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
 import { DateTimePicker } from "@/components/ui/datetime-picker";
 
 import { useCreateBrewEntry } from "@/hooks/reactQuery/useCreateBrewEntry";
 import type { CreateBrewEntryInput } from "@/hooks/reactQuery/useAccountBrews";
-import { BREW_ENTRY_TYPE } from "@/lib/brewEnums";
+import { BREW_ENTRY_TYPE, GRAVITY_UNITS } from "@/lib/brewEnums";
 import type { TempUnits } from "@/lib/brewEnums";
 import { entryPayload } from "@/lib/utils/entryPayload";
 import type { GravityReadingRole } from "@/lib/utils/entryPayload";
 import { BREW_TRACKER_DIALOG_CONTENT_CLASS } from "@/components/brews/brewTrackerDialog";
 import { getUnitLabel } from "@/components/brews/stages/additionDialogShared";
+import type { GravityUnit } from "@/lib/brewEnums";
+import { refractometerCorrectedSg, toBrix, toSG } from "@/lib/utils/unitConverter";
+import { formatSgAsBrixDisplay, formatSgDisplay } from "@/lib/utils/gravityFormatting";
+import TooltipHelper from "@/components/Tooltips";
 
 export type EntryType =
   | typeof BREW_ENTRY_TYPE.NOTE
@@ -71,6 +76,9 @@ export default function AddBrewEntryDialog({
   gravityRole,
   gravityDefaultValue,
   gravitySource = "measured",
+  gravityUnitPreference = GRAVITY_UNITS.SG,
+  correctionOg,
+  onGravityUnitPreferenceChange,
   triggerLabel,
   open: openProp,
   onOpenChange: onOpenChangeProp,
@@ -83,6 +91,9 @@ export default function AddBrewEntryDialog({
   gravityRole?: GravityReadingRole;
   gravityDefaultValue?: number;
   gravitySource?: "measured" | "recipe";
+  gravityUnitPreference?: GravityUnit;
+  correctionOg?: number | null;
+  onGravityUnitPreferenceChange?: (unit: GravityUnit) => void | Promise<void>;
   triggerLabel?: string;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -115,22 +126,40 @@ export default function AddBrewEntryDialog({
   const [datetime, setDatetime] = React.useState<Date>(new Date());
 
   const [gravity, setGravity] = React.useState<string>("");
+  const [gravityUnit, setGravityUnit] = React.useState<GravityUnit>(gravityUnitPreference);
+  const [applyRefractometerCorrection, setApplyRefractometerCorrection] = React.useState(false);
+  const [correctionFactor, setCorrectionFactor] = React.useState("1");
   const [temperature, setTemperature] = React.useState<string>("");
   const [tempUnits, setTempUnits] = React.useState<TempUnits>("F" as TempUnits);
 
   const [ph, setPh] = React.useState<string>("");
+
+  const hasCorrectionOg =
+    typeof correctionOg === "number" &&
+    Number.isFinite(correctionOg) &&
+    correctionOg > 1;
+  const canApplyRefractometerCorrection =
+    gravityUnit === GRAVITY_UNITS.BRIX && hasCorrectionOg;
+
+  const formatDefaultGravity = React.useCallback(
+    (value?: number) => {
+      if (typeof value !== "number" || !Number.isFinite(value)) return "";
+      return gravityUnitPreference === GRAVITY_UNITS.BRIX
+        ? toBrix(value).toFixed(2)
+        : value.toFixed(3);
+    },
+    [gravityUnitPreference]
+  );
 
   function reset() {
     setType(initialType);
     setTitle("");
     setNote("");
     setDatetime(new Date());
-    setGravity(
-      typeof gravityDefaultValue === "number" &&
-        Number.isFinite(gravityDefaultValue)
-        ? gravityDefaultValue.toFixed(3)
-        : ""
-    );
+    setGravityUnit(gravityUnitPreference);
+    setGravity(formatDefaultGravity(gravityDefaultValue));
+    setApplyRefractometerCorrection(false);
+    setCorrectionFactor("1");
     setTemperature("");
     setTempUnits("F" as TempUnits);
     setPh("");
@@ -139,13 +168,44 @@ export default function AddBrewEntryDialog({
   React.useEffect(() => {
     if (!open) return;
     setType(initialType);
-    setGravity(
-      typeof gravityDefaultValue === "number" &&
-        Number.isFinite(gravityDefaultValue)
-        ? gravityDefaultValue.toFixed(3)
-        : ""
-    );
-  }, [gravityDefaultValue, initialType, open]);
+    setGravityUnit(gravityUnitPreference);
+    setGravity(formatDefaultGravity(gravityDefaultValue));
+    setApplyRefractometerCorrection(false);
+    setCorrectionFactor("1");
+  }, [formatDefaultGravity, gravityDefaultValue, gravityUnitPreference, initialType, open]);
+
+  React.useEffect(() => {
+    if (!canApplyRefractometerCorrection) {
+      setApplyRefractometerCorrection(false);
+    }
+  }, [canApplyRefractometerCorrection]);
+
+  const gravityPreview = React.useMemo(() => {
+    if (type !== BREW_ENTRY_TYPE.GRAVITY) return null;
+    const enteredValue = Number(gravity);
+    if (!Number.isFinite(enteredValue)) return null;
+    if (gravityUnit === GRAVITY_UNITS.SG) return enteredValue;
+
+    if (applyRefractometerCorrection && hasCorrectionOg) {
+      const factor = Number(correctionFactor);
+      if (!Number.isFinite(factor) || factor <= 0) return null;
+      return refractometerCorrectedSg(
+        toBrix(correctionOg!),
+        enteredValue,
+        factor
+      );
+    }
+
+    return toSG(enteredValue);
+  }, [
+    applyRefractometerCorrection,
+    correctionFactor,
+    correctionOg,
+    gravity,
+    gravityUnit,
+    hasCorrectionOg,
+    type
+  ]);
 
   function buildInput(): CreateBrewEntryInput {
     const trimmedTitle = title.trim();
@@ -169,12 +229,43 @@ export default function AddBrewEntryDialog({
     }
 
     if (type === BREW_ENTRY_TYPE.GRAVITY) {
-      const n = Number(gravity);
-      if (!Number.isFinite(n)) throw new Error("Invalid gravity");
-      return entryPayload.gravity(n, noteOrNull, {
+      const enteredValue = Number(gravity);
+      if (!Number.isFinite(enteredValue)) throw new Error("Invalid gravity");
+      const factor = Number(correctionFactor);
+      if (
+        gravityUnit === GRAVITY_UNITS.BRIX &&
+        applyRefractometerCorrection &&
+        (!Number.isFinite(factor) || factor <= 0)
+      ) {
+        throw new Error("Invalid correction factor");
+      }
+      const sg =
+        gravityUnit === GRAVITY_UNITS.SG
+          ? enteredValue
+          : applyRefractometerCorrection && hasCorrectionOg
+            ? refractometerCorrectedSg(toBrix(correctionOg!), enteredValue, factor)
+            : toSG(enteredValue);
+      return entryPayload.gravity(sg, noteOrNull, {
         readingRole: gravityRole ?? "GENERAL",
         source: gravitySource,
-        datetime: datetimeIso
+        datetime: datetimeIso,
+        display: {
+          enteredValue,
+          enteredUnit: gravityUnit,
+          convertedGravity: sg,
+          refractometerCorrectionApplied:
+            gravityUnit === GRAVITY_UNITS.BRIX && applyRefractometerCorrection,
+          correctionFactor:
+            gravityUnit === GRAVITY_UNITS.BRIX && applyRefractometerCorrection
+              ? factor
+              : undefined,
+          ogUsed:
+            gravityUnit === GRAVITY_UNITS.BRIX &&
+            applyRefractometerCorrection &&
+            hasCorrectionOg
+              ? correctionOg!
+              : undefined
+        }
       });
     }
 
@@ -299,9 +390,93 @@ export default function AddBrewEntryDialog({
                   align="inline-end"
                   className="mr-1 text-xs sm:text-sm"
                 >
-                  <InputGroupText>SG</InputGroupText>
+                  <Separator orientation="vertical" className="h-12" />
+                  <Select
+                    value={gravityUnit}
+                    onValueChange={(value) => {
+                      const nextUnit = value as GravityUnit;
+                      const currentValue = Number(gravity);
+                      if (Number.isFinite(currentValue) && nextUnit !== gravityUnit) {
+                        setGravity(
+                          nextUnit === GRAVITY_UNITS.BRIX
+                            ? toBrix(currentValue).toFixed(2)
+                            : toSG(currentValue).toFixed(3)
+                        );
+                      }
+                      setGravityUnit(nextUnit);
+                      void onGravityUnitPreferenceChange?.(nextUnit);
+                    }}
+                  >
+                    <SelectTrigger className="mr-2 w-24 border-none p-2">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={GRAVITY_UNITS.SG}>{t("SG", "SG")}</SelectItem>
+                      <SelectItem value={GRAVITY_UNITS.BRIX}>{t("BRIX")}</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </InputGroupAddon>
               </InputGroup>
+              {gravityUnit === GRAVITY_UNITS.BRIX ? (
+                <div className="space-y-3 rounded-md border border-border bg-background/40 p-3">
+                  {canApplyRefractometerCorrection ? (
+                    <div className="flex items-center justify-between gap-3">
+                      <Label htmlFor="refractometer-correction" className="text-sm">
+                        {t(
+                          "brews.gravity.applyRefractometerCorrection",
+                          "Apply refractometer correction"
+                        )}
+                      </Label>
+                      <Switch
+                        id="refractometer-correction"
+                        checked={applyRefractometerCorrection}
+                        onCheckedChange={setApplyRefractometerCorrection}
+                      />
+                    </div>
+                  ) : null}
+
+                  {applyRefractometerCorrection && canApplyRefractometerCorrection ? (
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-1">
+                        <Label>{t("brews.gravity.correctionFactor", "Correction factor")}</Label>
+                        <TooltipHelper
+                          body={t("tiptext.refractometerWarning")}
+                          link="https://www.brewersfriend.com/how-to-determine-your-refractometers-wort-correction-factor/"
+                          variant={correctionFactor !== "1" ? "warning" : "muted"}
+                        />
+                      </div>
+                      <Input
+                        inputMode="decimal"
+                        value={correctionFactor}
+                        onChange={(event) => setCorrectionFactor(event.target.value)}
+                      />
+                      <div className="text-xs text-muted-foreground">
+                        {t("brews.gravity.correctionOg", "OG: {{og}}", {
+                          og: formatSgDisplay(correctionOg, undefined)
+                        })}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {gravityPreview != null ? (
+                    <div className="text-sm text-muted-foreground">
+                      {applyRefractometerCorrection && canApplyRefractometerCorrection
+                        ? t("brews.gravity.correctedSgPreview", "Corrected SG: {{sg}}", {
+                            sg: formatSgDisplay(gravityPreview, undefined)
+                          })
+                        : t("brews.gravity.convertedSgPreview", "Converted SG: {{sg}}", {
+                            sg: formatSgDisplay(gravityPreview, undefined)
+                          })}
+                    </div>
+                  ) : null}
+
+                  {gravityPreview != null ? (
+                    <div className="text-xs text-muted-foreground">
+                      {formatSgAsBrixDisplay(gravityPreview, t("BRIX"), undefined)}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
           )}
 

--- a/components/brews/BrewStagePath.tsx
+++ b/components/brews/BrewStagePath.tsx
@@ -1,4 +1,4 @@
-import { BREW_ENTRY_TYPE, type BrewStage } from "@/lib/brewEnums";
+import { BREW_ENTRY_TYPE, GRAVITY_UNITS, type BrewStage, type GravityUnit } from "@/lib/brewEnums";
 import { Path, PathActivePanel, PathContent, PathHeader, PathItem, PathList, PathTitle } from "@/components/ui/path";
 import { Button } from "@/components/ui/button";
 import { BREW_TRACKER_DIALOG_CONTENT_CLASS, BREW_TRACKER_DIALOG_FOOTER_CLASS } from "@/components/brews/brewTrackerDialog";
@@ -28,6 +28,7 @@ type BrewStagePathProps = {
   onMoveToStage: (to: BrewStage, datetime?: string) => Promise<void>;
   entries: BrewEntry[];
   current_volume_liters: number | null;
+  gravity_unit_preference?: GravityUnit;
   recipe: BrewRecipeStageData;
   patchBrewMetadata: BrewStageHelpers["patchBrewMetadata"];
   linkRecipeHref?: string;
@@ -56,6 +57,7 @@ export function BrewStagePath({
   onMoveToStage,
   entries,
   current_volume_liters,
+  gravity_unit_preference = GRAVITY_UNITS.SG,
   recipe,
   patchBrewMetadata,
   linkRecipeHref,
@@ -389,12 +391,14 @@ export function BrewStagePath({
           }
           suggestedOgSource={suggestedOgSource}
           estimatedFg={estimatedFg}
+          gravityUnitPreference={gravity_unit_preference}
           onSave={async (input) => {
             await addEntry(
               entryPayload.gravity(input.chosenOg, input.note ?? null, {
                 readingRole: "OG",
                 source: "measured",
-                datetime: input.datetime
+                datetime: input.datetime,
+                display: input.ogDisplay
               })
             );
             await addEntry(

--- a/components/brews/LogOriginalGravityDialog.tsx
+++ b/components/brews/LogOriginalGravityDialog.tsx
@@ -12,11 +12,17 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { DateTimePicker } from "@/components/ui/datetime-picker";
+import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/input-group";
+import { Separator } from "@/components/ui/separator";
 import { BREW_TRACKER_DIALOG_CONTENT_CLASS, BREW_TRACKER_DIALOG_FOOTER_CLASS } from "@/components/brews/brewTrackerDialog";
+import { GRAVITY_UNITS, type GravityUnit } from "@/lib/brewEnums";
+import { toBrix, toSG } from "@/lib/utils/unitConverter";
+import { formatBrixNumber, formatSgDisplay } from "@/lib/utils/gravityFormatting";
+import type { GravityEntryDisplayData } from "@/lib/utils/entryPayload";
 
 export type LogOriginalGravityInput = {
   chosenOg: number;
@@ -25,12 +31,67 @@ export type LogOriginalGravityInput = {
   estimatedFg: number;
   fermentableSg: number;
   warningAcknowledged: boolean;
+  ogDisplay?: GravityEntryDisplayData;
   note?: string;
   datetime?: string;
 };
 
 function formatGravity(value?: number | null) {
-  return typeof value === "number" && Number.isFinite(value) ? value.toFixed(3) : "";
+  return formatSgDisplay(value, undefined, "");
+}
+
+function formatGravityForUnit(value: number | null, unit: GravityUnit) {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "";
+  return unit === GRAVITY_UNITS.BRIX
+    ? formatBrixNumber(toBrix(value), undefined, "")
+    : formatGravity(value);
+}
+
+function gravityInputToSg(value: string, unit: GravityUnit) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return NaN;
+  return unit === GRAVITY_UNITS.BRIX ? toSG(parsed) : parsed;
+}
+
+function GravityInputWithUnits({
+  value,
+  unit,
+  onValueChange,
+  onUnitChange
+}: {
+  value: string;
+  unit: GravityUnit;
+  onValueChange: (value: string) => void;
+  onUnitChange: (unit: GravityUnit) => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <InputGroup className="h-12">
+      <InputGroupInput
+        inputMode="decimal"
+        value={value}
+        onChange={(event) => onValueChange(event.target.value)}
+        onFocus={(event) => event.target.select()}
+        className="h-full text-lg"
+      />
+      <InputGroupAddon
+        align="inline-end"
+        className="mr-1 whitespace-nowrap px-1 text-xs sm:text-sm"
+      >
+        <Separator orientation="vertical" className="h-12" />
+        <Select value={unit} onValueChange={(next) => onUnitChange(next as GravityUnit)}>
+          <SelectTrigger className="mr-2 w-24 border-none p-2">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={GRAVITY_UNITS.SG}>{t("SG", "SG")}</SelectItem>
+            <SelectItem value={GRAVITY_UNITS.BRIX}>{t("BRIX")}</SelectItem>
+          </SelectContent>
+        </Select>
+      </InputGroupAddon>
+    </InputGroup>
+  );
 }
 
 export function LogOriginalGravityDialog({
@@ -39,6 +100,7 @@ export function LogOriginalGravityDialog({
   suggestedOg,
   suggestedOgSource,
   estimatedFg,
+  gravityUnitPreference = GRAVITY_UNITS.SG,
   onSave
 }: {
   open: boolean;
@@ -46,25 +108,30 @@ export function LogOriginalGravityDialog({
   suggestedOg: number | null;
   suggestedOgSource: "actualized_recipe" | "recipe" | "measured";
   estimatedFg: number | null;
+  gravityUnitPreference?: GravityUnit;
   onSave: (input: LogOriginalGravityInput) => Promise<void>;
 }) {
   const { t } = useTranslation();
   const [og, setOg] = React.useState("");
+  const [ogUnit, setOgUnit] = React.useState<GravityUnit>(gravityUnitPreference);
   const [fg, setFg] = React.useState("");
+  const [fgUnit, setFgUnit] = React.useState<GravityUnit>(gravityUnitPreference);
   const [note, setNote] = React.useState("");
   const [datetime, setDatetime] = React.useState<Date>(new Date());
   const [isSaving, setIsSaving] = React.useState(false);
 
   React.useEffect(() => {
     if (!open) return;
-    setOg(formatGravity(suggestedOg));
-    setFg(formatGravity(estimatedFg));
+    setOgUnit(gravityUnitPreference);
+    setFgUnit(gravityUnitPreference);
+    setOg(formatGravityForUnit(suggestedOg, gravityUnitPreference));
+    setFg(formatGravityForUnit(estimatedFg, gravityUnitPreference));
     setNote("");
     setDatetime(new Date());
-  }, [estimatedFg, open, suggestedOg]);
+  }, [estimatedFg, gravityUnitPreference, open, suggestedOg]);
 
-  const parsedOg = Number(og);
-  const parsedFg = Number(fg);
+  const parsedOg = gravityInputToSg(og, ogUnit);
+  const parsedFg = gravityInputToSg(fg, fgUnit);
   const hasSuggested = typeof suggestedOg === "number" && Number.isFinite(suggestedOg) && suggestedOg > 1;
   const differsFromSuggested = hasSuggested && Number.isFinite(parsedOg) && Math.abs(parsedOg - suggestedOg) > 0.0005;
   const fermentableSg = Number.isFinite(parsedOg) && Number.isFinite(parsedFg) ? 1 + (parsedOg - parsedFg) : null;
@@ -95,6 +162,12 @@ export function LogOriginalGravityDialog({
         estimatedFg: parsedFg,
         fermentableSg,
         warningAcknowledged: differsFromSuggested,
+        ogDisplay: {
+          enteredValue: Number(og),
+          enteredUnit: ogUnit,
+          convertedGravity: parsedOg,
+          refractometerCorrectionApplied: false
+        },
         note: note.trim() || undefined,
         datetime: datetime.toISOString()
       });
@@ -124,20 +197,32 @@ export function LogOriginalGravityDialog({
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
               <Label>{t("brews.primary.og", "Original gravity")}</Label>
-              <Input
-                inputMode="decimal"
+              <GravityInputWithUnits
                 value={og}
-                onChange={(event) => setOg(event.target.value)}
-                onFocus={(event) => event.target.select()}
+                unit={ogUnit}
+                onValueChange={setOg}
+                onUnitChange={(nextUnit) => {
+                  const currentSg = gravityInputToSg(og, ogUnit);
+                  setOgUnit(nextUnit);
+                  if (Number.isFinite(currentSg)) {
+                    setOg(formatGravityForUnit(currentSg, nextUnit));
+                  }
+                }}
               />
             </div>
             <div className="space-y-2">
               <Label>{t("brews.primary.estimatedFg", "Estimated FG")}</Label>
-              <Input
-                inputMode="decimal"
+              <GravityInputWithUnits
                 value={fg}
-                onChange={(event) => setFg(event.target.value)}
-                onFocus={(event) => event.target.select()}
+                unit={fgUnit}
+                onValueChange={setFg}
+                onUnitChange={(nextUnit) => {
+                  const currentSg = gravityInputToSg(fg, fgUnit);
+                  setFgUnit(nextUnit);
+                  if (Number.isFinite(currentSg)) {
+                    setFg(formatGravityForUnit(currentSg, nextUnit));
+                  }
+                }}
               />
             </div>
           </div>

--- a/components/brews/stages/StagePanelShared.tsx
+++ b/components/brews/stages/StagePanelShared.tsx
@@ -6,6 +6,7 @@ import { DateTimePicker } from "@/components/ui/datetime-picker";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
+import { formatSgDisplay } from "@/lib/utils/gravityFormatting";
 import { L_TO_VOLUME } from "@/lib/utils/recipeDataCalculations";
 import { normalizeNumberString } from "@/lib/utils/validateInput";
 import type { AdditiveLine, IngredientLine, NoteLine, RecipeUnitDefaults } from "@/types/recipeData";
@@ -19,7 +20,7 @@ export function formatNumber(value?: number | null, decimals = 2, locale?: strin
 }
 
 export function formatGravity(value?: number | null, locale?: string, fallback = "—") {
-  return formatNumber(value, 3, locale, fallback);
+  return formatSgDisplay(value, locale, fallback);
 }
 
 export function formatVolume(

--- a/components/ispindel/HydrometerData.tsx
+++ b/components/ispindel/HydrometerData.tsx
@@ -36,6 +36,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useTranslation } from "react-i18next";
 import { toBrix } from "@/lib/utils/unitConverter";
 import { toCelsius, toFahrenheit } from "@/lib/utils/temperature";
+import { formatBrixDisplay, formatSgDisplay } from "@/lib/utils/gravityFormatting";
 
 import {
   Dialog,
@@ -257,6 +258,45 @@ export function HydrometerData({
     return ticks;
   }, [hasData, data]);
 
+  const formatGravityAxis = useCallback(
+    (val: number) =>
+      gravityUnits === "Brix"
+        ? formatBrixDisplay(Number(val), t("BRIX"), lang)
+        : formatSgDisplay(Number(val), lang),
+    [gravityUnits, lang, t]
+  );
+
+  const tooltipFormatter = useCallback(
+    (value: any, name: any, item: any) => {
+      const key = String(item?.dataKey ?? name ?? "");
+      const label = chartConfig[key as keyof typeof chartConfig]?.label ?? name;
+      let displayValue = value;
+      if (key === "gravity" && typeof value === "number") {
+        displayValue =
+          gravityUnits === "Brix"
+            ? formatBrixDisplay(value, t("BRIX"), lang)
+            : formatSgDisplay(value, lang);
+      }
+
+      return (
+        <>
+          <div className="flex items-center gap-2">
+            <div
+              className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+              style={{ backgroundColor: item?.color }}
+            />
+            <span className="text-muted-foreground">{label}</span>
+          </div>
+          <span className="mx-2 font-mono font-medium tabular-nums text-foreground">
+            {displayValue}
+            {key === "gravity" ? "" : item?.unit}
+          </span>
+        </>
+      );
+    },
+    [chartConfig, gravityUnits, lang, t]
+  );
+
   // ---------- handlers ----------
   const handleDivDownload = useCallback(async () => {
     if (!hasData) return;
@@ -382,11 +422,7 @@ export function HydrometerData({
               ticks={generateTicks(dataMin, dataMax, 0.005)}
               allowDecimals
               tickMargin={8}
-              tickFormatter={(val) =>
-                gravityUnits === "Brix"
-                  ? Number(val).toFixed(2)
-                  : Number(val).toFixed(3)
-              }
+              tickFormatter={formatGravityAxis}
             />
           ) : null}
 
@@ -446,6 +482,7 @@ export function HydrometerData({
             cursor={false}
             content={
               <ChartTooltipContent
+                formatter={tooltipFormatter}
                 labelFormatter={(val) => {
                   const date = new Date(val);
                   return date.toLocaleString(lang, {
@@ -664,11 +701,7 @@ export function HydrometerData({
                   tickMargin={8}
                   dataKey={"gravity"}
                   yAxisId={"gravity"}
-                  tickFormatter={(val) =>
-                    gravityUnits === "Brix"
-                      ? Number(val).toFixed(2)
-                      : Number(val).toFixed(3)
-                  }
+                  tickFormatter={formatGravityAxis}
                   padding={yPadding}
                   hide={!checkObj.gravity}
                 />
@@ -732,6 +765,7 @@ export function HydrometerData({
                 cursor={false}
                 content={
                   <ChartTooltipContent
+                    formatter={tooltipFormatter}
                     labelFormatter={(val) => {
                       const date = new Date(val);
                       return date.toLocaleString(lang, {

--- a/components/recipes/OwnerRecipe.tsx
+++ b/components/recipes/OwnerRecipe.tsx
@@ -34,6 +34,7 @@ import { useBanner } from "../ui/banner";
 import { useSaveRecipe } from "@/hooks/useSaveRecipe";
 import { useAccountBrews } from "@/hooks/reactQuery/useAccountBrews";
 import { Skeleton } from "../ui/skeleton";
+import { formatSgDisplay } from "@/lib/utils/gravityFormatting";
 
 const buildCardConfig = ({
   recipeId,
@@ -355,7 +356,7 @@ function ConnectedBrews({ recipeId }: { recipeId: number }) {
                     <dt className="text-muted-foreground">
                       {t("brews.secondary.latestGravity", "Latest gravity")}
                     </dt>
-                    <dd>{brew.latest_gravity ?? "—"}</dd>
+                    <dd>{formatSgDisplay(brew.latest_gravity, i18n.resolvedLanguage)}</dd>
                   </div>
                 </dl>
               </div>

--- a/hooks/reactQuery/useAccountBrews.ts
+++ b/hooks/reactQuery/useAccountBrews.ts
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useFetchWithAuth } from "@/hooks/auth/useFetchWithAuth";
 import type { BrewEntryType, BrewStage } from "@/lib/brewEnums";
 import { BREW_ENTRY_TYPE } from "@/lib/brewEnums";
-import type { TempUnits } from "@/lib/brewEnums";
+import type { GravityUnit, TempUnits } from "@/lib/brewEnums";
 import { qk } from "@/lib/db/queryKeys";
 import type {
   BrewAdditionData,
@@ -24,6 +24,7 @@ export type AccountBrewListItem = {
   batch_number: number | null;
   current_volume_liters: number | null;
   requested_email_alerts: boolean;
+  gravity_unit_preference: GravityUnit;
 
   recipe_id: number | null;
   recipe_name: string | null;
@@ -67,6 +68,7 @@ export type AccountBrew = {
   batch_number: number | null;
   current_volume_liters: number | null;
   requested_email_alerts: boolean;
+  gravity_unit_preference: GravityUnit;
 
   latest_gravity: number | null;
 
@@ -230,6 +232,7 @@ export type PatchAccountBrewMetadataInput = {
   stage?: BrewStage;
   current_volume_liters?: number | null;
   requested_email_alerts?: boolean;
+  gravity_unit_preference?: GravityUnit;
   end_date?: string | null; // ISO or null
   stage_change_datetime?: string;
 };

--- a/hooks/useRefrac.ts
+++ b/hooks/useRefrac.ts
@@ -1,4 +1,4 @@
-import { toBrix, toSG } from "@/lib/utils/unitConverter";
+import { refractometerCorrectedSg, toBrix, toSG } from "@/lib/utils/unitConverter";
 import { isValidNumber, parseNumber } from "@/lib/utils/validateInput";
 import { useState } from "react";
 
@@ -12,7 +12,7 @@ const useRefrac = () => {
   const ogBrix = ogUnits === "Brix" ? parseNumber(og) : toBrix(parseNumber(og));
   const fgBrix = fgUnits === "Brix" ? parseNumber(fg) : toBrix(parseNumber(fg));
 
-  const correctedFg = refracCalc(ogBrix, fgBrix, parseNumber(correctionFactor));
+  const correctedFg = refractometerCorrectedSg(ogBrix, fgBrix, parseNumber(correctionFactor));
 
   const changeOgUnits = () => {
     if (ogUnits === "SG") {
@@ -75,7 +75,3 @@ const useRefrac = () => {
 };
 
 export default useRefrac;
-
-function refracCalc(ogBr: number, fgBr: number, corFac: number) {
-  return -0.002349 * (ogBr / corFac) + 0.006276 * (fgBr / corFac) + 1;
-}

--- a/lib/brewEnums.ts
+++ b/lib/brewEnums.ts
@@ -34,3 +34,10 @@ export const TEMP_UNITS = {
 } as const;
 
 export type TempUnits = (typeof TEMP_UNITS)[keyof typeof TEMP_UNITS];
+
+export const GRAVITY_UNITS = {
+  SG: "SG",
+  BRIX: "BRIX"
+} as const;
+
+export type GravityUnit = (typeof GRAVITY_UNITS)[keyof typeof GRAVITY_UNITS];

--- a/lib/db/brews.ts
+++ b/lib/db/brews.ts
@@ -3,7 +3,8 @@ import {
   Prisma,
   brew_stage,
   brew_entry_type,
-  temp_units
+  temp_units,
+  gravity_unit
 } from "@prisma/client";
 import { calcABV } from "@/lib/utils/unitConverter";
 import { buildBrewRecipeStageData } from "@/lib/utils/buildBrewRecipeStageData";
@@ -18,6 +19,7 @@ export type BrewListItem = {
   batch_number: number | null;
   current_volume_liters: number | null;
   requested_email_alerts: boolean;
+  gravity_unit_preference: gravity_unit;
 
   recipe_id: number | null;
   recipe_name: string | null;
@@ -56,6 +58,7 @@ export type BrewForApp = {
   batch_number: number | null;
   current_volume_liters: number | null;
   requested_email_alerts: boolean;
+  gravity_unit_preference: gravity_unit;
 
   latest_gravity: number | null;
 
@@ -81,6 +84,7 @@ export type PatchBrewMetadataInput = {
   stage?: brew_stage;
   current_volume_liters?: number | null;
   requested_email_alerts?: boolean;
+  gravity_unit_preference?: gravity_unit;
   end_date?: string | Date | null; // allow ISO string from client
   stage_change_datetime?: string | Date;
 };
@@ -130,6 +134,7 @@ export async function getBrewsForApp(userId: number): Promise<BrewListItem[]> {
       batch_number: true,
       current_volume_liters: true,
       requested_email_alerts: true,
+      gravity_unit_preference: true,
       latest_gravity: true,
       recipe_id: true,
       recipes: { select: { name: true } },
@@ -147,6 +152,7 @@ export async function getBrewsForApp(userId: number): Promise<BrewListItem[]> {
     batch_number: b.batch_number,
     current_volume_liters: b.current_volume_liters,
     requested_email_alerts: b.requested_email_alerts ?? false,
+    gravity_unit_preference: b.gravity_unit_preference ?? gravity_unit.SG,
 
     recipe_id: b.recipe_id,
     recipe_name: b.recipes?.name ?? null,
@@ -265,6 +271,9 @@ export async function createBrewForApp(userId: number, input: CreateBrewInput) {
         stage: true,
         batch_number: true,
         current_volume_liters: true,
+        requested_email_alerts: true,
+        gravity_unit_preference: true,
+        latest_gravity: true,
         recipe_id: true
       }
     });
@@ -287,6 +296,7 @@ export async function getBrewForApp(
       batch_number: true,
       current_volume_liters: true,
       requested_email_alerts: true,
+      gravity_unit_preference: true,
       latest_gravity: true,
 
       recipe_id: true,
@@ -349,6 +359,7 @@ export async function getBrewForApp(
     batch_number: brew.batch_number,
     current_volume_liters: brew.current_volume_liters,
     requested_email_alerts: brew.requested_email_alerts ?? false,
+    gravity_unit_preference: brew.gravity_unit_preference ?? gravity_unit.SG,
 
     latest_gravity: brew.latest_gravity,
 
@@ -489,6 +500,16 @@ export async function patchBrewMetadata(
       data.requested_email_alerts = Boolean(input.requested_email_alerts);
     }
 
+    if ("gravity_unit_preference" in input) {
+      if (
+        input.gravity_unit_preference !== gravity_unit.SG &&
+        input.gravity_unit_preference !== gravity_unit.BRIX
+      ) {
+        throw new Error("Invalid gravity_unit_preference");
+      }
+      data.gravity_unit_preference = input.gravity_unit_preference;
+    }
+
     // end_date (null to reopen)
     if ("end_date" in input) {
       const v = input.end_date;
@@ -596,6 +617,7 @@ export async function patchBrewMetadata(
         batch_number: true,
         current_volume_liters: true,
         requested_email_alerts: true,
+        gravity_unit_preference: true,
         latest_gravity: true,
         recipe_id: true,
         recipes: { select: { name: true } }

--- a/lib/utils/entryPayload.ts
+++ b/lib/utils/entryPayload.ts
@@ -14,6 +14,16 @@ export type BrewAdditionSource =
   | "manual";
 export type GravityReadingRole = "OG" | "FG" | "GENERAL";
 export type GravityReadingSource = "measured" | "recipe" | "nutrient_basis" | "abv_estimate";
+export type GravityEntryUnit = "SG" | "BRIX";
+
+export type GravityEntryDisplayData = {
+  enteredValue?: number;
+  enteredUnit?: GravityEntryUnit;
+  convertedGravity?: number;
+  refractometerCorrectionApplied?: boolean;
+  correctionFactor?: number;
+  ogUsed?: number;
+};
 
 export type BrewAbvEstimateData = {
   abv: number;
@@ -43,6 +53,7 @@ export type GravityPayloadOptions = {
   hidden?: boolean;
   nutrientBasis?: BrewNutrientBasisData;
   abvEstimate?: BrewAbvEstimateData;
+  display?: GravityEntryDisplayData;
 };
 
 export type BrewAdditionData = {
@@ -114,7 +125,8 @@ export const entryPayload = {
         recipeValue: options.recipeValue,
         hidden: options.hidden,
         nutrientBasis: options.nutrientBasis,
-        abvEstimate: options.abvEstimate
+        abvEstimate: options.abvEstimate,
+        display: options.display
       },
       note
     };

--- a/lib/utils/gravityFormatting.ts
+++ b/lib/utils/gravityFormatting.ts
@@ -1,0 +1,32 @@
+import { toBrix } from "@/lib/utils/unitConverter";
+import { normalizeNumberString } from "@/lib/utils/validateInput";
+
+export function formatSgDisplay(value?: number | null, locale?: string, fallback = "—") {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return normalizeNumberString(value, 3, locale, true);
+}
+
+export function formatBrixNumber(value?: number | null, locale?: string, fallback = "—") {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return normalizeNumberString(value, 2, locale, true);
+}
+
+export function formatBrixDisplay(
+  value: number | null | undefined,
+  brixLabel: string,
+  locale?: string,
+  fallback = "—"
+) {
+  const formatted = formatBrixNumber(value, locale, fallback);
+  return formatted === fallback ? fallback : `${formatted} ${brixLabel}`;
+}
+
+export function formatSgAsBrixDisplay(
+  sg: number | null | undefined,
+  brixLabel: string,
+  locale?: string,
+  fallback = "—"
+) {
+  if (typeof sg !== "number" || !Number.isFinite(sg)) return fallback;
+  return formatBrixDisplay(toBrix(sg), brixLabel, locale, fallback);
+}

--- a/lib/utils/unitConverter.test.ts
+++ b/lib/utils/unitConverter.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  refractometerCorrectedSg,
+  toBrix,
+  toSG
+} from "@/lib/utils/unitConverter";
+import {
+  formatBrixDisplay,
+  formatSgDisplay
+} from "@/lib/utils/gravityFormatting";
+
+test("refractometerCorrectedSg matches existing correction formula", () => {
+  const ogBrix = toBrix(1.1);
+  const fgBrix = 8.5;
+  const expected = -0.002349 * ogBrix + 0.006276 * fgBrix + 1;
+
+  assert.equal(refractometerCorrectedSg(ogBrix, fgBrix, 1), expected);
+});
+
+test("gravity display formatters use fixed SG and Brix precision", () => {
+  assert.equal(formatSgDisplay(1.04, "en"), "1.040");
+  assert.equal(formatBrixDisplay(10, "Brix", "en"), "10.00 Brix");
+});
+
+test("toSG keeps Brix conversion usable for pre-fermentation readings", () => {
+  assert.equal(Number(toSG(10).toFixed(3)), 1.040);
+});

--- a/lib/utils/unitConverter.ts
+++ b/lib/utils/unitConverter.ts
@@ -21,6 +21,18 @@ export const toSG = (gravityReading: number) => {
   );
 };
 
+export function refractometerCorrectedSg(
+  originalGravityBrix: number,
+  finalGravityBrix: number,
+  correctionFactor = 1
+) {
+  return (
+    -0.002349 * (originalGravityBrix / correctionFactor) +
+    0.006276 * (finalGravityBrix / correctionFactor) +
+    1
+  );
+}
+
 export function calcSb(SG: number) {
   const afterDecimal = SG - 1;
   return 1 + Math.round((afterDecimal * 2000) / 3) / 1000;

--- a/locales/de/default.json
+++ b/locales/de/default.json
@@ -384,6 +384,16 @@
       "loadDetail": "Beim Laden dieses Brauvorgangs ist ein Fehler aufgetreten.",
       "loadList": "Beim Laden der Biere ist ein Fehler aufgetreten."
     },
+    "gravity": {
+      "applyRefractometerCorrection": "Refraktometerkorrektur anwenden",
+      "convertedSgPreview": "Umgewandelte SG: {{sg}}",
+      "corrected": "korrigiert",
+      "correctedSgPreview": "Korrigierte SG: {{sg}}",
+      "correctionFactor": "Korrekturfaktor",
+      "correctionOg": "Korrektur OG: {{og}}",
+      "enteredBrix": "{{brix}}",
+      "unitPreference": "Schwerkrafteinheit-Präferenz"
+    },
     "history": {
       "filters": {
         "additions": "Zusätze",

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -384,6 +384,16 @@
       "loadDetail": "Something went wrong loading this brew.",
       "loadList": "Something went wrong loading brews."
     },
+    "gravity": {
+      "applyRefractometerCorrection": "Apply refractometer correction",
+      "convertedSgPreview": "Converted SG: {{sg}}",
+      "corrected": "corrected",
+      "correctedSgPreview": "Corrected SG: {{sg}}",
+      "correctionFactor": "Correction factor",
+      "correctionOg": "OG: {{og}}",
+      "enteredBrix": "{{brix}}",
+      "unitPreference": "Gravity unit preference"
+    },
     "history": {
       "filters": {
         "additions": "Additions",

--- a/prisma/migrations/20260606000000_add_brew_gravity_unit_preference/migration.sql
+++ b/prisma/migrations/20260606000000_add_brew_gravity_unit_preference/migration.sql
@@ -1,0 +1,4 @@
+CREATE TYPE "gravity_unit" AS ENUM ('SG', 'BRIX');
+
+ALTER TABLE "brews"
+ADD COLUMN "gravity_unit_preference" "gravity_unit" NOT NULL DEFAULT 'SG';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,34 +4,35 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
   directUrl = env("DATABASE_DIRECT_URL")
 }
 
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model brews {
-  id                     String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  start_date             DateTime   @default(now()) @db.Timestamptz(6)
-  end_date               DateTime?  @db.Timestamptz(6)
+  id                     String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  start_date             DateTime  @default(now()) @db.Timestamptz(6)
+  end_date               DateTime? @db.Timestamptz(6)
   user_id                Int?
-  latest_gravity         Float?     @db.Real
+  latest_gravity         Float?    @db.Real
   recipe_id              Int?
   name                   String?
-  requested_email_alerts Boolean?   @default(false)
-  sb_alert_sent          Boolean?   @default(false)
-  fg_alert_sent          Boolean?   @default(false)
+  requested_email_alerts Boolean?  @default(false)
+  sb_alert_sent          Boolean?  @default(false)
+  fg_alert_sent          Boolean?  @default(false)
 
   // brew-tracking additions
-  stage                 brew_stage @default(PLANNED)
-  batch_number          Int?
-  current_volume_liters Float?     @db.Real
-  recipe_snapshot       Json?      // keep as Json (no @db.JsonB) to avoid churn vs pulled schema
+  stage                   brew_stage   @default(PLANNED)
+  batch_number            Int?
+  current_volume_liters   Float?       @db.Real
+  recipe_snapshot         Json? // keep as Json (no @db.JsonB) to avoid churn vs pulled schema
+  gravity_unit_preference gravity_unit @default(SG)
 
   // relations
   entries brew_entries[]
-  recipes recipes? @relation(fields: [recipe_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
-  users   users?   @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  recipes recipes?       @relation(fields: [recipe_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
+  users   users?         @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
   devices devices[]
   logs    logs[]
 
@@ -47,11 +48,11 @@ model brew_entries {
 
   type  brew_entry_type
   title String?
-  note  String? @db.Text
+  note  String?         @db.Text
 
   // optional typed fields
-  gravity     Float?     @db.Real
-  temperature Float?     @db.Real
+  gravity     Float?      @db.Real
+  temperature Float?      @db.Real
   temp_units  temp_units?
 
   // flexible payload
@@ -90,17 +91,17 @@ model ingredients {
 
 /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
 model logs {
-  id                 String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  datetime           DateTime  @default(now()) @db.Timestamptz(6)
-  angle              Float     @db.Real
-  temperature        Float     @db.Real
+  id                 String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  datetime           DateTime   @default(now()) @db.Timestamptz(6)
+  angle              Float      @db.Real
+  temperature        Float      @db.Real
   temp_units         temp_units
-  battery            Float     @db.Real
-  gravity            Float     @db.Real
+  battery            Float      @db.Real
+  gravity            Float      @db.Real
   interval           Int
-  calculated_gravity Float?    @db.Real
-  device_id          String?   @db.Uuid
-  brew_id            String?   @db.Uuid
+  calculated_gravity Float?     @db.Real
+  device_id          String?    @db.Uuid
+  brew_id            String?    @db.Uuid
 
   // leaving logs alone if a brew is deleted:
   brews   brews?   @relation(fields: [brew_id], references: [id], onDelete: NoAction, onUpdate: NoAction)
@@ -123,8 +124,8 @@ model recipes {
   secondaryNotes  String[]
 
   // NEW
-  dataV2   Json?
-  version  Int   @default(1)
+  dataV2  Json?
+  version Int   @default(1)
 
   private               Boolean   @default(false)
   lastActivityEmailAt   DateTime? @db.Timestamptz(6)
@@ -132,7 +133,7 @@ model recipes {
 
   brews          brews[]
   devices        devices[]
-  users          users? @relation(fields: [user_id], references: [id])
+  users          users?                  @relation(fields: [user_id], references: [id])
   comments       comments[]
   ratings        recipe_ratings[]
   daily_activity recipe_daily_activity[]
@@ -239,8 +240,8 @@ model comments {
 
   comment String @db.Text
 
-  created_at DateTime @default(now()) @db.Timestamptz(6)
-  updated_at DateTime @updatedAt
+  created_at DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at DateTime  @updatedAt
   deleted_at DateTime?
 
   recipe recipes @relation(fields: [recipe_id], references: [id], onDelete: Cascade, onUpdate: NoAction)
@@ -277,7 +278,7 @@ model recipe_daily_activity {
 
   summary_date DateTime @db.Date
   changes      Json?
-  emailed      Boolean @default(false)
+  emailed      Boolean  @default(false)
   created_at   DateTime @default(now()) @db.Timestamptz(6)
 
   recipe recipes @relation(fields: [recipe_id], references: [id], onDelete: Cascade)
@@ -291,6 +292,11 @@ enum temp_units {
   F
   C
   K
+}
+
+enum gravity_unit {
+  SG
+  BRIX
 }
 
 enum additive_unit {


### PR DESCRIPTION
## Summary
- Add SG/Brix entry support for brew tracker gravity readings while storing canonical SG values
- Add optional refractometer correction for post-OG Brix readings and preserve entered-unit metadata
- Add a brew-level gravity unit preference and standardize SG/Brix display formatting
- Support SG/Brix input in the OG quick action and add database migration coverage

## Validation
- `npx tsc --noEmit`
- `npx tsx --test lib/utils/unitConverter.test.ts`
- `npm run build`