### PR TITLE
[codex] Refresh admin UI and add public brew sharing

### DIFF
--- a/app/[locale]/account/brews/[brew_id]/page.tsx
+++ b/app/[locale]/account/brews/[brew_id]/page.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
-import { ArrowLeft, Check, Filter, Pencil, PencilOff, Scale, Trash2, X } from "lucide-react";
+import { ArrowLeft, Check, Filter, Pencil, PencilOff, Scale, Share2, Trash2, X } from "lucide-react";
 
 import {
   AccountBrewEntry,
@@ -676,6 +676,43 @@ export default function BrewPageClient() {
     setStartDateDialogOpen(false);
   }
 
+  async function sharePublicBrew() {
+    if (
+      !brew?.public ||
+      !brew.recipe_id ||
+      brew.recipe_private !== false
+    ) {
+      return;
+    }
+
+    const url = `${window.location.origin}/recipes/${brew.recipe_id}/brews/${brew.id}`;
+    const title = t("brews.share.title", "Shared brew: {{name}}", {
+      name: brew.name || brew.recipe_name || t("brew", "Brew")
+    });
+
+    if (typeof navigator.share === "function") {
+      try {
+        await navigator.share({ title, url });
+        return;
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") return;
+      }
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      toast({
+        description: t("brews.share.copied", "Public brew link copied.")
+      });
+    } catch (error) {
+      console.error("Error sharing public brew:", error);
+      toast({
+        description: t("error", "Something went wrong."),
+        variant: "destructive"
+      });
+    }
+  }
+
   useEffect(() => {
     if (brew?.recipe_snapshot?.dataV2) {
       hydrate(brew.recipe_snapshot.dataV2);
@@ -920,6 +957,19 @@ export default function BrewPageClient() {
               )}
             </div>
           </div>
+          {brew.public &&
+          brew.recipe_id &&
+          brew.recipe_private === false ? (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={sharePublicBrew}
+            >
+              <Share2 className="h-4 w-4" />
+              {t("brews.share.action", "Share brew")}
+            </Button>
+          ) : null}
         </div>
 
         <div className="grid gap-6 lg:grid-cols-2">
@@ -1009,6 +1059,43 @@ export default function BrewPageClient() {
                         await saveMetadata({
                           requested_email_alerts: checked
                         });
+                      }}
+                    />
+                  </div>
+                }
+              />
+              <SummaryField
+                label={t("brews.visibility.label", "Visibility")}
+                value={
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-foreground">
+                        {brew.public
+                          ? t("brews.visibility.public", "Public")
+                          : t("brews.visibility.private", "Private")}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {brew.recipe_private !== false
+                          ? t(
+                              "brews.visibility.recipeMustBePublic",
+                              "Make the recipe public before sharing this brew."
+                            )
+                          : brew.public
+                          ? t(
+                              "brews.visibility.publicDescription",
+                              "Public brews can be viewed from public recipe pages."
+                            )
+                          : t(
+                              "brews.visibility.privateDescription",
+                              "Only you and admins can view this brew."
+                            )}
+                      </div>
+                    </div>
+                    <Switch
+                      checked={brew.public}
+                      disabled={brew.recipe_private !== false}
+                      onCheckedChange={async (checked) => {
+                        await saveMetadata({ public: checked });
                       }}
                     />
                   </div>

--- a/app/[locale]/account/brews/page.tsx
+++ b/app/[locale]/account/brews/page.tsx
@@ -5,14 +5,6 @@ import { useTranslation } from "react-i18next";
 import Link from "next/link";
 
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow
-} from "@/components/ui/table";
-import {
   Select,
   SelectContent,
   SelectItem,
@@ -20,7 +12,7 @@ import {
   SelectValue
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Button, buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { X, Search } from "lucide-react";
 
@@ -34,13 +26,11 @@ import {
 import { AccountPagination } from "@/components/account/pagination";
 import { useFuzzySearch } from "@/hooks/useFuzzySearch";
 
-import {
-  useAccountBrews,
-  type AccountBrewListItem
-} from "@/hooks/reactQuery/useAccountBrews";
+import { useAccountBrews } from "@/hooks/reactQuery/useAccountBrews";
+import { BrewList } from "@/components/brews/BrewList";
 
 export default function AccountBrews() {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { data: brews = [], isLoading, isError, error } = useAccountBrews();
 
   const [pageSize, setPageSize] = useState(10);
@@ -61,12 +51,6 @@ export default function AccountBrews() {
     pageSize,
     searchKey: ["name", "id", "recipe_name", "stage"]
   });
-
-  const formatter = new Intl.DateTimeFormat(i18n.resolvedLanguage, {
-    dateStyle: "short",
-    timeStyle: "short"
-  });
-  const formatDate = (date: string | Date) => formatter.format(new Date(date));
 
   if (isError) {
     console.error(error);
@@ -142,42 +126,12 @@ export default function AccountBrews() {
         </div>
       ) : (
         <>
-          <div className="w-full overflow-x-auto rounded-md border border-border bg-card">
-            <Table className="w-full">
-              <TableHeader>
-                <TableRow>
-                  <TableHead
-                    className={cn(
-                      "sticky left-0 z-10 bg-card border-r",
-                      "min-w-28 sm:min-w-72"
-                    )}
-                  >
-                    {t("name")}
-                  </TableHead>
-
-                  <TableHead>{t("brews.stage")}</TableHead>
-                  <TableHead>{t("brews.recipe")}</TableHead>
-                  <TableHead>{t("brews.startDate")}</TableHead>
-                  <TableHead>{t("brews.endDate")}</TableHead>
-                  <TableHead>{t("brews.entries")}</TableHead>
-                </TableRow>
-              </TableHeader>
-
-              <TableBody>
-                {isLoading ? (
-                  <AccountBrewsTableSkeleton rows={pageSize} />
-                ) : (
-                  pageData.map((brew) => (
-                    <AccountBrewRow
-                      key={brew.id}
-                      brew={brew}
-                      formatDate={formatDate}
-                    />
-                  ))
-                )}
-              </TableBody>
-            </Table>
-          </div>
+          <BrewList
+            brews={pageData}
+            detailHref={(brewId) => `/account/brews/${brewId}`}
+            loading={isLoading}
+            loadingRows={pageSize}
+          />
 
           {!isLoading && totalPages > 1 && (
             <AccountPagination
@@ -190,104 +144,8 @@ export default function AccountBrews() {
               onGoTo={goToPage}
             />
           )}
-
         </>
       )}
     </div>
-  );
-}
-
-function AccountBrewRow({
-  brew,
-  formatDate
-}: {
-  brew: AccountBrewListItem;
-  formatDate: (d: string | Date) => string;
-}) {
-  const { t } = useTranslation();
-
-  return (
-    <TableRow>
-      <TableCell
-        className={cn(
-          "sticky left-0 z-10 bg-card border-r font-medium truncate",
-          "max-w-28 sm:max-w-72"
-        )}
-      >
-        <Link
-          href={`/account/brews/${brew.id}`}
-          className="underline block truncate"
-          title={brew.name || brew.id}
-        >
-          {brew.name || brew.id}
-        </Link>
-      </TableCell>
-
-      <TableCell className="whitespace-nowrap">
-        {t(`brewStage.${brew.stage}`)}
-      </TableCell>
-
-      <TableCell>
-        {brew.recipe_id ? (
-          <Link
-            href={`/recipes/${brew.recipe_id}`}
-            className={buttonVariants({ variant: "secondary", size: "sm" })}
-          >
-            {brew.recipe_name || t("open")}
-          </Link>
-        ) : (
-          <span className="text-muted-foreground">—</span>
-        )}
-      </TableCell>
-
-      <TableCell className="whitespace-nowrap">
-        {formatDate(brew.start_date)}
-      </TableCell>
-
-      <TableCell className="whitespace-nowrap">
-        {brew.end_date ? formatDate(brew.end_date) : t("ongoing")}
-      </TableCell>
-
-      <TableCell className="whitespace-nowrap">
-        {brew.entry_count ?? 0}
-      </TableCell>
-    </TableRow>
-  );
-}
-
-function AccountBrewsTableSkeleton({ rows = 10 }: { rows?: number }) {
-  return (
-    <>
-      {Array.from({ length: rows }).map((_, i) => (
-        <TableRow key={i}>
-          <TableCell
-            className={cn(
-              "sticky left-0 z-10 bg-card border-r",
-              "min-w-28 sm:min-w-72",
-              "max-w-28 sm:max-w-72",
-              "truncate"
-            )}
-          >
-            <Skeleton className="h-4 w-full max-w-[14rem]" />
-          </TableCell>
-
-          <TableCell>
-            <Skeleton className="h-4 w-[90px]" />
-          </TableCell>
-          <TableCell>
-            <Skeleton className="h-8 w-[120px] rounded-md" />
-          </TableCell>
-          <TableCell>
-            <Skeleton className="h-4 w-[110px]" />
-          </TableCell>
-          <TableCell>
-            <Skeleton className="h-4 w-[110px]" />
-          </TableCell>
-          <TableCell>
-            <Skeleton className="h-4 w-[40px]" />
-          </TableCell>
-        </TableRow>
-      ))}
-    </>
   );
 }

--- a/app/[locale]/admin/additives/page.tsx
+++ b/app/[locale]/admin/additives/page.tsx
@@ -5,9 +5,14 @@ import { PaginatedTable } from "@/components/PaginatedTable";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAdditivesQuery } from "@/hooks/reactQuery/useAdditivesQuery";
+import { Plus } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { Button } from "@/components/ui/button";
 
 function AdditiveDashboard() {
   const router = useRouter();
+  const { t } = useTranslation();
 
   const { data: additives, isLoading, isError } = useAdditivesQuery();
 
@@ -16,11 +21,18 @@ function AdditiveDashboard() {
   if (!additives) return null;
 
   return (
-    <div>
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl">Additives</h1>
-        <Link href={"/admin/additives/new-additive"}>Add New Additive</Link>
-      </div>
+    <div className="space-y-6">
+      <AdminPageHeader
+        title={t("admin.nav.additives", "Additives")}
+        actions={
+          <Button asChild>
+            <Link href="/admin/additives/new-additive">
+              <Plus />
+              {t("admin.additives.add", "Add additive")}
+            </Link>
+          </Button>
+        }
+      />
 
       <PaginatedTable
         data={additives}
@@ -34,6 +46,7 @@ function AdditiveDashboard() {
           router.push(`/admin/additives/${additive.id}`)
         }
         searchKey={["name"]}
+        getRowKey={(additive) => additive.id}
       />
     </div>
   );

--- a/app/[locale]/admin/brews/[brew_id]/page.tsx
+++ b/app/[locale]/admin/brews/[brew_id]/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useTranslation } from "react-i18next";
+
+import { BrewViewer } from "@/components/brews/BrewViewer";
+import Loading from "@/components/loading";
+import { useAdminBrew } from "@/hooks/reactQuery/useAdminDashboard";
+
+export default function AdminBrewPage() {
+  const { brew_id: brewId } = useParams<{ brew_id: string }>();
+  const { t } = useTranslation();
+  const { data, isLoading, isError } = useAdminBrew(brewId);
+
+  if (isLoading) return <Loading />;
+  if (isError || !data)
+    return (
+      <div className="rounded-md border border-destructive/40 p-4 text-sm text-destructive">
+        {t("brews.notFound", "Brew not found.")}
+      </div>
+    );
+
+  return (
+    <BrewViewer
+      brew={data}
+      backHref="/admin/brews"
+      recipeHref={data.recipe_id ? `/admin/recipes/${data.recipe_id}` : null}
+    />
+  );
+}

--- a/app/[locale]/admin/brews/page.tsx
+++ b/app/[locale]/admin/brews/page.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Search, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { AccountPagination } from "@/components/account/pagination";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { BrewList } from "@/components/brews/BrewList";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput
+} from "@/components/ui/input-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
+import { useAdminBrews } from "@/hooks/reactQuery/useAdminDashboard";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { BREW_STAGE } from "@/lib/brewEnums";
+
+export default function AdminBrewsPage() {
+  const { t } = useTranslation();
+  const [page, setPage] = useState(1);
+  const [limit, setLimit] = useState(10);
+  const [query, setQuery] = useState("");
+  const [stage, setStage] = useState("all");
+  const [status, setStatus] = useState("all");
+  const debouncedQuery = useDebouncedValue(query, 350);
+  const { data, isLoading, isFetching, isError } = useAdminBrews({
+    page,
+    limit,
+    query: debouncedQuery || undefined,
+    stage: stage === "all" ? undefined : stage,
+    status: status === "all" ? undefined : status
+  });
+
+  useEffect(() => setPage(1), [debouncedQuery, limit, stage, status]);
+
+  return (
+    <div className="space-y-6">
+      <AdminPageHeader
+        title={t("admin.nav.brews", "Brews")}
+        description={t(
+          "admin.brews.description",
+          "Inspect every brew in the tracker without changing owner data."
+        )}
+      />
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-[minmax(16rem,1fr)_11rem_11rem_7rem]">
+        <InputGroup>
+          <InputGroupAddon>
+            <Search className="size-4" />
+          </InputGroupAddon>
+          <InputGroupInput
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder={t(
+              "admin.brews.searchPlaceholder",
+              "Search brews, recipes, or owners"
+            )}
+          />
+          {query ? (
+            <InputGroupAddon align="inline-end">
+              <InputGroupButton
+                title={t("clear", "Clear")}
+                onClick={() => setQuery("")}
+              >
+                <X />
+              </InputGroupButton>
+            </InputGroupAddon>
+          ) : null}
+        </InputGroup>
+        <Select value={stage} onValueChange={setStage}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{t("allStages", "All stages")}</SelectItem>
+            {Object.values(BREW_STAGE).map((value) => (
+              <SelectItem key={value} value={value}>
+                {t(`brewStage.${value}`, value)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={status} onValueChange={setStatus}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">{t("all", "All")}</SelectItem>
+            <SelectItem value="active">{t("active", "Active")}</SelectItem>
+            <SelectItem value="complete">
+              {t("complete", "Complete")}
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        <Select
+          value={String(limit)}
+          onValueChange={(value) => setLimit(Number(value))}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {[10, 25, 50].map((value) => (
+              <SelectItem key={value} value={String(value)}>
+                {value}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      {isError ? (
+        <div className="rounded-md border border-destructive/40 p-4 text-sm text-destructive">
+          {t("error.generic", "Something went wrong.")}
+        </div>
+      ) : null}
+      <BrewList
+        brews={data?.brews ?? []}
+        detailHref={(id) => `/admin/brews/${id}`}
+        recipeHref={(id) => `/admin/recipes/${id}`}
+        loading={isLoading || (!data && isFetching)}
+        loadingRows={limit}
+        showOwner
+        showVisibility
+      />
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <span className="text-sm text-muted-foreground">
+          {t("showingCount", "Showing {{shown}} of {{total}}", {
+            shown: data?.brews.length ?? 0,
+            total: data?.totalCount ?? 0
+          })}
+        </span>
+        <AccountPagination
+          page={page}
+          totalPages={data?.totalPages ?? 1}
+          canPrev={page > 1}
+          canNext={page < (data?.totalPages ?? 1)}
+          onPrev={() => setPage((value) => value - 1)}
+          onNext={() => setPage((value) => value + 1)}
+          onGoTo={setPage}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/admin/ingredients/page.tsx
+++ b/app/[locale]/admin/ingredients/page.tsx
@@ -5,9 +5,14 @@ import { PaginatedTable } from "@/components/PaginatedTable";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useIngredientsQuery } from "@/hooks/reactQuery/useIngredientsQuery";
+import { Plus } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { Button } from "@/components/ui/button";
 
 function IngredientDashboard() {
   const router = useRouter();
+  const { t } = useTranslation();
 
   // React Query-based fetch
   const { data: ingredients, isLoading, isError } = useIngredientsQuery(); // no category needed here
@@ -17,13 +22,18 @@ function IngredientDashboard() {
   if (!ingredients) return null;
 
   return (
-    <div>
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl">Ingredients</h1>
-        <Link href={"/admin/ingredients/new-ingredient"}>
-          Add New Ingredient
-        </Link>
-      </div>
+    <div className="space-y-6">
+      <AdminPageHeader
+        title={t("admin.nav.ingredients", "Ingredients")}
+        actions={
+          <Button asChild>
+            <Link href="/admin/ingredients/new-ingredient">
+              <Plus />
+              {t("admin.ingredients.add", "Add ingredient")}
+            </Link>
+          </Button>
+        }
+      />
 
       <PaginatedTable
         data={ingredients}
@@ -38,6 +48,7 @@ function IngredientDashboard() {
           router.push(`/admin/ingredients/${ingredient.id}`)
         }
         searchKey={["name", "category"]}
+        getRowKey={(ingredient) => ingredient.id}
       />
     </div>
   );

--- a/app/[locale]/admin/layout.tsx
+++ b/app/[locale]/admin/layout.tsx
@@ -9,10 +9,10 @@ function AdminDashboard({ children }: { children: React.ReactNode }) {
   if (loading) return <Loading />;
 
   return (
-    <section className="w-full flex justify-center items-center sm:pt-24 pt-[6rem]">
-      <div className="relative flex flex-col md:p-12 py-8 rounded-xl bg-background gap-4 w-11/12 max-w-[1000px]">
+    <section className="flex w-full justify-center pb-12 pt-24 sm:pt-28">
+      <div className="relative flex w-11/12 max-w-[1200px] flex-col gap-6 rounded-xl bg-background px-4 py-6 sm:px-8 sm:py-8 md:p-12">
         <AdminNav />
-        {children}
+        <main>{children}</main>
       </div>
     </section>
   );

--- a/app/[locale]/admin/page.tsx
+++ b/app/[locale]/admin/page.tsx
@@ -1,15 +1,111 @@
 "use client";
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import Link from "next/link";
+import {
+  Beer,
+  FlaskConical,
+  NotebookText,
+  TestTube2,
+  Users,
+  Wheat
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAdminSummary } from "@/hooks/reactQuery/useAdminDashboard";
 
 function AdminDashboard() {
-  const router = useRouter();
+  const { t } = useTranslation();
+  const { data, isLoading, isError } = useAdminSummary();
+  const items = [
+    {
+      label: t("admin.nav.users", "Users"),
+      value: data?.users,
+      href: "/admin/users",
+      icon: Users
+    },
+    {
+      label: t("admin.nav.brews", "Brews"),
+      value: data?.brews,
+      detail: data
+        ? t("admin.overview.activeBrews", "{{count}} active", {
+            count: data.activeBrews
+          })
+        : undefined,
+      href: "/admin/brews",
+      icon: Beer
+    },
+    {
+      label: t("admin.nav.recipes", "Recipes"),
+      value: data?.recipes,
+      detail: data
+        ? t("admin.overview.privateRecipes", "{{count}} private", {
+            count: data.privateRecipes
+          })
+        : undefined,
+      href: "/admin/recipes",
+      icon: NotebookText
+    },
+    {
+      label: t("admin.nav.yeasts", "Yeasts"),
+      value: data?.yeasts,
+      href: "/admin/yeasts",
+      icon: FlaskConical
+    },
+    {
+      label: t("admin.nav.ingredients", "Ingredients"),
+      value: data?.ingredients,
+      href: "/admin/ingredients",
+      icon: Wheat
+    },
+    {
+      label: t("admin.nav.additives", "Additives"),
+      value: data?.additives,
+      href: "/admin/additives",
+      icon: TestTube2
+    }
+  ];
 
-  useEffect(() => {
-    router.replace("/admin/yeasts");
-  }, [router]);
-
-  return null;
+  return (
+    <div className="space-y-6">
+      <AdminPageHeader
+        title={t("admin.overview.title", "Overview")}
+        description={t(
+          "admin.overview.description",
+          "Review site activity and open an administrative workspace."
+        )}
+      />
+      {isError ? (
+        <div className="rounded-md border border-destructive/40 p-4 text-sm text-destructive">
+          {t("error.generic", "Something went wrong.")}
+        </div>
+      ) : null}
+      <div className="grid border-l border-t sm:grid-cols-2 lg:grid-cols-3">
+        {items.map(({ label, value, detail, href, icon: Icon }) => (
+          <Link
+            key={href}
+            href={href}
+            className="group min-h-36 border-b border-r p-5 transition-colors hover:bg-muted/50"
+          >
+            <div className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
+              <span>{label}</span>
+              <Icon className="size-4" />
+            </div>
+            {isLoading ? (
+              <Skeleton className="mt-5 h-9 w-20" />
+            ) : (
+              <div className="mt-5 text-3xl font-semibold tabular-nums">
+                {value ?? 0}
+              </div>
+            )}
+            {detail ? (
+              <div className="mt-2 text-sm text-muted-foreground">{detail}</div>
+            ) : null}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 export default AdminDashboard;

--- a/app/[locale]/admin/recipes/[id]/page.tsx
+++ b/app/[locale]/admin/recipes/[id]/page.tsx
@@ -1,0 +1,5 @@
+import RecipePage from "@/components/recipes/RecipeClient";
+
+export default function AdminRecipePage() {
+  return <RecipePage mode="admin-readonly" />;
+}

--- a/app/[locale]/admin/recipes/page.tsx
+++ b/app/[locale]/admin/recipes/page.tsx
@@ -1,12 +1,19 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { useAdminRecipesQuery } from "@/hooks/reactQuery/useAdminRecipesQuery";
-import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Search, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
-import { Input } from "@/components/ui/input";
+import { AccountPagination } from "@/components/account/pagination";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
 import { Button } from "@/components/ui/button";
-import Loading from "@/components/loading";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput
+} from "@/components/ui/input-group";
 import {
   Table,
   TableBody,
@@ -15,128 +22,130 @@ import {
   TableHeader,
   TableRow
 } from "@/components/ui/table";
-import { LucideX } from "lucide-react";
+import { useAdminRecipesQuery } from "@/hooks/reactQuery/useAdminRecipesQuery";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 
 const PAGE_SIZE = 10;
 
-function RecipesDashboard() {
-  const [page, setPage] = useState(1); // backend is 1-based
+export default function RecipesDashboard() {
+  const { t } = useTranslation();
+  const [page, setPage] = useState(1);
   const [search, setSearch] = useState("");
-
-  const debouncedSearch = useDebouncedValue(search, 400);
-
-  // Reset to first page whenever the debounced search term changes
-  useEffect(() => {
-    setPage(1);
-  }, [debouncedSearch]);
-
-  const { data, isLoading, isError, isFetching } = useAdminRecipesQuery({
+  const debouncedSearch = useDebouncedValue(search, 350);
+  const { data, isLoading, isError } = useAdminRecipesQuery({
     page,
     limit: PAGE_SIZE,
     search: debouncedSearch || undefined
   });
 
-  if (isLoading && !data) {
-    return <Loading />;
-  }
-
-  if (isError) {
-    return <div>An error has occured.</div>;
-  }
-
-  if (!data) return null;
-
-  const { recipes, totalCount, totalPages } = data;
+  useEffect(() => setPage(1), [debouncedSearch]);
 
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl">Recipes</h1>
-
-      {/* Search input (hits DB, not local Fuse) */}
-      <div className="flex items-center gap-2">
-        <label htmlFor="search" className="text-sm font-medium">
-          Search:
-        </label>
-        <div className="relative max-w-sm">
-          <Input
-            id="search"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search name, username…"
-            className="pr-8"
-          />
-          {search && (
-            <button
-              type="button"
-              onClick={() => setSearch("")}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-            >
-              <LucideX />
-            </button>
-          )}
-        </div>
-        {isFetching && (
-          <span className="text-xs text-muted-foreground">Updating…</span>
+    <div className="space-y-6">
+      <AdminPageHeader
+        title={t("admin.nav.recipes", "Recipes")}
+        description={t(
+          "admin.recipes.description",
+          "Open public and private recipes in a read-only administrative view."
         )}
-      </div>
-
-      {/* Table */}
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Name</TableHead>
-            <TableHead>Username</TableHead>
-            <TableHead>Private Recipe</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {recipes.length === 0 ? (
-            <TableRow>
-              <TableCell colSpan={3} className="text-center">
-                No recipes found.
-              </TableCell>
-            </TableRow>
-          ) : (
-            recipes.map((recipe) => (
-              <TableRow key={recipe.id}>
-                <TableCell>{recipe.name}</TableCell>
-                <TableCell>{recipe.public_username || "—"}</TableCell>
-                <TableCell>{recipe.private ? "Yes" : "No"}</TableCell>
-              </TableRow>
-            ))
+      />
+      <InputGroup className="max-w-xl">
+        <InputGroupAddon>
+          <Search className="size-4" />
+        </InputGroupAddon>
+        <InputGroupInput
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder={t(
+            "admin.recipes.searchPlaceholder",
+            "Search name or owner"
           )}
-        </TableBody>
-      </Table>
-
-      {/* Pagination (uses totalCount/totalPages from DB) */}
-      <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 text-sm">
-        <span>
-          Showing{" "}
-          {totalCount === 0
-            ? "0"
-            : `${(page - 1) * PAGE_SIZE + 1}–${Math.min(
-                page * PAGE_SIZE,
-                totalCount
-              )} of ${totalCount}`}
-        </span>
-
-        <div className="flex items-center gap-4">
-          <Button disabled={page === 1} onClick={() => setPage((p) => p - 1)}>
-            Previous
-          </Button>
-          <span>
-            Page {page} of {totalPages || 1}
-          </span>
-          <Button
-            disabled={page >= (totalPages || 1)}
-            onClick={() => setPage((p) => p + 1)}
-          >
-            Next
-          </Button>
+        />
+        {search ? (
+          <InputGroupAddon align="inline-end">
+            <InputGroupButton
+              title={t("clear", "Clear")}
+              onClick={() => setSearch("")}
+            >
+              <X />
+            </InputGroupButton>
+          </InputGroupAddon>
+        ) : null}
+      </InputGroup>
+      {isError ? (
+        <div className="rounded-md border border-destructive/40 p-4 text-sm text-destructive">
+          {t("error.generic", "Something went wrong.")}
         </div>
+      ) : null}
+      <div className="overflow-x-auto rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{t("name", "Name")}</TableHead>
+              <TableHead>{t("admin.owner", "Owner")}</TableHead>
+              <TableHead>{t("private", "Private")}</TableHead>
+              <TableHead className="text-right">
+                {t("actions", "Actions")}
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              Array.from({ length: PAGE_SIZE }).map((_, index) => (
+                <TableRow key={index}>
+                  <TableCell
+                    colSpan={4}
+                    className="h-12 animate-pulse bg-muted/20"
+                  />
+                </TableRow>
+              ))
+            ) : data?.recipes.length ? (
+              data.recipes.map((recipe) => (
+                <TableRow key={recipe.id}>
+                  <TableCell className="font-medium">{recipe.name}</TableCell>
+                  <TableCell>{recipe.public_username || "-"}</TableCell>
+                  <TableCell>
+                    {recipe.private ? t("yes", "Yes") : t("no", "No")}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button asChild size="sm" variant="secondary">
+                      <Link href={`/admin/recipes/${recipe.id}`}>
+                        {t("view", "View")}
+                      </Link>
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={4}
+                  className="h-28 text-center text-muted-foreground"
+                >
+                  {t("recipes.none", "No recipes found.")}
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <span className="text-sm text-muted-foreground">
+          {t("showingCount", "Showing {{shown}} of {{total}}", {
+            shown: data?.recipes.length ?? 0,
+            total: data?.totalCount ?? 0
+          })}
+        </span>
+        <AccountPagination
+          page={page}
+          totalPages={data?.totalPages ?? 1}
+          canPrev={page > 1}
+          canNext={page < (data?.totalPages ?? 1)}
+          onPrev={() => setPage((value) => value - 1)}
+          onNext={() => setPage((value) => value + 1)}
+          onGoTo={setPage}
+        />
       </div>
     </div>
   );
 }
-
-export default RecipesDashboard;

--- a/app/[locale]/admin/users/[id]/page.tsx
+++ b/app/[locale]/admin/users/[id]/page.tsx
@@ -5,6 +5,8 @@ import Loading from "@/components/loading";
 import Link from "next/link";
 import UserEditForm from "@/components/admin/UserEditForm";
 import { useAdminUserById } from "@/hooks/reactQuery/useAdminUsersQuery";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { Button } from "@/components/ui/button";
 
 export default function UserEditPage() {
   const { id } = useParams();
@@ -15,11 +17,16 @@ export default function UserEditPage() {
   if (!user) return <p>User not found.</p>;
 
   return (
-    <div>
-      <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-bold mb-6">Edit User</h2>
-        <Link href={"/admin/users"}>Back to All Users</Link>
-      </div>
+    <div className="space-y-6">
+      <AdminPageHeader
+        title="Edit User"
+        description={user.email}
+        actions={
+          <Button asChild variant="secondary">
+            <Link href="/admin/users">Back to All Users</Link>
+          </Button>
+        }
+      />
 
       <UserEditForm user={user} />
     </div>

--- a/app/[locale]/admin/users/page.tsx
+++ b/app/[locale]/admin/users/page.tsx
@@ -4,9 +4,12 @@ import { useRouter } from "next/navigation";
 import Loading from "@/components/loading";
 import { PaginatedTable } from "@/components/PaginatedTable";
 import { useAdminUsersQuery } from "@/hooks/reactQuery/useAdminUsersQuery";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { useTranslation } from "react-i18next";
 
 function UserDashboard() {
   const router = useRouter();
+  const { t } = useTranslation();
   const { data: users, isLoading, isError, error } = useAdminUsersQuery();
 
   if (isLoading) return <Loading />;
@@ -23,8 +26,8 @@ function UserDashboard() {
     .sort((a, b) => a.role.localeCompare(b.role));
 
   return (
-    <div>
-      <h1 className="text-2xl">Users</h1>
+    <div className="space-y-6">
+      <AdminPageHeader title={t("admin.nav.users", "Users")} />
 
       <PaginatedTable
         data={sorted}
@@ -38,6 +41,7 @@ function UserDashboard() {
         pageSize={10}
         onRowClick={(user) => router.push(`/admin/users/${user.id}`)}
         searchKey={["email", "public_username", "role"]}
+        getRowKey={(user) => user.id}
       />
     </div>
   );

--- a/app/[locale]/admin/yeasts/page.tsx
+++ b/app/[locale]/admin/yeasts/page.tsx
@@ -4,9 +4,14 @@ import { PaginatedTable } from "@/components/PaginatedTable";
 import { useYeastsQuery } from "@/hooks/reactQuery/useYeastsQuery";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { Plus } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+import { Button } from "@/components/ui/button";
 
 function YeastDashboard() {
   const router = useRouter();
+  const { t } = useTranslation();
   const { data: yeasts, isLoading, isError } = useYeastsQuery();
 
   if (isLoading) return <Loading />;
@@ -14,11 +19,8 @@ function YeastDashboard() {
   if (!yeasts) return null;
 
   return (
-    <div>
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl">Yeasts</h1>
-        <Link href={"/admin/yeasts/new-yeast"}>Add New Yeast</Link>
-      </div>
+    <div className="space-y-6">
+      <AdminPageHeader title={t("admin.nav.yeasts", "Yeasts")} actions={<Button asChild><Link href="/admin/yeasts/new-yeast"><Plus />{t("admin.yeasts.add", "Add yeast")}</Link></Button>} />
 
       <PaginatedTable
         data={yeasts}
@@ -33,6 +35,7 @@ function YeastDashboard() {
         pageSize={10}
         onRowClick={(yeast) => router.push(`/admin/yeasts/${yeast.id}`)}
         searchKey={["name", "brand", "nitrogen_requirement"]}
+        getRowKey={(yeast) => yeast.id}
       />
     </div>
   );

--- a/app/[locale]/recipes/[id]/brews/[brew_id]/page.tsx
+++ b/app/[locale]/recipes/[id]/brews/[brew_id]/page.tsx
@@ -1,0 +1,37 @@
+import { notFound } from "next/navigation";
+
+import { CardWrapper } from "@/components/CardWrapper";
+import { BrewViewer } from "@/components/brews/BrewViewer";
+import { getPublicBrewForRecipe } from "@/lib/db/brews";
+
+export default async function PublicRecipeBrewPage({
+  params
+}: {
+  params: Promise<{ id: string; brew_id: string }>;
+}) {
+  const { id, brew_id } = await params;
+  const recipeId = Number(id);
+
+  if (!Number.isInteger(recipeId)) {
+    notFound();
+  }
+
+  const brew = await getPublicBrewForRecipe(recipeId, brew_id);
+
+  if (!brew) {
+    notFound();
+  }
+
+  return (
+    <main className="flex w-full justify-center py-[6rem]">
+      <CardWrapper>
+        <BrewViewer
+          brew={brew}
+          backHref={`/recipes/${recipeId}`}
+          recipeHref={`/recipes/${recipeId}`}
+          backLabelKey="publicBrews.backToRecipe"
+        />
+      </CardWrapper>
+    </main>
+  );
+}

--- a/app/api/admin/brews/[brew_id]/route.ts
+++ b/app/api/admin/brews/[brew_id]/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAdminBrew } from "@/lib/db/admin";
+import { verifyAdmin } from "@/lib/userAccessFunctions";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ brew_id: string }> }
+) {
+  const adminOrResponse = await verifyAdmin(req);
+  if (adminOrResponse instanceof NextResponse) return adminOrResponse;
+
+  const { brew_id } = await params;
+  if (!brew_id) {
+    return NextResponse.json({ error: "Missing brew id." }, { status: 400 });
+  }
+
+  try {
+    const brew = await getAdminBrew(brew_id);
+    if (!brew) {
+      return NextResponse.json({ error: "Brew not found." }, { status: 404 });
+    }
+
+    return NextResponse.json(brew);
+  } catch (error) {
+    console.error("GET /api/admin/brews/[brew_id] failed:", error);
+    return NextResponse.json(
+      { error: "Failed to load brew." },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/brews/route.ts
+++ b/app/api/admin/brews/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAdminBrewsPage } from "@/lib/db/admin";
+import { verifyAdmin } from "@/lib/userAccessFunctions";
+
+export async function GET(req: NextRequest) {
+  const adminOrResponse = await verifyAdmin(req);
+  if (adminOrResponse instanceof NextResponse) return adminOrResponse;
+
+  const page = Number(req.nextUrl.searchParams.get("page") ?? "1");
+  const limit = Number(req.nextUrl.searchParams.get("limit") ?? "10");
+  const query = req.nextUrl.searchParams.get("query") ?? "";
+  const stage = req.nextUrl.searchParams.get("stage") ?? undefined;
+  const statusParam = req.nextUrl.searchParams.get("status");
+  const status =
+    statusParam === "active" || statusParam === "complete"
+      ? statusParam
+      : undefined;
+
+  try {
+    return NextResponse.json(
+      await getAdminBrewsPage({ page, limit, query, stage, status })
+    );
+  } catch (error) {
+    console.error("GET /api/admin/brews failed:", error);
+    return NextResponse.json(
+      { error: "Failed to load brews." },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/summary/route.ts
+++ b/app/api/admin/summary/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getAdminSummary } from "@/lib/db/admin";
+import { verifyAdmin } from "@/lib/userAccessFunctions";
+
+export async function GET(req: NextRequest) {
+  const adminOrResponse = await verifyAdmin(req);
+  if (adminOrResponse instanceof NextResponse) return adminOrResponse;
+
+  try {
+    return NextResponse.json(await getAdminSummary());
+  } catch (error) {
+    console.error("GET /api/admin/summary failed:", error);
+    return NextResponse.json(
+      { error: "Failed to load admin summary." },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/users/[id]/password-reset/route.ts
+++ b/app/api/admin/users/[id]/password-reset/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { sendPasswordResetEmail } from "@/lib/auth/passwordReset";
+import { getUserById } from "@/lib/db/users";
+import { verifyAdmin } from "@/lib/userAccessFunctions";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const adminOrResponse = await verifyAdmin(req);
+  if (adminOrResponse instanceof NextResponse) return adminOrResponse;
+
+  const { id } = await params;
+  const userId = Number(id);
+
+  if (!Number.isInteger(userId) || userId <= 0) {
+    return NextResponse.json({ error: "Invalid user id." }, { status: 400 });
+  }
+
+  try {
+    const user = await getUserById(userId);
+    if (!user) {
+      return NextResponse.json({ error: "User not found." }, { status: 404 });
+    }
+
+    await sendPasswordResetEmail({ userId: user.id, email: user.email });
+
+    return NextResponse.json({ message: "Password reset link sent." });
+  } catch (error) {
+    console.error("POST /api/admin/users/[id]/password-reset failed:", error);
+    return NextResponse.json(
+      { error: "Failed to send password reset link." },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/request-reset/route.ts
+++ b/app/api/auth/request-reset/route.ts
@@ -1,14 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
-import jwt from "jsonwebtoken";
-import nodemailer from "nodemailer";
 import { getUserByEmail } from "@/lib/db/users";
-
-const {
-  RESET_PASSWORD_SECRET = "",
-  EMAIL_USER,
-  EMAIL_PASS,
-  NEXT_PUBLIC_BASE_URL
-} = process.env;
+import { sendPasswordResetEmail } from "@/lib/auth/passwordReset";
 
 /**
  * Request password reset
@@ -35,31 +27,7 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  const token = jwt.sign({ userId: user.id }, RESET_PASSWORD_SECRET, {
-    expiresIn: "15m"
-  });
-
-  const resetUrl = `${NEXT_PUBLIC_BASE_URL}/reset-password?token=${token}`;
-
-  const transporter = nodemailer.createTransport({
-    host: "smtp.office365.com",
-    port: 587,
-    secure: false,
-    auth: {
-      user: EMAIL_USER,
-      pass: EMAIL_PASS
-    }
-  });
-
-  await transporter.sendMail({
-    to: email,
-    from: { name: "MeadTools", address: EMAIL_USER! },
-    subject: "Reset your MeadTools password",
-    html: `
-      <p>Click the link below to reset your password:</p>
-      <p><a href="${resetUrl}">This link</a> will expire in 15 minutes.</p>
-    `
-  });
+  await sendPasswordResetEmail({ userId: user.id, email: user.email });
 
   return NextResponse.json({ message: "Reset link sent." });
 }

--- a/app/api/openapi-types.ts
+++ b/app/api/openapi-types.ts
@@ -879,6 +879,7 @@ export type BrewEntryTypeResponse =
   | "ISSUE";
 
 export type TemperatureUnitResponse = "F" | "C" | "K";
+export type GravityUnitResponse = "SG" | "BRIX";
 
 export type BrewPathParams = {
   brew_id: string;
@@ -895,9 +896,14 @@ export type BrewListItemResponse = {
   start_date: string;
   end_date: string | null;
   stage: BrewStageResponse;
+  batch_number: number | null;
   current_volume_liters: number | null;
+  requested_email_alerts: boolean;
+  gravity_unit_preference: GravityUnitResponse;
+  public: boolean;
   recipe_id: number | null;
   recipe_name: string | null;
+  recipe_private: boolean | null;
   entry_count: number;
   latest_gravity: number | null;
 };
@@ -954,9 +960,13 @@ export type BrewResponse = {
   stage: BrewStageResponse;
   batch_number: number | null;
   current_volume_liters: number | null;
+  requested_email_alerts: boolean;
+  gravity_unit_preference: GravityUnitResponse;
+  public: boolean;
   latest_gravity: number | null;
   recipe_id: number | null;
   recipe_name: string | null;
+  recipe_private: boolean | null;
   recipe_snapshot: BrewRecipeSnapshotResponse | null;
   entry_count: number;
   entries: BrewEntryResponse[];
@@ -978,7 +988,14 @@ export type CreateBrewResponse = {
     stage: BrewStageResponse;
     batch_number: number | null;
     current_volume_liters: number | null;
+    requested_email_alerts: boolean | null;
+    gravity_unit_preference: GravityUnitResponse;
+    public: boolean;
+    latest_gravity: number | null;
     recipe_id: number | null;
+    recipe_name: string | null;
+    recipe_private: boolean | null;
+    entry_count: number;
   };
 };
 
@@ -987,6 +1004,8 @@ export type UpdateBrewRequestBody = {
   stage?: BrewStageResponse;
   current_volume_liters?: number | null;
   requested_email_alerts?: boolean;
+  gravity_unit_preference?: GravityUnitResponse;
+  public?: boolean;
   end_date?: string | null;
 };
 
@@ -999,9 +1018,110 @@ export type UpdateBrewResponse = {
   batch_number: number | null;
   current_volume_liters: number | null;
   requested_email_alerts: boolean | null;
+  gravity_unit_preference: GravityUnitResponse;
+  public: boolean;
   latest_gravity: number | null;
   recipe_id: number | null;
+  recipe_name: string | null;
+  recipe_private: boolean | null;
 } | null;
+
+export type PublicRecipeBrewsPathParams = {
+  id: string;
+};
+
+export type PublicRecipeBrewPathParams = {
+  id: string;
+  brew_id: string;
+};
+
+export type PublicBrewOwnerResponse = {
+  displayName: string;
+};
+
+export type PublicBrewListItemResponse = {
+  id: string;
+  name: string | null;
+  start_date: string;
+  end_date: string | null;
+  stage: BrewStageResponse;
+  batch_number: number | null;
+  current_volume_liters: number | null;
+  gravity_unit_preference: GravityUnitResponse;
+  latest_gravity: number | null;
+  public: boolean;
+  recipe_id: number | null;
+  recipe_name: string | null;
+  entry_count: number;
+  owner: PublicBrewOwnerResponse | null;
+};
+
+export type PublicBrewEntryResponse = {
+  id: string;
+  datetime: string;
+  type: BrewEntryTypeResponse;
+  title: string | null;
+  note: string | null;
+  gravity: number | null;
+  temperature: number | null;
+  temp_units: TemperatureUnitResponse | null;
+  data: object | null;
+};
+
+export type PublicBrewEntriesByStageResponse = {
+  stage: BrewStageResponse;
+  entries: PublicBrewEntryResponse[];
+};
+
+export type PublicBrewLogResponse = {
+  datetime: string;
+  temperature: number;
+  temp_units: TemperatureUnitResponse;
+  battery: number | null;
+  gravity: number;
+  calculated_gravity: number | null;
+};
+
+export type PublicBrewDetailResponse = {
+  id: string;
+  name: string | null;
+  start_date: string;
+  end_date: string | null;
+  stage: BrewStageResponse;
+  batch_number: number | null;
+  current_volume_liters: number | null;
+  gravity_unit_preference: GravityUnitResponse;
+  latest_gravity: number | null;
+  public: boolean;
+  recipe_id: number | null;
+  recipe_name: string | null;
+  entry_count: number;
+  owner: PublicBrewOwnerResponse | null;
+  recipe_snapshot: BrewRecipeSnapshotResponse | null;
+  entries: PublicBrewEntryResponse[];
+  entries_by_stage: PublicBrewEntriesByStageResponse[];
+  logs: PublicBrewLogResponse[];
+};
+
+export type PublicRecipeBrewsResponse = {
+  brews: PublicBrewListItemResponse[];
+};
+
+export type PublicRecipeBrewResponse = {
+  brew: PublicBrewDetailResponse;
+};
+
+export type PublicBrewValidationErrorResponse = {
+  error: "Invalid recipe ID" | "Missing brew_id";
+};
+
+export type PublicBrewNotFoundErrorResponse = {
+  error: "Brew not found";
+};
+
+export type PublicBrewFetchErrorResponse = {
+  error: "Failed to fetch public brews" | "Failed to fetch public brew";
+};
 
 export type CreateBrewEntryRequestBody = {
   type: BrewEntryTypeResponse;

--- a/app/api/recipes/[id]/brews/[brew_id]/route.ts
+++ b/app/api/recipes/[id]/brews/[brew_id]/route.ts
@@ -1,0 +1,47 @@
+import { getPublicBrewForRecipe } from "@/lib/db/brews";
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Get public brew for recipe
+ * @description Returns the read-only tracker data for a brew whose owner explicitly made it public and whose linked recipe is public.
+ * @pathParams PublicRecipeBrewPathParams
+ * @response 200:PublicRecipeBrewResponse
+ * @responseSet none
+ * @add 400:PublicBrewValidationErrorResponse
+ * @add 404:PublicBrewNotFoundErrorResponse
+ * @add 500:PublicBrewFetchErrorResponse
+ * @tag Brews
+ * @openapi
+ */
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; brew_id: string }> }
+) {
+  const { id, brew_id } = await params;
+  const recipeId = Number(id);
+
+  if (!Number.isInteger(recipeId)) {
+    return NextResponse.json({ error: "Invalid recipe ID" }, { status: 400 });
+  }
+
+  if (!brew_id) {
+    return NextResponse.json({ error: "Missing brew_id" }, { status: 400 });
+  }
+
+  try {
+    const brew = await getPublicBrewForRecipe(recipeId, brew_id);
+
+    if (!brew) {
+      return NextResponse.json({ error: "Brew not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ brew });
+  } catch (error) {
+    console.error("Error fetching public recipe brew:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch public brew" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/recipes/[id]/brews/route.ts
+++ b/app/api/recipes/[id]/brews/route.ts
@@ -1,0 +1,37 @@
+import { getPublicBrewsForRecipe } from "@/lib/db/brews";
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * List public brews for recipe
+ * @description Returns brews whose owners explicitly made them public for the given public recipe. Private recipes and private brews return an empty list.
+ * @pathParams PublicRecipeBrewsPathParams
+ * @response 200:PublicRecipeBrewsResponse
+ * @responseSet none
+ * @add 400:PublicBrewValidationErrorResponse
+ * @add 500:PublicBrewFetchErrorResponse
+ * @tag Brews
+ * @openapi
+ */
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  const recipeId = Number(id);
+
+  if (!Number.isInteger(recipeId)) {
+    return NextResponse.json({ error: "Invalid recipe ID" }, { status: 400 });
+  }
+
+  try {
+    const brews = await getPublicBrewsForRecipe(recipeId);
+    return NextResponse.json({ brews });
+  } catch (error) {
+    console.error("Error fetching public recipe brews:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch public brews" },
+      { status: 500 }
+    );
+  }
+}

--- a/components/PaginatedTable.tsx
+++ b/components/PaginatedTable.tsx
@@ -5,13 +5,19 @@ import {
   TableCell,
   TableHead,
   TableHeader,
-  TableRow,
+  TableRow
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
-import { useState } from "react";
-import { Input } from "./ui/input";
+import { useEffect, useState } from "react";
 import Fuse from "fuse.js";
-import { LucideX } from "lucide-react";
+import { Search, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput
+} from "./ui/input-group";
 interface PaginatedTableProps<T> {
   data: T[];
   columns: {
@@ -22,6 +28,7 @@ interface PaginatedTableProps<T> {
   pageSize?: number;
   onRowClick?: (item: T) => void;
   searchKey?: keyof T | (keyof T)[];
+  getRowKey?: (item: T) => React.Key;
 }
 
 export function PaginatedTable<T>({
@@ -30,18 +37,22 @@ export function PaginatedTable<T>({
   pageSize = 10,
   onRowClick,
   searchKey,
+  getRowKey
 }: PaginatedTableProps<T>) {
+  const { t } = useTranslation();
   const [page, setPage] = useState(0);
   const [search, setSearch] = useState("");
   const keys = Array.isArray(searchKey)
     ? searchKey.map(String)
-    : [String(searchKey)];
+    : searchKey
+      ? [String(searchKey)]
+      : [];
 
   const filteredData =
     searchKey && search
       ? new Fuse(data, {
           keys,
-          threshold: 0.4,
+          threshold: 0.4
         })
           .search(search)
           .map((r) => r.item)
@@ -52,101 +63,119 @@ export function PaginatedTable<T>({
   const end = start + pageSize;
   const pageData = filteredData.slice(start, end);
 
+  useEffect(() => {
+    if (page > 0 && page >= totalPages) setPage(Math.max(0, totalPages - 1));
+  }, [page, totalPages]);
+
   return (
     <div className="space-y-4">
       {searchKey && (
-        <div className="flex items-center gap-2">
-          <label htmlFor="search" className="text-sm font-medium">
-            Search:
-          </label>
-          <div className="relative max-w-sm">
-            <Input
-              id="search"
-              value={search}
-              onChange={(e) => {
-                setSearch(e.target.value);
-                setPage(0);
-              }}
-              placeholder={`Search ${
-                Array.isArray(searchKey)
-                  ? searchKey.map((key) => String(key)).join(", ")
-                  : String(searchKey)
-              }`}
-              className="pr-8" // Add space for the clear button
-            />
-            {search && (
-              <button
-                type="button"
+        <InputGroup className="max-w-xl">
+          <InputGroupAddon>
+            <Search className="size-4" />
+          </InputGroupAddon>
+          <InputGroupInput
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPage(0);
+            }}
+            placeholder={t("search", "Search")}
+          />
+          {search && (
+            <InputGroupAddon align="inline-end">
+              <InputGroupButton
+                title={t("clear", "Clear")}
                 onClick={() => {
                   setSearch("");
                   setPage(0);
                 }}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
               >
-                <LucideX />
-              </button>
-            )}
-          </div>
-        </div>
+                <X />
+              </InputGroupButton>
+            </InputGroupAddon>
+          )}
+        </InputGroup>
       )}
-      <Table>
-        <TableHeader>
-          <TableRow>
-            {columns.map((col) => (
-              <TableHead key={String(col.key)}>{col.header}</TableHead>
-            ))}
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {pageData.map((item, i) => (
-            <TableRow
-              key={i}
-              className={onRowClick ? "cursor-pointer hover:bg-muted" : ""}
-              onClick={onRowClick ? () => onRowClick(item) : undefined}
-            >
-              {columns.map((col) => {
-                const isEmpty =
-                  item[col.key] === null ||
-                  item[col.key] === undefined ||
-                  item[col.key] === "";
-                return (
-                  <TableCell
-                    key={String(col.key)}
-                    className={isEmpty ? "text-muted-foreground" : ""}
-                  >
-                    {col.render
-                      ? col.render(item)
-                      : isEmpty
-                        ? "—"
-                        : String(item[col.key])}
-                  </TableCell>
-                );
-              })}
+      <div className="overflow-x-auto rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {columns.map((col) => (
+                <TableHead key={String(col.key)}>{col.header}</TableHead>
+              ))}
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {pageData.length ? (
+              pageData.map((item, i) => (
+                <TableRow
+                  key={getRowKey?.(item) ?? i}
+                  className={onRowClick ? "cursor-pointer hover:bg-muted" : ""}
+                  onClick={onRowClick ? () => onRowClick(item) : undefined}
+                >
+                  {columns.map((col) => {
+                    const isEmpty =
+                      item[col.key] === null ||
+                      item[col.key] === undefined ||
+                      item[col.key] === "";
+                    return (
+                      <TableCell
+                        key={String(col.key)}
+                        className={isEmpty ? "text-muted-foreground" : ""}
+                      >
+                        {col.render
+                          ? col.render(item)
+                          : isEmpty
+                            ? "—"
+                            : String(item[col.key])}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-28 text-center text-muted-foreground"
+                >
+                  {t("noResults", "No results found.")}
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
 
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 text-sm">
         <span>
-          Showing{" "}
+          {t("showing", "Showing")}{" "}
           {filteredData.length === 0
             ? "0"
             : `${start + 1}–${Math.min(end, filteredData.length)} of ${filteredData.length}`}
         </span>
 
         <div className="flex items-center gap-4">
-          <Button disabled={page === 0} onClick={() => setPage((p) => p - 1)}>
-            Previous
+          <Button
+            variant="outline"
+            disabled={page === 0}
+            onClick={() => setPage((p) => p - 1)}
+          >
+            {t("previous", "Previous")}
           </Button>
           <span>
-            Page {page + 1} of {totalPages}
+            {t("pageOf", "Page {{page}} of {{total}}", {
+              page: totalPages ? page + 1 : 1,
+              total: totalPages || 1
+            })}
           </span>
           <Button
+            variant="outline"
             disabled={page >= totalPages - 1}
             onClick={() => setPage((p) => p + 1)}
           >
-            Next
+            {t("next", "Next")}
           </Button>
         </div>
       </div>

--- a/components/admin/AdminPageHeader.tsx
+++ b/components/admin/AdminPageHeader.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+export function AdminPageHeader({
+  title,
+  description,
+  actions
+}: {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-3 border-b pb-5 sm:flex-row sm:items-end sm:justify-between">
+      <div className="min-w-0">
+        <h1 className="text-2xl font-semibold sm:text-3xl">{title}</h1>
+        {description ? <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{description}</p> : null}
+      </div>
+      {actions ? <div className="shrink-0">{actions}</div> : null}
+    </div>
+  );
+}

--- a/components/admin/Nav.tsx
+++ b/components/admin/Nav.tsx
@@ -1,50 +1,69 @@
 "use client";
 
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+  Beer,
+  FlaskConical,
+  LayoutDashboard,
+  Menu,
+  NotebookText,
+  TestTube2,
+  Users,
+  Wheat
+} from "lucide-react";
+import { useTranslation } from "react-i18next";
+
 import { Button } from "@/components/ui/button";
-import { Menu } from "lucide-react";
+import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import clsx from "clsx";
+import { cn } from "@/lib/utils";
 
 const baseRoute = "/admin";
 
 const navLinks = [
-  { label: "Yeasts", to: `${baseRoute}/yeasts` },
-  { label: "Ingredients", to: `${baseRoute}/ingredients` },
-  { label: "Users", to: `${baseRoute}/users` },
-  { label: "Recipes", to: `${baseRoute}/recipes` },
-  { label: "Additives", to: `${baseRoute}/additives` },
+  { key: "overview", fallback: "Overview", to: baseRoute, icon: LayoutDashboard },
+  { key: "brews", fallback: "Brews", to: `${baseRoute}/brews`, icon: Beer },
+  { key: "recipes", fallback: "Recipes", to: `${baseRoute}/recipes`, icon: NotebookText },
+  { key: "users", fallback: "Users", to: `${baseRoute}/users`, icon: Users },
+  { key: "yeasts", fallback: "Yeasts", to: `${baseRoute}/yeasts`, icon: FlaskConical },
+  { key: "ingredients", fallback: "Ingredients", to: `${baseRoute}/ingredients`, icon: Wheat },
+  { key: "additives", fallback: "Additives", to: `${baseRoute}/additives`, icon: TestTube2 }
 ];
 
 export default function AdminNav() {
   const pathname = usePathname();
+  const { t } = useTranslation();
+  const links = navLinks.map((link) => ({ ...link, label: t(`admin.nav.${link.key}`, link.fallback) }));
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild className="absolute top-2 sm:left-4 left-1">
-        <Button variant="ghost" size="icon">
-          <Menu />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent className="grid p-4 gap-2">
-        {navLinks.map(({ label, to }) => (
-          <Link
-            key={label}
-            href={to}
-            className={clsx(
-              "px-2 py-1.5 rounded hover:bg-muted transition-colors",
-              pathname.startsWith(to) && "font-semibold bg-muted"
-            )}
-          >
-            {label}
-          </Link>
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      <nav className="hidden items-center gap-1 overflow-x-auto border-b pb-3 md:flex" aria-label={t("admin.title", "Admin")}>
+        {links.map(({ key, ...link }) => <AdminNavLink key={key} {...link} pathname={pathname} />)}
+      </nav>
+      <div className="flex items-center justify-between border-b pb-3 md:hidden">
+        <Link href="/admin" className="font-semibold">{t("admin.title", "Admin")}</Link>
+        <Sheet>
+          <SheetTrigger asChild><Button variant="outline" size="icon" title={t("menu", "Menu")}><Menu /></Button></SheetTrigger>
+          <SheetContent side="left" className="w-[18rem]">
+            <SheetHeader><SheetTitle>{t("admin.title", "Admin")}</SheetTitle></SheetHeader>
+            <nav className="mt-6 grid gap-1">
+              {links.map(({ key, ...link }) => (
+                <SheetClose asChild key={key}><AdminNavLink {...link} pathname={pathname} /></SheetClose>
+              ))}
+            </nav>
+          </SheetContent>
+        </Sheet>
+      </div>
+    </>
+  );
+}
+
+function AdminNavLink({ label, to, icon: Icon, pathname }: { label: string; to: string; icon: typeof Menu; pathname: string }) {
+  const adminPath = pathname.slice(pathname.indexOf("/admin"));
+  const active = to === baseRoute ? adminPath === baseRoute : adminPath.startsWith(to);
+  return (
+    <Link href={to} className={cn("flex min-h-9 items-center gap-2 whitespace-nowrap rounded-md px-3 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground", active && "bg-muted font-medium text-foreground")}>
+      <Icon className="size-4" />{label}
+    </Link>
   );
 }

--- a/components/admin/UserEditForm.tsx
+++ b/components/admin/UserEditForm.tsx
@@ -29,6 +29,8 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useFetchWithAuth } from "@/hooks/auth/useFetchWithAuth";
 import { qk } from "@/lib/db/queryKeys";
 import { User } from "@/hooks/reactQuery/useAdminUsersQuery";
+import { KeyRound } from "lucide-react";
+import { useTranslation } from "react-i18next";
 
 interface Props {
   user: User;
@@ -36,6 +38,7 @@ interface Props {
 
 export default function UserEditForm({ user }: Props) {
   const { toast } = useToast();
+  const { t } = useTranslation();
   const router = useRouter();
   const queryClient = useQueryClient();
   const fetchWithAuth = useFetchWithAuth();
@@ -107,6 +110,37 @@ export default function UserEditForm({ user }: Props) {
     }
   });
 
+  const sendPasswordResetMutation = useMutation({
+    mutationFn: async () => {
+      await fetchWithAuth<{ message: string }>(
+        `/api/admin/users/${user.id}/password-reset`,
+        { method: "POST" }
+      );
+    },
+    onSuccess: () => {
+      toast({
+        title: t("admin.users.resetSentTitle", "Reset link sent"),
+        description: t(
+          "admin.users.resetSentDescription",
+          "A password reset link was sent to {{email}}.",
+          { email: user.email }
+        )
+      });
+    },
+    onError: (err: Error) => {
+      toast({
+        title: t("errorLabel", "Error"),
+        description:
+          err.message ||
+          t(
+            "admin.users.resetError",
+            "The password reset link could not be sent."
+          ),
+        variant: "destructive"
+      });
+    }
+  });
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     await updateUserMutation.mutateAsync(formData);
@@ -118,6 +152,7 @@ export default function UserEditForm({ user }: Props) {
 
   const isSaving = updateUserMutation.isPending;
   const isDeleting = deleteUserMutation.isPending;
+  const isSendingReset = sendPasswordResetMutation.isPending;
 
   return (
     <form className="space-y-4" onSubmit={handleSubmit}>
@@ -185,10 +220,48 @@ export default function UserEditForm({ user }: Props) {
         <Label htmlFor="updateToken">Generate new hydro token</Label>
       </div>
 
-      <div className="flex gap-4">
+      <div className="flex flex-wrap gap-3">
         <Button type="submit" disabled={isSaving}>
           {isSaving ? "Saving..." : "Save Changes"}
         </Button>
+
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={isSendingReset}
+            >
+              <KeyRound />
+              {isSendingReset
+                ? t("admin.users.sendingReset", "Sending...")
+                : t("admin.users.sendReset", "Send password reset")}
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                {t("admin.users.confirmResetTitle", "Send password reset?")}
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                {t(
+                  "admin.users.confirmResetDescription",
+                  "Send a password reset link to {{email}}? The link will expire in 15 minutes.",
+                  { email: user.email }
+                )}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>{t("cancel", "Cancel")}</AlertDialogCancel>
+              <AlertDialogAction
+                type="button"
+                onClick={() => sendPasswordResetMutation.mutate()}
+              >
+                {t("admin.users.sendReset", "Send password reset")}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
 
         <AlertDialog>
           <AlertDialogTrigger asChild>

--- a/components/brews/BrewList.tsx
+++ b/components/brews/BrewList.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+export type BrewListDisplayItem = {
+  id: string;
+  name: string | null;
+  start_date: string | Date;
+  end_date: string | Date | null;
+  stage: string;
+  public?: boolean;
+  recipe_id: number | null;
+  recipe_name: string | null;
+  entry_count: number;
+  owner?: { displayName: string } | null;
+};
+
+export function BrewList({
+  brews,
+  detailHref,
+  recipeHref = (recipeId) => `/recipes/${recipeId}`,
+  loading = false,
+  loadingRows = 10,
+  showOwner = false,
+  showVisibility = false,
+  emptyMessage
+}: {
+  brews: BrewListDisplayItem[];
+  detailHref: (brewId: string) => string;
+  recipeHref?: (recipeId: number) => string;
+  loading?: boolean;
+  loadingRows?: number;
+  showOwner?: boolean;
+  showVisibility?: boolean;
+  emptyMessage?: string;
+}) {
+  const { t, i18n } = useTranslation();
+  const formatter = new Intl.DateTimeFormat(i18n.resolvedLanguage, {
+    dateStyle: "short",
+    timeStyle: "short"
+  });
+  const formatDate = (date: string | Date) => formatter.format(new Date(date));
+  const columnCount = 6 + (showOwner ? 1 : 0) + (showVisibility ? 1 : 0);
+
+  return (
+    <div className="w-full overflow-x-auto rounded-md border border-border bg-card">
+      <Table className="w-full">
+        <TableHeader>
+          <TableRow>
+            <TableHead
+              className={cn(
+                "sticky left-0 z-10 min-w-40 border-r bg-card",
+                "sm:min-w-64"
+              )}
+            >
+              {t("name")}
+            </TableHead>
+            {showOwner ? (
+              <TableHead>{t("admin.owner", "Owner")}</TableHead>
+            ) : null}
+            {showVisibility ? (
+              <TableHead>
+                {t("brews.visibility.label", "Visibility")}
+              </TableHead>
+            ) : null}
+            <TableHead>{t("brews.stage")}</TableHead>
+            <TableHead>{t("brews.recipe")}</TableHead>
+            <TableHead>{t("brews.startDate")}</TableHead>
+            <TableHead>{t("brews.endDate")}</TableHead>
+            <TableHead className="text-right">{t("brews.entries")}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {loading ? (
+            <BrewListSkeleton
+              rows={loadingRows}
+              showOwner={showOwner}
+              showVisibility={showVisibility}
+            />
+          ) : brews.length === 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={columnCount}
+                className="h-28 text-center text-muted-foreground"
+              >
+                {emptyMessage ?? t("brews.none")}
+              </TableCell>
+            </TableRow>
+          ) : (
+            brews.map((brew) => (
+              <TableRow key={brew.id}>
+                <TableCell className="sticky left-0 z-10 max-w-64 border-r bg-card font-medium">
+                  <Link
+                    href={detailHref(brew.id)}
+                    className="block truncate underline underline-offset-4"
+                    title={brew.name || brew.id}
+                  >
+                    {brew.name || brew.id}
+                  </Link>
+                </TableCell>
+                {showOwner ? (
+                  <TableCell className="whitespace-nowrap">
+                    {brew.owner?.displayName || "—"}
+                  </TableCell>
+                ) : null}
+                {showVisibility ? (
+                  <TableCell className="whitespace-nowrap">
+                    {brew.public
+                      ? t("brews.visibility.public", "Public")
+                      : t("brews.visibility.private", "Private")}
+                  </TableCell>
+                ) : null}
+                <TableCell className="whitespace-nowrap">
+                  {t(`brewStage.${brew.stage}`, brew.stage)}
+                </TableCell>
+                <TableCell>
+                  {brew.recipe_id ? (
+                    <Button asChild variant="secondary" size="sm">
+                      <Link href={recipeHref(brew.recipe_id)}>
+                        {brew.recipe_name || t("open")}
+                      </Link>
+                    </Button>
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+                </TableCell>
+                <TableCell className="whitespace-nowrap">
+                  {formatDate(brew.start_date)}
+                </TableCell>
+                <TableCell className="whitespace-nowrap">
+                  {brew.end_date ? formatDate(brew.end_date) : t("ongoing")}
+                </TableCell>
+                <TableCell className="text-right tabular-nums">
+                  {brew.entry_count ?? 0}
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function BrewListSkeleton({
+  rows,
+  showOwner,
+  showVisibility
+}: {
+  rows: number;
+  showOwner: boolean;
+  showVisibility?: boolean;
+}) {
+  return Array.from({ length: rows }).map((_, index) => (
+    <TableRow key={index}>
+      <TableCell className="sticky left-0 z-10 border-r bg-card">
+        <Skeleton className="h-4 w-40" />
+      </TableCell>
+      {showOwner ? (
+        <TableCell>
+          <Skeleton className="h-4 w-28" />
+        </TableCell>
+      ) : null}
+      {showVisibility ? (
+        <TableCell>
+          <Skeleton className="h-4 w-20" />
+        </TableCell>
+      ) : null}
+      <TableCell>
+        <Skeleton className="h-4 w-20" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-8 w-28" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-24" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-24" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="ml-auto h-4 w-8" />
+      </TableCell>
+    </TableRow>
+  ));
+}

--- a/components/brews/BrewStagePath.tsx
+++ b/components/brews/BrewStagePath.tsx
@@ -1,8 +1,30 @@
-import { BREW_ENTRY_TYPE, GRAVITY_UNITS, type BrewStage, type GravityUnit } from "@/lib/brewEnums";
-import { Path, PathActivePanel, PathContent, PathHeader, PathItem, PathList, PathTitle } from "@/components/ui/path";
+import {
+  BREW_ENTRY_TYPE,
+  GRAVITY_UNITS,
+  type BrewStage,
+  type GravityUnit
+} from "@/lib/brewEnums";
+import {
+  Path,
+  PathActivePanel,
+  PathContent,
+  PathHeader,
+  PathItem,
+  PathList,
+  PathTitle
+} from "@/components/ui/path";
 import { Button } from "@/components/ui/button";
-import { BREW_TRACKER_DIALOG_CONTENT_CLASS, BREW_TRACKER_DIALOG_FOOTER_CLASS } from "@/components/brews/brewTrackerDialog";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  BREW_TRACKER_DIALOG_CONTENT_CLASS,
+  BREW_TRACKER_DIALOG_FOOTER_CLASS
+} from "@/components/brews/brewTrackerDialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog";
 import { DateTimePicker } from "@/components/ui/datetime-picker";
 import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
@@ -38,6 +60,7 @@ type BrewStagePathProps = {
   addEntry: BrewStageHelpers["addEntry"];
   patchEntry?: BrewStageHelpers["patchEntry"];
   hasRecipeLinked: boolean;
+  readOnly?: boolean;
 };
 
 function idxOf(stage: BrewStage) {
@@ -66,31 +89,46 @@ export function BrewStagePath({
   addAdditions,
   addEntry,
   patchEntry,
-  hasRecipeLinked
+  hasRecipeLinked,
+  readOnly = false
 }: BrewStagePathProps) {
   const { t } = useTranslation();
   const router = useRouter();
   const currentIdx = idxOf(stage);
   const [activeId, setActiveId] = useState<BrewStage>(stage);
   const [recordVolumeOpen, setRecordVolumeOpen] = useState(false);
-  const [recordVolumeIntent, setRecordVolumeIntent] = useState<RecordVolumeIntent>("current");
+  const [recordVolumeIntent, setRecordVolumeIntent] =
+    useState<RecordVolumeIntent>("current");
   const [originalGravityOpen, setOriginalGravityOpen] = useState(false);
   const [reviewStage, setReviewStage] = useState<BrewStage | null>(null);
-  const [pendingStageMove, setPendingStageMove] = useState<BrewStage | null>(null);
+  const [pendingStageMove, setPendingStageMove] = useState<BrewStage | null>(
+    null
+  );
 
   const numericRecipeFg =
-    typeof recipe.recipeData?.fg === "string" ? Number(recipe.recipeData.fg) : recipe.recipeData?.fg;
-  const suggestedOg = recipe.actual.suggestedOriginalGravity ?? recipe.derived?.gravity.ogPrimary ?? null;
-  const suggestedOgSource = recipe.actual.suggestedOriginalGravitySource ?? "recipe";
+    typeof recipe.recipeData?.fg === "string"
+      ? Number(recipe.recipeData.fg)
+      : recipe.recipeData?.fg;
+  const suggestedOg =
+    recipe.actual.suggestedOriginalGravity ??
+    recipe.derived?.gravity.ogPrimary ??
+    null;
+  const suggestedOgSource =
+    recipe.actual.suggestedOriginalGravitySource ?? "recipe";
   const estimatedFg =
-    typeof numericRecipeFg === "number" && Number.isFinite(numericRecipeFg) && numericRecipeFg > 0
+    typeof numericRecipeFg === "number" &&
+    Number.isFinite(numericRecipeFg) &&
+    numericRecipeFg > 0
       ? numericRecipeFg
       : null;
   const fallbackRecordVolumeLiters =
     stage === "PRIMARY"
       ? (recipe.derived?.volume.primaryL ?? recipe.effective.currentVolumeL)
       : recipe.effective.currentVolumeL;
-  const recipeVolumeUnit = recipe.recipeData?.unitDefaults.volume ?? recipe.derived?.volume.unit ?? "gal";
+  const recipeVolumeUnit =
+    recipe.recipeData?.unitDefaults.volume ??
+    recipe.derived?.volume.unit ??
+    "gal";
 
   useEffect(() => {
     setActiveId(stage);
@@ -106,18 +144,34 @@ export function BrewStagePath({
       <PathHeader>
         <div className="space-y-0.5">
           <PathTitle>{t("stage", "Stage")}</PathTitle>
-          <div className="text-base font-semibold">{t(`brewStage.${stage}`)}</div>
+          <div className="text-base font-semibold">
+            {t(`brewStage.${stage}`)}
+          </div>
         </div>
 
-        <div className="text-sm text-muted-foreground">{t("brews.stagePathHint", "Click a stage to see actions.")}</div>
+        <div className="text-sm text-muted-foreground">
+          {t("brews.stagePathHint", "Click a stage to see actions.")}
+        </div>
       </PathHeader>
 
       <PathContent className="space-y-3">
         <PathList>
           {STAGE_FLOW.map((s, i) => {
-            const state = i < currentIdx ? "complete" : i === currentIdx ? "current" : "upcoming";
+            const state =
+              i < currentIdx
+                ? "complete"
+                : i === currentIdx
+                  ? "current"
+                  : "upcoming";
 
-            return <PathItem key={s} id={s} label={t(`brewStage.${s}`)} state={state} />;
+            return (
+              <PathItem
+                key={s}
+                id={s}
+                label={t(`brewStage.${s}`)}
+                state={state}
+              />
+            );
           })}
         </PathList>
 
@@ -144,7 +198,8 @@ export function BrewStagePath({
                 id: brewId,
                 entries,
                 current_volume_liters,
-                effective_current_volume_liters: recipe.effective.currentVolumeL,
+                effective_current_volume_liters:
+                  recipe.effective.currentVolumeL,
                 latest_gravity: recipe.actual.latestGravity,
                 effective_latest_gravity: recipe.effective.latestGravity
               }
@@ -161,18 +216,23 @@ export function BrewStagePath({
                 setReviewStage(to);
               },
               openRecordVolume: () => {
-                setRecordVolumeIntent(stage === "PRIMARY" ? "secondaryVolume" : "current");
+                setRecordVolumeIntent(
+                  stage === "PRIMARY" ? "secondaryVolume" : "current"
+                );
                 setRecordVolumeOpen(true);
               },
               openOriginalGravityDialog: () => setOriginalGravityOpen(true),
               openFinalGravityDialog: () => {
                 const recipeFg = recipe.recipeData?.fg;
-                const numericRecipeFg = typeof recipeFg === "string" ? Number(recipeFg) : recipeFg;
+                const numericRecipeFg =
+                  typeof recipeFg === "string" ? Number(recipeFg) : recipeFg;
                 openAddEntry?.({
                   presetType: BREW_ENTRY_TYPE.GRAVITY,
                   gravityRole: "FG",
                   gravityDefaultValue:
-                    typeof numericRecipeFg === "number" && Number.isFinite(numericRecipeFg) && numericRecipeFg > 0
+                    typeof numericRecipeFg === "number" &&
+                    Number.isFinite(numericRecipeFg) &&
+                    numericRecipeFg > 0
                       ? numericRecipeFg
                       : undefined,
                   gravitySource: "measured"
@@ -180,7 +240,11 @@ export function BrewStagePath({
               },
               acceptRecipeOriginalGravity: async () => {
                 const recipeOg = recipe.derived?.gravity.ogPrimary;
-                if (typeof recipeOg !== "number" || !Number.isFinite(recipeOg) || recipeOg <= 1) {
+                if (
+                  typeof recipeOg !== "number" ||
+                  !Number.isFinite(recipeOg) ||
+                  recipeOg <= 1
+                ) {
                   return;
                 }
                 await addEntry(
@@ -205,52 +269,73 @@ export function BrewStagePath({
             const moveDecision = getStageMoveDecision(s, stage, ctx);
             const unmet = moveDecision.unmet;
 
-            const actions = (cfg.actions ?? []).filter((a) => (a.when ? a.when(status, ctx) : true));
+            const actions = (cfg.actions ?? []).filter((a) =>
+              a.when ? a.when(status, ctx) : true
+            );
             const visiblePrereqs =
-              stage === "PRIMARY" && s === "SECONDARY" && !ctx.recipe.actual.originalGravity
+              stage === "PRIMARY" &&
+              s === "SECONDARY" &&
+              !ctx.recipe.actual.originalGravity
                 ? prereqs.filter((p) => p.id !== "primaryHasFinalGravity")
                 : prereqs;
 
             const Panel = cfg.Panel;
             const isBlocked = !moveDecision.allowed && !moveDecision.isNoOp;
-            const warnings = (cfg.warnings ?? []).filter((w) => w.isActive(ctx) && w.when(status, ctx));
+            const warnings = (cfg.warnings ?? []).filter(
+              (w) => w.isActive(ctx) && w.when(status, ctx)
+            );
             return (
               <div className="p-4 space-y-3">
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div className="font-medium">{cfg.title(t)}</div>
 
-                  <Button
-                    size="sm"
-                    onClick={async () => {
-                      if (stage === "PRIMARY" && s === "SECONDARY") {
-                        setReviewStage(s);
-                        return;
+                  {!readOnly ? (
+                    <Button
+                      size="sm"
+                      onClick={async () => {
+                        if (stage === "PRIMARY" && s === "SECONDARY") {
+                          setReviewStage(s);
+                          return;
+                        }
+                        if (!moveDecision.allowed) return;
+                        setPendingStageMove(s);
+                      }}
+                      disabled={
+                        moveDecision.isNoOp ||
+                        (isBlocked &&
+                          !(stage === "PRIMARY" && s === "SECONDARY"))
                       }
-                      if (!moveDecision.allowed) return;
-                      setPendingStageMove(s);
-                    }}
-                    disabled={moveDecision.isNoOp || (isBlocked && !(stage === "PRIMARY" && s === "SECONDARY"))}
-                    title={
-                      isBlocked
-                        ? t("brews.prereqsNotMet", "Some items are not complete yet.")
-                        : moveDecision.isNoOp
+                      title={
+                        isBlocked
+                          ? t(
+                              "brews.prereqsNotMet",
+                              "Some items are not complete yet."
+                            )
+                          : moveDecision.isNoOp
+                            ? t("brews.stayHere", "You are here")
+                            : undefined
+                      }
+                    >
+                      {status === "past"
+                        ? t("brews.moveBack", "Move back to this stage")
+                        : status === "current"
                           ? t("brews.stayHere", "You are here")
-                          : undefined
-                    }
-                  >
-                    {status === "past"
-                      ? t("brews.moveBack", "Move back to this stage")
-                      : status === "current"
-                        ? t("brews.stayHere", "You are here")
-                        : t("brews.moveToStage", "Move to this stage")}
-                  </Button>
+                          : t("brews.moveToStage", "Move to this stage")}
+                    </Button>
+                  ) : null}
                 </div>
 
-                {cfg.description ? <div className="text-sm text-muted-foreground">{cfg.description(t)}</div> : null}
+                {cfg.description ? (
+                  <div className="text-sm text-muted-foreground">
+                    {cfg.description(t)}
+                  </div>
+                ) : null}
 
                 {status === "future" && visiblePrereqs.length > 0 && (
                   <div className="space-y-2">
-                    <div className="text-sm font-medium">{t("brews.beforeYouProceed", "Before you proceed")}</div>
+                    <div className="text-sm font-medium">
+                      {t("brews.beforeYouProceed", "Before you proceed")}
+                    </div>
 
                     <ul className="text-sm text-muted-foreground list-disc pl-5">
                       {visiblePrereqs.map((p) => {
@@ -261,17 +346,29 @@ export function BrewStagePath({
                               <div className="min-w-0 flex-1">
                                 <span>{p.label(t)}</span>
                                 {!ok && p.hint ? (
-                                  <span className="block text-xs opacity-90 mt-1">{p.hint(t)}</span>
+                                  <span className="block text-xs opacity-90 mt-1">
+                                    {p.hint(t)}
+                                  </span>
                                 ) : null}
                               </div>
 
-                              {!ok && p.id === "primaryHasGravity" ? (
-                                <Button size="sm" variant="secondary" onClick={() => p.run?.(helpers, ctx)}>
+                              {!readOnly &&
+                              !ok &&
+                              p.id === "primaryHasGravity" ? (
+                                <Button
+                                  size="sm"
+                                  variant="secondary"
+                                  onClick={() => p.run?.(helpers, ctx)}
+                                >
                                   {t("brews.actions.logOg", "Log OG")}
                                 </Button>
                               ) : null}
 
-                              {!ok && p.id !== "primaryHasGravity" && p.run && p.actionLabel ? (
+                              {!readOnly &&
+                              !ok &&
+                              p.id !== "primaryHasGravity" &&
+                              p.run &&
+                              p.actionLabel ? (
                                 <Button
                                   size="sm"
                                   variant="secondary"
@@ -289,15 +386,20 @@ export function BrewStagePath({
 
                     {unmet.length > 0 && (
                       <div className="text-xs text-muted-foreground">
-                        {t("brews.prereqsNotMet", "Some items are not complete yet.")}
+                        {t(
+                          "brews.prereqsNotMet",
+                          "Some items are not complete yet."
+                        )}
                       </div>
                     )}
                   </div>
                 )}
 
-                {actions.length > 0 && (
+                {!readOnly && actions.length > 0 && (
                   <div className="space-y-2">
-                    <div className="text-sm font-medium">{t("brews.actionsLabel", "Actions")}</div>
+                    <div className="text-sm font-medium">
+                      {t("brews.actionsLabel", "Actions")}
+                    </div>
                     <div className="flex flex-wrap gap-2">
                       {actions.map((a) => (
                         <Button
@@ -313,112 +415,148 @@ export function BrewStagePath({
                   </div>
                 )}
 
-                {Panel ? <Panel t={t} status={status} ctx={ctx} helpers={helpers} warnings={warnings} /> : null}
+                {Panel ? (
+                  <div
+                    className={
+                      readOnly ? "[&_button:disabled]:hidden" : undefined
+                    }
+                  >
+                    <Panel
+                      t={t}
+                      status={status}
+                      ctx={ctx}
+                      helpers={helpers}
+                      warnings={warnings}
+                      readOnly={readOnly}
+                    />
+                  </div>
+                ) : null}
 
                 {!Panel && warnings.length > 0 && (
                   <div className="space-y-2">
                     {warnings.map((w) => (
-                      <div key={w.id} className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3 text-sm">
+                      <div
+                        key={w.id}
+                        className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3 text-sm"
+                      >
                         {w.message(t)}
                       </div>
                     ))}
                   </div>
                 )}
 
-                <StageMoveReviewDialog
-                  open={reviewStage === s}
-                  onOpenChange={(open) => {
-                    if (!open) setReviewStage(null);
-                  }}
-                  title={t("brews.moveToSecondary", "Move to Secondary")}
-                  required={STAGE_CONFIG.SECONDARY.prereqs ?? []}
-                  warnings={STAGE_CONFIG.PRIMARY.warnings ?? []}
-                  ctx={ctx}
-                  helpers={helpers}
-                  onMove={async (stageChangeDatetime) => {
-                    const decision = getStageMoveDecision("SECONDARY", stage, ctx);
-                    if (!decision.allowed) return;
-                    await onMoveToStage("SECONDARY", stageChangeDatetime);
-                    setActiveId("SECONDARY");
-                    setReviewStage(null);
-                  }}
-                />
-                <StageMoveDateDialog
-                  open={pendingStageMove === s}
-                  onOpenChange={(open) => {
-                    if (!open) setPendingStageMove(null);
-                  }}
-                  title={
-                    status === "past"
-                      ? t("brews.moveBack", "Move back to this stage")
-                      : t("brews.moveToStage", "Move to this stage")
-                  }
-                  onMove={async (datetime) => {
-                    await onMoveToStage(s, datetime);
-                    setActiveId(s);
-                    setPendingStageMove(null);
-                  }}
-                />
+                {!readOnly ? (
+                  <StageMoveReviewDialog
+                    open={reviewStage === s}
+                    onOpenChange={(open) => {
+                      if (!open) setReviewStage(null);
+                    }}
+                    title={t("brews.moveToSecondary", "Move to Secondary")}
+                    required={STAGE_CONFIG.SECONDARY.prereqs ?? []}
+                    warnings={STAGE_CONFIG.PRIMARY.warnings ?? []}
+                    ctx={ctx}
+                    helpers={helpers}
+                    onMove={async (stageChangeDatetime) => {
+                      const decision = getStageMoveDecision(
+                        "SECONDARY",
+                        stage,
+                        ctx
+                      );
+                      if (!decision.allowed) return;
+                      await onMoveToStage("SECONDARY", stageChangeDatetime);
+                      setActiveId("SECONDARY");
+                      setReviewStage(null);
+                    }}
+                  />
+                ) : null}
+                {!readOnly ? (
+                  <StageMoveDateDialog
+                    open={pendingStageMove === s}
+                    onOpenChange={(open) => {
+                      if (!open) setPendingStageMove(null);
+                    }}
+                    title={
+                      status === "past"
+                        ? t("brews.moveBack", "Move back to this stage")
+                        : t("brews.moveToStage", "Move to this stage")
+                    }
+                    onMove={async (datetime) => {
+                      await onMoveToStage(s, datetime);
+                      setActiveId(s);
+                      setPendingStageMove(null);
+                    }}
+                  />
+                ) : null}
               </div>
             );
           }}
         />
-        <RecordVolumeDialog
-          t={t}
-          open={recordVolumeOpen}
-          onOpenChange={setRecordVolumeOpen}
-          currentVolumeLiters={current_volume_liters ?? fallbackRecordVolumeLiters}
-          defaultVolumeUnit={recipeVolumeUnit}
-          intent={recordVolumeIntent}
-          onSave={async (volume, meta) => {
-            await patchBrewMetadata({ current_volume_liters: volume });
-            await addEntry(
-              entryPayload.volume({
-                liters: volume,
-                displayValue: meta.displayValue,
-                displayUnit: meta.displayUnit,
-                startingLiters: meta.startingLiters,
-                datetime: meta.datetime
-              })
-            );
-          }}
-        />
-        <LogOriginalGravityDialog
-          open={originalGravityOpen}
-          onOpenChange={setOriginalGravityOpen}
-          suggestedOg={
-            typeof suggestedOg === "number" && Number.isFinite(suggestedOg) && suggestedOg > 1 ? suggestedOg : null
-          }
-          suggestedOgSource={suggestedOgSource}
-          estimatedFg={estimatedFg}
-          gravityUnitPreference={gravity_unit_preference}
-          onSave={async (input) => {
-            await addEntry(
-              entryPayload.gravity(input.chosenOg, input.note ?? null, {
-                readingRole: "OG",
-                source: "measured",
-                datetime: input.datetime,
-                display: input.ogDisplay
-              })
-            );
-            await addEntry(
-              entryPayload.gravity(input.fermentableSg, null, {
-                readingRole: "GENERAL",
-                source: "nutrient_basis",
-                hidden: true,
-                datetime: input.datetime,
-                nutrientBasis: {
-                  chosenOg: input.chosenOg,
-                  suggestedOg: input.suggestedOg,
-                  suggestedOgSource: input.suggestedOgSource,
-                  estimatedFg: input.estimatedFg,
-                  fermentableSg: input.fermentableSg,
-                  warningAcknowledged: input.warningAcknowledged
-                }
-              })
-            );
-          }}
-        />
+        {!readOnly ? (
+          <RecordVolumeDialog
+            t={t}
+            open={recordVolumeOpen}
+            onOpenChange={setRecordVolumeOpen}
+            currentVolumeLiters={
+              current_volume_liters ?? fallbackRecordVolumeLiters
+            }
+            defaultVolumeUnit={recipeVolumeUnit}
+            intent={recordVolumeIntent}
+            onSave={async (volume, meta) => {
+              await patchBrewMetadata({ current_volume_liters: volume });
+              await addEntry(
+                entryPayload.volume({
+                  liters: volume,
+                  displayValue: meta.displayValue,
+                  displayUnit: meta.displayUnit,
+                  startingLiters: meta.startingLiters,
+                  datetime: meta.datetime
+                })
+              );
+            }}
+          />
+        ) : null}
+        {!readOnly ? (
+          <LogOriginalGravityDialog
+            open={originalGravityOpen}
+            onOpenChange={setOriginalGravityOpen}
+            suggestedOg={
+              typeof suggestedOg === "number" &&
+              Number.isFinite(suggestedOg) &&
+              suggestedOg > 1
+                ? suggestedOg
+                : null
+            }
+            suggestedOgSource={suggestedOgSource}
+            estimatedFg={estimatedFg}
+            gravityUnitPreference={gravity_unit_preference}
+            onSave={async (input) => {
+              await addEntry(
+                entryPayload.gravity(input.chosenOg, input.note ?? null, {
+                  readingRole: "OG",
+                  source: "measured",
+                  datetime: input.datetime,
+                  display: input.ogDisplay
+                })
+              );
+              await addEntry(
+                entryPayload.gravity(input.fermentableSg, null, {
+                  readingRole: "GENERAL",
+                  source: "nutrient_basis",
+                  hidden: true,
+                  datetime: input.datetime,
+                  nutrientBasis: {
+                    chosenOg: input.chosenOg,
+                    suggestedOg: input.suggestedOg,
+                    suggestedOgSource: input.suggestedOgSource,
+                    estimatedFg: input.estimatedFg,
+                    fermentableSg: input.fermentableSg,
+                    warningAcknowledged: input.warningAcknowledged
+                  }
+                })
+              );
+            }}
+          />
+        ) : null}
       </PathContent>
     </Path>
   );
@@ -454,16 +592,26 @@ function StageMoveDateDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[480px]`}>
+      <DialogContent
+        className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[480px]`}
+      >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
         <div className="space-y-2">
           <div className="text-sm font-medium">{t("date", "Date")}</div>
-          <DateTimePicker value={datetime} onChange={(value) => value && setDatetime(value)} hourCycle={12} />
+          <DateTimePicker
+            value={datetime}
+            onChange={(value) => value && setDatetime(value)}
+            hourCycle={12}
+          />
         </div>
         <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
-          <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
+          <Button
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            disabled={isSaving}
+          >
             {t("cancel", "Cancel")}
           </Button>
           <Button onClick={move} disabled={isSaving}>
@@ -498,10 +646,17 @@ function StageMoveReviewDialog({
   const [yeastOpen, setYeastOpen] = useState(false);
   const [datetime, setDatetime] = useState<Date>(new Date());
   const unmet = required.filter((item) => !item.isMet(ctx));
-  const hasOriginalGravity = required.find((item) => item.id === "primaryHasGravity")?.isMet(ctx) ?? true;
-  const visibleRequired = required.filter((item) => item.id !== "primaryHasFinalGravity" || hasOriginalGravity);
+  const hasOriginalGravity =
+    required.find((item) => item.id === "primaryHasGravity")?.isMet(ctx) ??
+    true;
+  const visibleRequired = required.filter(
+    (item) => item.id !== "primaryHasFinalGravity" || hasOriginalGravity
+  );
   const activeWarnings = warnings
-    .filter((warning, index, all) => all.findIndex((item) => item.id === warning.id) === index)
+    .filter(
+      (warning, index, all) =>
+        all.findIndex((item) => item.id === warning.id) === index
+    )
     .filter((warning) => warning.isActive(ctx));
   const canMove = unmet.length === 0;
 
@@ -511,14 +666,18 @@ function StageMoveReviewDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[560px]`}>
+      <DialogContent
+        className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[560px]`}
+      >
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
 
         <div className="space-y-4">
           <div className="space-y-2">
-            <div className="text-sm font-medium">{t("brews.requiredBeforeMoving", "Required before moving")}</div>
+            <div className="text-sm font-medium">
+              {t("brews.requiredBeforeMoving", "Required before moving")}
+            </div>
             <ul className="space-y-2">
               {visibleRequired.map((item) => {
                 const ok = item.isMet(ctx);
@@ -533,21 +692,38 @@ function StageMoveReviewDialog({
                         {item.label(t)}
                       </span>
                       {!ok && item.hint ? (
-                        <div className="mt-1 text-xs text-muted-foreground">{item.hint(t)}</div>
+                        <div className="mt-1 text-xs text-muted-foreground">
+                          {item.hint(t)}
+                        </div>
                       ) : null}
                     </div>
                     {!ok && item.id === "primaryHasGravity" ? (
-                      <Button size="sm" variant="secondary" onClick={() => item.run?.(helpers, ctx)}>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => item.run?.(helpers, ctx)}
+                      >
                         {t("brews.actions.logOg", "Log OG")}
                       </Button>
                     ) : null}
                     {!ok && item.id === "primaryHasYeast" ? (
-                      <Button size="sm" variant="secondary" onClick={() => setYeastOpen(true)}>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => setYeastOpen(true)}
+                      >
                         {t("brews.actions.logYeast", "Log yeast")}
                       </Button>
                     ) : null}
-                    {!ok && item.id !== "primaryHasGravity" && item.run && item.actionLabel ? (
-                      <Button size="sm" variant="secondary" onClick={() => item.run?.(helpers, ctx)}>
+                    {!ok &&
+                    item.id !== "primaryHasGravity" &&
+                    item.run &&
+                    item.actionLabel ? (
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => item.run?.(helpers, ctx)}
+                      >
                         {item.actionLabel(t)}
                       </Button>
                     ) : null}
@@ -558,7 +734,9 @@ function StageMoveReviewDialog({
           </div>
 
           <div className="space-y-2">
-            <div className="text-sm font-medium">{t("brews.warnings", "Warnings")}</div>
+            <div className="text-sm font-medium">
+              {t("brews.warnings", "Warnings")}
+            </div>
             {activeWarnings.length ? (
               <ul className="space-y-2">
                 {activeWarnings.map((warning) => (
@@ -571,13 +749,19 @@ function StageMoveReviewDialog({
                 ))}
               </ul>
             ) : (
-              <div className="text-sm text-muted-foreground">{t("brews.noWarnings", "No active warnings.")}</div>
+              <div className="text-sm text-muted-foreground">
+                {t("brews.noWarnings", "No active warnings.")}
+              </div>
             )}
           </div>
 
           <div className="space-y-2">
             <div className="text-sm font-medium">{t("date", "Date")}</div>
-            <DateTimePicker value={datetime} onChange={(value) => value && setDatetime(value)} hourCycle={12} />
+            <DateTimePicker
+              value={datetime}
+              onChange={(value) => value && setDatetime(value)}
+              hourCycle={12}
+            />
           </div>
         </div>
 
@@ -585,7 +769,10 @@ function StageMoveReviewDialog({
           <Button variant="secondary" onClick={() => onOpenChange(false)}>
             {t("cancel", "Cancel")}
           </Button>
-          <Button disabled={!canMove} onClick={() => onMove(datetime.toISOString())}>
+          <Button
+            disabled={!canMove}
+            onClick={() => onMove(datetime.toISOString())}
+          >
             {t("brews.moveToSecondary", "Move to Secondary")}
           </Button>
         </DialogFooter>

--- a/components/brews/BrewTimelineCharts.tsx
+++ b/components/brews/BrewTimelineCharts.tsx
@@ -4,15 +4,15 @@ import { type ReactNode, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import Link from "next/link";
 
-import type {
-  AccountBrewEntry,
-  AccountBrewLinkedDevice
-} from "@/hooks/reactQuery/useAccountBrews";
+import type { AccountBrewLinkedDevice } from "@/hooks/reactQuery/useAccountBrews";
 import {
   useLinkHydrometerDeviceToAccountBrew,
   useUnlinkHydrometerDeviceFromAccountBrew
 } from "@/hooks/reactQuery/useAccountBrews";
-import { useHydrometerInfo, type Device } from "@/hooks/reactQuery/useHydrometerInfo";
+import {
+  useHydrometerInfo,
+  type Device
+} from "@/hooks/reactQuery/useHydrometerInfo";
 import { useBrewLogs, type Log } from "@/hooks/reactQuery/useHydrometerLogs";
 import {
   HydrometerData,
@@ -20,12 +20,44 @@ import {
   type TempUnits
 } from "@/components/ispindel/HydrometerData";
 import { Button } from "@/components/ui/button";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger
+} from "@/components/ui/accordion";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
 import { toast } from "@/hooks/use-toast";
 import { BREW_ENTRY_TYPE } from "@/lib/brewEnums";
 import { calcABV } from "@/lib/utils/unitConverter";
+import type { BrewViewEntry, BrewViewLog } from "@/types/brewView";
+
+type WirelessLog = {
+  datetime: string;
+  temperature: number;
+  temp_units?: BrewViewLog["temp_units"];
+  battery?: number | null;
+  gravity: number;
+  calculated_gravity: number | null;
+};
+
+type BrewChartEntry = Pick<
+  BrewViewEntry,
+  "datetime" | "type" | "gravity" | "temperature" | "temp_units" | "data"
+>;
 
 function getTime(value: string) {
   const time = new Date(value).getTime();
@@ -36,12 +68,14 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
-function getManualTemperatureUnits(entries: AccountBrewEntry[]): TempUnits {
+function getManualTemperatureUnits(entries: BrewChartEntry[]): TempUnits {
   const entryUnits = entries.find(
     (entry) =>
       entry.type === BREW_ENTRY_TYPE.TEMPERATURE &&
       isFiniteNumber(entry.temperature) &&
-      (entry.temp_units === "F" || entry.temp_units === "C" || entry.temp_units === "K")
+      (entry.temp_units === "F" ||
+        entry.temp_units === "C" ||
+        entry.temp_units === "K")
   )?.temp_units;
 
   if (entryUnits === "F" || entryUnits === "C" || entryUnits === "K") {
@@ -51,15 +85,18 @@ function getManualTemperatureUnits(entries: AccountBrewEntry[]): TempUnits {
   return "F";
 }
 
-function getWirelessTemperatureUnits(logs: Log[]): TempUnits {
+function getWirelessTemperatureUnits(logs: WirelessLog[]): TempUnits {
   const logUnits = logs.find(
-    (log) => log.temp_units === "F" || log.temp_units === "C" || log.temp_units === "K"
+    (log) =>
+      log.temp_units === "F" || log.temp_units === "C" || log.temp_units === "K"
   )?.temp_units;
 
   return logUnits ?? "F";
 }
 
-export function buildManualBrewChartData(entries: AccountBrewEntry[]): HydrometerChartData[] {
+export function buildManualBrewChartData(
+  entries: BrewChartEntry[]
+): HydrometerChartData[] {
   const points: HydrometerChartData[] = [];
 
   for (const entry of entries) {
@@ -74,7 +111,9 @@ export function buildManualBrewChartData(entries: AccountBrewEntry[]): Hydromete
     } | null;
 
     if (data?.source === "abv_estimate") {
-      const abv = isFiniteNumber(data.abvEstimate?.abv) ? data.abvEstimate.abv : entry.gravity;
+      const abv = isFiniteNumber(data.abvEstimate?.abv)
+        ? data.abvEstimate.abv
+        : entry.gravity;
       if (isFiniteNumber(abv)) {
         points.push({
           date: entry.datetime,
@@ -86,14 +125,20 @@ export function buildManualBrewChartData(entries: AccountBrewEntry[]): Hydromete
 
     if (data?.hidden) continue;
 
-    if (entry.type === BREW_ENTRY_TYPE.GRAVITY && isFiniteNumber(entry.gravity)) {
+    if (
+      entry.type === BREW_ENTRY_TYPE.GRAVITY &&
+      isFiniteNumber(entry.gravity)
+    ) {
       points.push({
         date: entry.datetime,
         gravity: entry.gravity
       });
     }
 
-    if (entry.type === BREW_ENTRY_TYPE.TEMPERATURE && isFiniteNumber(entry.temperature)) {
+    if (
+      entry.type === BREW_ENTRY_TYPE.TEMPERATURE &&
+      isFiniteNumber(entry.temperature)
+    ) {
       points.push({
         date: entry.datetime,
         temperature: entry.temperature
@@ -129,11 +174,19 @@ export function buildManualBrewChartData(entries: AccountBrewEntry[]): Hydromete
     .sort((a, b) => getTime(a.date) - getTime(b.date));
 }
 
-export function buildWirelessHydrometerChartData(logs: Log[]): HydrometerChartData[] {
+export function buildWirelessHydrometerChartData(
+  logs: WirelessLog[]
+): HydrometerChartData[] {
   const points: HydrometerChartData[] = [];
-  const sortedLogs = [...logs].sort((a, b) => getTime(a.datetime) - getTime(b.datetime));
+  const sortedLogs = [...logs].sort(
+    (a, b) => getTime(a.datetime) - getTime(b.datetime)
+  );
   const deviceOriginalGravity = sortedLogs
-    .map((log) => (isFiniteNumber(log.calculated_gravity) ? log.calculated_gravity : log.gravity))
+    .map((log) =>
+      isFiniteNumber(log.calculated_gravity)
+        ? log.calculated_gravity
+        : log.gravity
+    )
     .find(isFiniteNumber);
 
   for (const log of sortedLogs) {
@@ -150,7 +203,9 @@ export function buildWirelessHydrometerChartData(logs: Log[]): HydrometerChartDa
     points.push({
       date: log.datetime,
       gravity: isFiniteNumber(gravity) ? gravity : undefined,
-      temperature: isFiniteNumber(log.temperature) ? log.temperature : undefined,
+      temperature: isFiniteNumber(log.temperature)
+        ? log.temperature
+        : undefined,
       battery: isFiniteNumber(log.battery) ? log.battery : undefined,
       ...(isFiniteNumber(abv) ? { abv: Math.max(abv, 0) } : {})
     });
@@ -172,16 +227,10 @@ export function BrewTimelineCharts({
   linkedDevices
 }: {
   brewId: string;
-  entries: AccountBrewEntry[];
+  entries: BrewChartEntry[];
   linkedDevices: AccountBrewLinkedDevice[];
 }) {
-  const { t } = useTranslation();
   const { data: logs = [], isLoading: logsLoading } = useBrewLogs(brewId);
-
-  const manualChartData = useMemo(() => buildManualBrewChartData(entries), [entries]);
-  const wirelessChartData = useMemo(() => buildWirelessHydrometerChartData(logs), [logs]);
-  const manualTempUnits = useMemo(() => getManualTemperatureUnits(entries), [entries]);
-  const wirelessTempUnits = useMemo(() => getWirelessTemperatureUnits(logs), [logs]);
 
   return (
     <div className="space-y-4">
@@ -192,13 +241,59 @@ export function BrewTimelineCharts({
         logsLoading={logsLoading}
       />
 
+      <BrewTimelineChartsView
+        entries={entries}
+        logs={logs}
+        logsLoading={logsLoading}
+      />
+    </div>
+  );
+}
+
+export function BrewTimelineChartsView({
+  entries,
+  logs,
+  logsLoading = false
+}: {
+  entries: BrewChartEntry[];
+  logs: WirelessLog[];
+  logsLoading?: boolean;
+}) {
+  const { t } = useTranslation();
+  const manualChartData = useMemo(
+    () => buildManualBrewChartData(entries),
+    [entries]
+  );
+  const wirelessChartData = useMemo(
+    () => buildWirelessHydrometerChartData(logs),
+    [logs]
+  );
+  const manualTempUnits = useMemo(
+    () => getManualTemperatureUnits(entries),
+    [entries]
+  );
+  const wirelessTempUnits = useMemo(
+    () => getWirelessTemperatureUnits(logs),
+    [logs]
+  );
+
+  return (
+    <div className="space-y-4">
       {logsLoading || wirelessChartData.length ? (
-        <ChartSection title={t("brews.charts.wirelessTitle", "Wireless hydrometer readings")}>
+        <ChartSection
+          title={t(
+            "brews.charts.wirelessTitle",
+            "Wireless hydrometer readings"
+          )}
+        >
           <HydrometerData
             chartData={wirelessChartData}
             tempUnits={wirelessTempUnits}
             loading={logsLoading}
-            name={t("brews.charts.wirelessTitle", "Wireless hydrometer readings")}
+            name={t(
+              "brews.charts.wirelessTitle",
+              "Wireless hydrometer readings"
+            )}
           />
         </ChartSection>
       ) : (
@@ -211,7 +306,9 @@ export function BrewTimelineCharts({
       )}
 
       {manualChartData.length ? (
-        <ChartSection title={t("brews.charts.manualTitle", "Manual timeline readings")}>
+        <ChartSection
+          title={t("brews.charts.manualTitle", "Manual timeline readings")}
+        >
           <HydrometerData
             chartData={manualChartData}
             tempUnits={manualTempUnits}
@@ -265,10 +362,16 @@ function HydrometerLinkPanel({
   const devices = hydrometerInfo?.devices ?? [];
   const linkableDevices = devices.filter((device) => !device.brew_id);
   const [selectedDeviceId, setSelectedDeviceId] = useState("");
-  const selectedDevice = linkableDevices.find((device) => device.id === selectedDeviceId);
+  const selectedDevice = linkableDevices.find(
+    (device) => device.id === selectedDeviceId
+  );
   const hasActiveLinkedDevice = linkedDevices.length > 0;
-  const linkedNames = linkedDevices.map((device) => device.device_name || device.id).join(", ");
-  const logDeviceIds = Array.from(new Set(logs.map((log) => log.device_id).filter(Boolean)));
+  const linkedNames = linkedDevices
+    .map((device) => device.device_name || device.id)
+    .join(", ");
+  const logDeviceIds = Array.from(
+    new Set(logs.map((log) => log.device_id).filter(Boolean))
+  );
   const logDeviceNames = logDeviceIds.map((deviceId) => {
     const device = devices.find((item) => item.id === deviceId);
     return device?.device_name || deviceId;
@@ -280,14 +383,23 @@ function HydrometerLinkPanel({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{t("brews.charts.hydrometerLinkTitle", "Wireless hydrometer")}</CardTitle>
+        <CardTitle>
+          {t("brews.charts.hydrometerLinkTitle", "Wireless hydrometer")}
+        </CardTitle>
         <CardDescription className="space-y-1">
           <span className="block">
             {linkedDevices.length
-              ? t("brews.charts.activeLinkedDevices", "Active device: {{devices}}", {
-                  devices: linkedNames
-                })
-              : t("brews.charts.noActiveLinkedDevice", "No active wireless hydrometer device is attached to this brew.")}
+              ? t(
+                  "brews.charts.activeLinkedDevices",
+                  "Active device: {{devices}}",
+                  {
+                    devices: linkedNames
+                  }
+                )
+              : t(
+                  "brews.charts.noActiveLinkedDevice",
+                  "No active wireless hydrometer device is attached to this brew."
+                )}
           </span>
           {logDeviceNames.length ? (
             <span className="block">
@@ -343,21 +455,32 @@ function HydrometerLinkPanel({
           </>
         ) : logsLoading ? (
           <div className="text-sm text-muted-foreground">
-            {t("brews.charts.checkingWirelessBrew", "Checking wireless hydrometer status...")}
+            {t(
+              "brews.charts.checkingWirelessBrew",
+              "Checking wireless hydrometer status..."
+            )}
           </div>
         ) : (
           <>
             <Select
               value={selectedDeviceId}
               onValueChange={setSelectedDeviceId}
-              disabled={isLoading || linkDevice.isPending || !linkableDevices.length}
+              disabled={
+                isLoading || linkDevice.isPending || !linkableDevices.length
+              }
             >
               <SelectTrigger className="w-full sm:max-w-md">
                 <SelectValue
                   placeholder={
                     linkableDevices.length
-                      ? t("brews.charts.selectDevice", "Select a hydrometer device")
-                      : t("brews.charts.noAvailableDevices", "No available hydrometer devices")
+                      ? t(
+                          "brews.charts.selectDevice",
+                          "Select a hydrometer device"
+                        )
+                      : t(
+                          "brews.charts.noAvailableDevices",
+                          "No available hydrometer devices"
+                        )
                   }
                 />
               </SelectTrigger>

--- a/components/brews/BrewViewer.tsx
+++ b/components/brews/BrewViewer.tsx
@@ -1,0 +1,524 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Filter, LockKeyhole, X } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { BrewStagePath } from "@/components/brews/BrewStagePath";
+import { BrewTimelineChartsView } from "@/components/brews/BrewTimelineCharts";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { BREW_ENTRY_TYPE, type BrewStage } from "@/lib/brewEnums";
+import { buildBrewRecipeStageData } from "@/lib/utils/buildBrewRecipeStageData";
+import { formatSgDisplay } from "@/lib/utils/gravityFormatting";
+import { L_TO_VOLUME } from "@/lib/utils/recipeDataCalculations";
+import { calcABV } from "@/lib/utils/unitConverter";
+import type {
+  BrewViewCapabilities,
+  BrewViewDetail,
+  BrewViewEntry
+} from "@/types/brewView";
+import { READ_ONLY_BREW_CAPABILITIES } from "@/types/brewView";
+
+type HistoryFilter =
+  | "readings"
+  | "additions"
+  | "volume"
+  | "notes"
+  | "stageChanges"
+  | "packaging";
+type MetricGroup = "readings" | "additions" | "volume";
+
+const FILTER_TYPES: Record<HistoryFilter, string[]> = {
+  readings: [
+    BREW_ENTRY_TYPE.GRAVITY,
+    BREW_ENTRY_TYPE.TEMPERATURE,
+    BREW_ENTRY_TYPE.PH
+  ],
+  additions: [BREW_ENTRY_TYPE.ADDITION],
+  volume: [BREW_ENTRY_TYPE.VOLUME],
+  notes: [BREW_ENTRY_TYPE.NOTE, BREW_ENTRY_TYPE.TASTING, BREW_ENTRY_TYPE.ISSUE],
+  stageChanges: [BREW_ENTRY_TYPE.STAGE_CHANGE],
+  packaging: [BREW_ENTRY_TYPE.PACKAGING]
+};
+
+const noopAsync = async () => undefined;
+
+function isHistoryFilter(value: string): value is HistoryFilter {
+  return Object.prototype.hasOwnProperty.call(FILTER_TYPES, value);
+}
+
+export function BrewViewer({
+  brew,
+  capabilities = READ_ONLY_BREW_CAPABILITIES,
+  backHref,
+  recipeHref,
+  backLabelKey = "back"
+}: {
+  brew: BrewViewDetail;
+  capabilities?: BrewViewCapabilities;
+  backHref: string;
+  recipeHref?: string | null;
+  backLabelKey?: string;
+}) {
+  const { t, i18n } = useTranslation();
+  const [filters, setFilters] = useState<HistoryFilter[]>([]);
+  const [newestFirst, setNewestFirst] = useState(true);
+  const readOnly = !Object.values(capabilities).some(Boolean);
+  const dateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(i18n.resolvedLanguage, {
+        dateStyle: "medium",
+        timeStyle: "short"
+      }),
+    [i18n.resolvedLanguage]
+  );
+  const formatDate = (value: string | null) =>
+    value ? dateFormatter.format(new Date(value)) : "-";
+  const visibleEntries = useMemo(
+    () =>
+      brew.entries.filter(
+        (entry) => !(entry.data as { hidden?: boolean } | null)?.hidden
+      ),
+    [brew.entries]
+  );
+  const filteredBuckets = useMemo(
+    () =>
+      brew.entries_by_stage
+        .map((bucket) => ({
+          ...bucket,
+          entries: bucket.entries
+            .filter(
+              (entry) => !(entry.data as { hidden?: boolean } | null)?.hidden
+            )
+            .filter((entry) =>
+              filters.length === 0
+                ? true
+                : filters.some((filter) =>
+                    FILTER_TYPES[filter].includes(entry.type)
+                  )
+            )
+            .sort((a, b) => {
+              const difference =
+                new Date(a.datetime).getTime() - new Date(b.datetime).getTime();
+              return newestFirst ? -difference : difference;
+            })
+        }))
+        .filter((bucket) => bucket.entries.length > 0),
+    [brew.entries_by_stage, filters, newestFirst]
+  );
+  const recipe = useMemo(
+    () =>
+      buildBrewRecipeStageData({
+        recipeSnapshot: brew.recipe_snapshot,
+        currentVolumeLiters: brew.current_volume_liters,
+        latestGravity: brew.latest_gravity,
+        entries: brew.entries
+      }),
+    [
+      brew.current_volume_liters,
+      brew.entries,
+      brew.latest_gravity,
+      brew.recipe_snapshot
+    ]
+  );
+  const actualOg = recipe.actual.originalGravity?.gravity ?? null;
+  const actualFg = recipe.actual.finalGravity?.gravity ?? null;
+  const actualAbv =
+    actualOg && actualFg
+      ? calcABV(actualOg, actualFg)
+      : recipe.actual.currentAbv;
+  const recipeUnit =
+    recipe.recipeData?.unitDefaults.volume ??
+    recipe.derived?.volume.unit ??
+    "gal";
+  const formatVolume = (liters: number | null) => {
+    if (liters == null) return "-";
+    const conversion = L_TO_VOLUME[recipeUnit];
+    return conversion
+      ? `${(liters * conversion).toFixed(2)} ${recipeUnit}`
+      : `${liters.toFixed(2)} L`;
+  };
+  const formatGravity = (gravity: number | null) =>
+    gravity == null ? "-" : formatSgDisplay(gravity);
+  const metricGroups = useMemo(() => {
+    const groups: Record<MetricGroup, BrewViewEntry[]> = {
+      readings: [],
+      additions: [],
+      volume: []
+    };
+    for (const entry of visibleEntries) {
+      if (FILTER_TYPES.readings.includes(entry.type))
+        groups.readings.push(entry);
+      if (FILTER_TYPES.additions.includes(entry.type))
+        groups.additions.push(entry);
+      if (
+        FILTER_TYPES.volume.includes(entry.type) ||
+        FILTER_TYPES.packaging.includes(entry.type)
+      ) {
+        groups.volume.push(entry);
+      }
+    }
+    return groups;
+  }, [visibleEntries]);
+
+  const summary = [
+    [
+      t("batchNumber", "Batch"),
+      brew.batch_number == null ? "-" : `#${brew.batch_number}`
+    ],
+    [t("start", "Start"), formatDate(brew.start_date)],
+    [
+      t("end", "End"),
+      brew.end_date ? formatDate(brew.end_date) : t("ongoing", "Ongoing")
+    ],
+    [
+      t("brews.volume.currentVolume", "Current volume"),
+      formatVolume(brew.current_volume_liters)
+    ],
+    [
+      t("iSpindelDashboard.brews.latestGrav", "Latest gravity"),
+      formatGravity(brew.latest_gravity)
+    ],
+    [t("brews.entries", "Entries"), String(brew.entry_count)]
+  ];
+  const recipeSummary = [
+    [
+      t("recipeBuilder.resultsLabels.estOG", "Estimated OG"),
+      formatGravity(recipe.derived?.gravity.ogPrimary ?? null)
+    ],
+    [
+      t("recipeBuilder.resultsLabels.estFG", "Estimated FG"),
+      formatGravity(Number(recipe.recipeData?.fg) || null)
+    ],
+    [t("brews.primary.og", "Original gravity"), formatGravity(actualOg)],
+    [t("brews.primary.fg", "Final gravity"), formatGravity(actualFg)],
+    [
+      t("recipeBuilder.resultsLabels.abv", "ABV"),
+      actualAbv == null ? "-" : `${actualAbv.toFixed(2)}%`
+    ],
+    [
+      t("recipeBuilder.resultsLabels.volume", "Volume"),
+      formatVolume(recipe.derived?.volume.totalL ?? null)
+    ]
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0 space-y-2">
+          <Button asChild variant="ghost" size="sm" className="-ml-3">
+            <Link href={backHref}>
+              <ArrowLeft />
+              {t(backLabelKey, "Back")}
+            </Link>
+          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="break-words text-2xl font-semibold sm:text-3xl">
+              {brew.name || brew.id}
+            </h1>
+            <span className="rounded-full border px-2.5 py-1 text-xs text-muted-foreground">
+              {t(`brewStage.${brew.stage}`, brew.stage)}
+            </span>
+            {readOnly ? (
+              <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2.5 py-1 text-xs text-muted-foreground">
+                <LockKeyhole className="size-3" />
+                {t("admin.readOnly", "Read only")}
+              </span>
+            ) : null}
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-muted-foreground">
+            {brew.owner ? (
+              <span>
+                {t("admin.owner", "Owner")}: {brew.owner.displayName}
+              </span>
+            ) : null}
+            {brew.recipe_id && recipeHref ? (
+              <span>
+                {t("brews.recipe", "Recipe")}:{" "}
+                <Link
+                  className="text-foreground underline underline-offset-4"
+                  href={recipeHref}
+                >
+                  {brew.recipe_name || t("recipe", "Recipe")}
+                </Link>
+              </span>
+            ) : (
+              <span>{t("noRecipe", "No recipe linked.")}</span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <SummarySection title={t("batchNumber", "Batch")} items={summary} />
+        <SummarySection title={t("recipe", "Recipe")} items={recipeSummary} />
+      </div>
+
+      <Accordion type="single" defaultValue="stage-panel" collapsible>
+        <AccordionItem value="stage-panel">
+          <AccordionTrigger>
+            {t("brews.stagePanel.title", "Brew tracker")} -{" "}
+            {t(`brewStage.${brew.stage}`, brew.stage)}
+          </AccordionTrigger>
+          <AccordionContent>
+            <BrewStagePath
+              brewId={brew.id}
+              stage={brew.stage}
+              entries={brew.entries}
+              onMoveToStage={noopAsync}
+              openAddEntry={() => undefined}
+              addAddition={noopAsync}
+              addAdditions={noopAsync}
+              addEntry={noopAsync}
+              current_volume_liters={brew.current_volume_liters}
+              gravity_unit_preference={brew.gravity_unit_preference}
+              recipe={recipe}
+              patchBrewMetadata={noopAsync}
+              hasRecipeLinked={Boolean(recipe.recipeData)}
+              readOnly={readOnly}
+            />
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+
+      <Tabs defaultValue="stages" className="space-y-4">
+        <div className="flex flex-col gap-3 border-b pb-4 sm:flex-row sm:items-center sm:justify-between">
+          <TabsList className="w-full sm:w-auto">
+            <TabsTrigger value="stages">
+              {t("brews.history.stages", "Stages")}
+            </TabsTrigger>
+            <TabsTrigger value="metrics">
+              {t("brews.history.metrics.title", "Metrics")}
+            </TabsTrigger>
+            <TabsTrigger value="charts">
+              {t("brews.history.charts", "Charts")}
+            </TabsTrigger>
+          </TabsList>
+          <div className="flex flex-wrap items-center gap-2">
+            <ToggleGroup
+              type="multiple"
+              value={filters}
+              onValueChange={(value) =>
+                setFilters(value.filter(isHistoryFilter))
+              }
+              variant="outline"
+              size="sm"
+            >
+              <ToggleGroupItem value="readings">
+                <Filter className="size-3.5" />
+                {t("brews.history.metrics.readings", "Readings")}
+              </ToggleGroupItem>
+              <ToggleGroupItem value="additions">
+                {t("brews.history.metrics.additions", "Additions")}
+              </ToggleGroupItem>
+              <ToggleGroupItem value="notes">
+                {t("brews.history.notes", "Notes")}
+              </ToggleGroupItem>
+            </ToggleGroup>
+            {filters.length ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="size-8"
+                onClick={() => setFilters([])}
+                aria-label={t("clear", "Clear")}
+                title={t("clear", "Clear")}
+              >
+                <X className="size-3.5" />
+              </Button>
+            ) : null}
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setNewestFirst((value) => !value)}
+            >
+              {newestFirst ? t("newest", "Newest") : t("oldest", "Oldest")}
+            </Button>
+          </div>
+        </div>
+
+        <TabsContent value="stages" className="mt-0">
+          {filteredBuckets.length ? (
+            <Accordion
+              type="multiple"
+              defaultValue={[brew.stage]}
+              className="space-y-3"
+            >
+              {filteredBuckets.map((bucket) => (
+                <AccordionItem
+                  key={bucket.stage}
+                  value={bucket.stage}
+                  className="rounded-md border px-4"
+                >
+                  <AccordionTrigger>
+                    <span className="flex flex-wrap items-center gap-2">
+                      {t(`brewStage.${bucket.stage}`, bucket.stage)}
+                      <span className="text-xs font-normal text-muted-foreground">
+                        {bucket.entries.length} {t("entries", "entries")}
+                      </span>
+                      {bucket.stage === brew.stage ? (
+                        <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs text-primary">
+                          {t("current", "Current")}
+                        </span>
+                      ) : null}
+                    </span>
+                  </AccordionTrigger>
+                  <AccordionContent className="space-y-3">
+                    {bucket.entries.map((entry) => (
+                      <EntryCard
+                        key={entry.id}
+                        entry={entry}
+                        stage={bucket.stage}
+                        formatDate={formatDate}
+                      />
+                    ))}
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+          ) : (
+            <EmptyHistory />
+          )}
+        </TabsContent>
+
+        <TabsContent value="metrics" className="mt-0">
+          {visibleEntries.length ? (
+            <div className="grid gap-4 lg:grid-cols-3">
+              {(["readings", "additions", "volume"] as const).map((group) => (
+                <section key={group} className="min-h-40 rounded-md border p-4">
+                  <div className="mb-3 flex items-center justify-between gap-2">
+                    <h2 className="font-medium">
+                      {t(`brews.history.metrics.${group}`, group)}
+                    </h2>
+                    <span className="text-sm tabular-nums text-muted-foreground">
+                      {metricGroups[group].length}
+                    </span>
+                  </div>
+                  <div className="space-y-3">
+                    {metricGroups[group].map((entry) => (
+                      <EntryCard
+                        key={entry.id}
+                        entry={entry}
+                        stage={findEntryStage(brew, entry.id)}
+                        formatDate={formatDate}
+                      />
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          ) : (
+            <EmptyHistory />
+          )}
+        </TabsContent>
+
+        <TabsContent value="charts" className="mt-0">
+          <BrewTimelineChartsView entries={brew.entries} logs={brew.logs} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}
+
+function SummarySection({
+  title,
+  items
+}: {
+  title: string;
+  items: string[][];
+}) {
+  return (
+    <section className="space-y-3 rounded-lg border border-border/70 bg-background/40 p-4">
+      <h2 className="text-sm font-semibold">{title}</h2>
+      <dl className="grid gap-x-6 gap-y-2 sm:grid-cols-2">
+        {items.map(([label, value]) => (
+          <div key={label} className="border-b border-border/60 py-2">
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+              {label}
+            </dt>
+            <dd className="mt-1 text-sm font-medium text-foreground">
+              {value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+function EntryCard({
+  entry,
+  stage,
+  formatDate
+}: {
+  entry: BrewViewEntry;
+  stage: BrewStage;
+  formatDate: (value: string | null) => string;
+}) {
+  const { t } = useTranslation();
+  const data = (entry.data ?? {}) as Record<string, unknown>;
+  const details = [
+    typeof entry.gravity === "number" ? formatSgDisplay(entry.gravity) : null,
+    typeof entry.temperature === "number"
+      ? `${entry.temperature} ${entry.temp_units || ""}`.trim()
+      : null,
+    typeof data.ph === "number" ? `pH ${data.ph}` : null,
+    typeof data.liters === "number" ? `${data.liters.toFixed(2)} L` : null,
+    typeof data.amount === "number"
+      ? `${data.amount} ${typeof data.unit === "string" ? data.unit : ""}`.trim()
+      : null
+  ].filter(Boolean);
+
+  return (
+    <article className="rounded-md border bg-card p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h3 className="font-medium">
+            {entry.title || t(`brewEntryType.${entry.type}`, entry.type)}
+          </h3>
+          <div className="text-xs text-muted-foreground">
+            {t(`brewStage.${stage}`, stage)} - {formatDate(entry.datetime)}
+          </div>
+        </div>
+        {details.length ? (
+          <div className="text-sm font-medium tabular-nums">
+            {details.join(" · ")}
+          </div>
+        ) : null}
+      </div>
+      {entry.note ? (
+        <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+          {entry.note}
+        </p>
+      ) : null}
+    </article>
+  );
+}
+
+function findEntryStage(brew: BrewViewDetail, entryId: string): BrewStage {
+  return (
+    brew.entries_by_stage.find((bucket) =>
+      bucket.entries.some((entry) => entry.id === entryId)
+    )?.stage ?? brew.stage
+  );
+}
+
+function EmptyHistory() {
+  const { t } = useTranslation();
+  return (
+    <div className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground">
+      {t("brews.history.empty", "No matching history entries.")}
+    </div>
+  );
+}

--- a/components/brews/stageConfig.ts
+++ b/components/brews/stageConfig.ts
@@ -65,7 +65,10 @@ export type StagePrereq = {
   isMet: (ctx: BrewStageContext) => boolean;
   hint?: (t: TFunction) => string;
   actionLabel?: (t: TFunction) => string;
-  run?: (helpers: BrewStageHelpers, ctx: BrewStageContext) => Promise<void> | void;
+  run?: (
+    helpers: BrewStageHelpers,
+    ctx: BrewStageContext
+  ) => Promise<void> | void;
 };
 
 export type BrewStageHelpers = {
@@ -129,7 +132,10 @@ export type StageAction = {
   id: string;
   label: (t: TFunction) => string;
   when?: (status: StageStatus, ctx: BrewStageContext) => boolean;
-  run: (helpers: BrewStageHelpers, ctx: BrewStageContext) => Promise<void> | void;
+  run: (
+    helpers: BrewStageHelpers,
+    ctx: BrewStageContext
+  ) => Promise<void> | void;
   variant?: "default" | "secondary" | "destructive";
 };
 
@@ -139,6 +145,7 @@ export type StagePanelProps = {
   ctx: BrewStageContext;
   helpers: BrewStageHelpers;
   warnings?: StageWarning[];
+  readOnly?: boolean;
 };
 
 export type StageWarning = {
@@ -271,7 +278,8 @@ function hasMissingPlannedNutrients(ctx: BrewStageContext) {
 
   const remaining = ctx.recipe.actual.remainingNutrientGrams;
   return Object.values(remaining ?? {}).some(
-    (amount) => typeof amount === "number" && Number.isFinite(amount) && amount > 0.01
+    (amount) =>
+      typeof amount === "number" && Number.isFinite(amount) && amount > 0.01
   );
 }
 
@@ -320,16 +328,32 @@ function getLatestSecondaryIngredientAdditionTime(ctx: BrewStageContext) {
   return latest;
 }
 
-function hasEntryAfter(ctx: BrewStageContext, type: BrewEntryType, after: number) {
-  return ctx.brew.entries.some((entry) => entry.type === type && getTime(entry.datetime ?? entry.createdAt) >= after);
+function hasEntryAfter(
+  ctx: BrewStageContext,
+  type: BrewEntryType,
+  after: number
+) {
+  return ctx.brew.entries.some(
+    (entry) =>
+      entry.type === type && getTime(entry.datetime ?? entry.createdAt) >= after
+  );
 }
 
 function needsSecondaryFollowupReadings(ctx: BrewStageContext) {
-  const latestSecondaryAdditionTime = getLatestSecondaryIngredientAdditionTime(ctx);
+  const latestSecondaryAdditionTime =
+    getLatestSecondaryIngredientAdditionTime(ctx);
   if (latestSecondaryAdditionTime === 0) return false;
 
-  const hasGravityAfterSecondary = hasEntryAfter(ctx, BREW_ENTRY_TYPE.GRAVITY, latestSecondaryAdditionTime);
-  const hasVolumeAfterSecondary = hasEntryAfter(ctx, BREW_ENTRY_TYPE.VOLUME, latestSecondaryAdditionTime);
+  const hasGravityAfterSecondary = hasEntryAfter(
+    ctx,
+    BREW_ENTRY_TYPE.GRAVITY,
+    latestSecondaryAdditionTime
+  );
+  const hasVolumeAfterSecondary = hasEntryAfter(
+    ctx,
+    BREW_ENTRY_TYPE.VOLUME,
+    latestSecondaryAdditionTime
+  );
 
   return !hasGravityAfterSecondary || !hasVolumeAfterSecondary;
 }
@@ -339,7 +363,9 @@ function hasOutstandingBulkAgeItems(ctx: BrewStageContext) {
 }
 
 function hasPackagingEntry(ctx: BrewStageContext) {
-  return ctx.brew.entries.some((entry) => entry.type === BREW_ENTRY_TYPE.PACKAGING);
+  return ctx.brew.entries.some(
+    (entry) => entry.type === BREW_ENTRY_TYPE.PACKAGING
+  );
 }
 
 function hasPackagedVolume(ctx: BrewStageContext) {
@@ -435,8 +461,7 @@ export const STAGE_CONFIG: Record<BrewStage, StageConfig> = {
             "brews.prereq.linkRecipeHardHint",
             "Brew tracking needs a linked recipe before primary can start."
           ),
-        actionLabel: (t) =>
-          t("brews.planned.linkRecipeAction", "Link recipe"),
+        actionLabel: (t) => t("brews.planned.linkRecipeAction", "Link recipe"),
         run: ({ openLinkRecipePage }) => {
           openLinkRecipePage?.();
         }
@@ -553,7 +578,7 @@ export const STAGE_CONFIG: Record<BrewStage, StageConfig> = {
           t(
             "brews.warn.primaryIngredientsMissing",
             "Not all primary ingredients have been added to this brew yet."
-        ),
+          ),
         isActive: (ctx) => hasMissingPrimaryIngredients(ctx),
         when: (status) => status === "current"
       },
@@ -601,8 +626,7 @@ export const STAGE_CONFIG: Record<BrewStage, StageConfig> = {
     prereqs: [
       {
         id: "primaryHasGravity",
-        label: (t) =>
-          t("brews.prereq.originalGravity", "Log original gravity"),
+        label: (t) => t("brews.prereq.originalGravity", "Log original gravity"),
         isMet: (ctx) => hasOriginalGravity(ctx),
         hint: (t) =>
           t(
@@ -654,8 +678,7 @@ export const STAGE_CONFIG: Record<BrewStage, StageConfig> = {
             "brews.prereq.volumeHint",
             "Record the total volume after transferring to secondary so stabilizers and later additions can use the right batch size."
           ),
-        actionLabel: (t) =>
-          t("brews.actions.logVolume", "Record volume"),
+        actionLabel: (t) => t("brews.actions.logVolume", "Record volume"),
         run: ({ openRecordVolume }) => {
           openRecordVolume?.();
         }

--- a/components/brews/stages/BulkAgeStagePanel.tsx
+++ b/components/brews/stages/BulkAgeStagePanel.tsx
@@ -28,13 +28,26 @@ import {
   WorkRow
 } from "./StagePanelShared";
 
-export function BulkAgeStagePanel({ t, status, ctx, helpers, warnings = [] }: StagePanelProps) {
+export function BulkAgeStagePanel({
+  t,
+  status,
+  ctx,
+  helpers,
+  warnings = [],
+  readOnly = false
+}: StagePanelProps) {
   const { i18n } = useTranslation();
-  const [additionDialog, setAdditionDialog] = React.useState<PlannedAdditionDialogItem | null>(null);
-  const [stageMove, setStageMove] = React.useState<"PACKAGED" | "COMPLETE" | null>(null);
+  const [additionDialog, setAdditionDialog] =
+    React.useState<PlannedAdditionDialogItem | null>(null);
+  const [stageMove, setStageMove] = React.useState<
+    "PACKAGED" | "COMPLETE" | null
+  >(null);
 
-  const canEdit = status === "current";
-  const unit = ctx.recipe.recipeData?.unitDefaults.volume ?? ctx.recipe.derived?.volume.unit ?? "gal";
+  const canEdit = status === "current" && !readOnly;
+  const unit =
+    ctx.recipe.recipeData?.unitDefaults.volume ??
+    ctx.recipe.derived?.volume.unit ??
+    "gal";
   const finalGravity = ctx.recipe.actual.finalGravity?.gravity ?? null;
   const hasCurrentVolume =
     typeof ctx.brew.current_volume_liters === "number" &&
@@ -58,12 +71,22 @@ export function BulkAgeStagePanel({ t, status, ctx, helpers, warnings = [] }: St
     () => buildAdditiveLines(ctx.recipe.additives),
     [ctx.recipe.additives]
   );
-  const missingSecondary = secondaryLines.filter((item) => !loggedIngredientIds.has(String(item.line.lineId)));
-  const missingAdditives = additiveLines.filter((item) => !loggedAdditiveIds.has(String(item.line.lineId)));
+  const missingSecondary = secondaryLines.filter(
+    (item) => !loggedIngredientIds.has(String(item.line.lineId))
+  );
+  const missingAdditives = additiveLines.filter(
+    (item) => !loggedAdditiveIds.has(String(item.line.lineId))
+  );
   const outstandingCount = missingSecondary.length + missingAdditives.length;
   const locale = i18n.resolvedLanguage;
 
-  const openEntry = (type: typeof BREW_ENTRY_TYPE.NOTE | typeof BREW_ENTRY_TYPE.TASTING | typeof BREW_ENTRY_TYPE.ISSUE | typeof BREW_ENTRY_TYPE.GRAVITY) => {
+  const openEntry = (
+    type:
+      | typeof BREW_ENTRY_TYPE.NOTE
+      | typeof BREW_ENTRY_TYPE.TASTING
+      | typeof BREW_ENTRY_TYPE.ISSUE
+      | typeof BREW_ENTRY_TYPE.GRAVITY
+  ) => {
     helpers.openAddEntry?.({
       presetType: type,
       allowedTypes: [type]
@@ -96,54 +119,103 @@ export function BulkAgeStagePanel({ t, status, ctx, helpers, warnings = [] }: St
       </div>
 
       <StageFocusActions
-        title={t("brews.bulkAge.focus", "Track aging notes and package when ready")}
+        title={t(
+          "brews.bulkAge.focus",
+          "Track aging notes and package when ready"
+        )}
         description={t(
           "brews.bulkAge.workflowHint",
           "Notes are the main log here; use readings and outstanding items only when they help."
         )}
       >
-            <Button size="sm" disabled={!canEdit} onClick={() => openEntry(BREW_ENTRY_TYPE.NOTE)}>
-              {t("brews.bulkAge.addNote", "Add note")}
-            </Button>
-            <Button size="sm" variant="secondary" disabled={!canEdit} onClick={() => openEntry(BREW_ENTRY_TYPE.TASTING)}>
-              {t("brews.bulkAge.addTasting", "Add tasting")}
-            </Button>
-            <Button size="sm" variant="secondary" disabled={!canEdit} onClick={() => openEntry(BREW_ENTRY_TYPE.GRAVITY)}>
-              {t("brews.actions.logGravity", "Log gravity")}
-            </Button>
-            <Button size="sm" variant="secondary" disabled={!canEdit} onClick={() => helpers.openRecordVolume?.()}>
-              {t("brews.actions.logVolume", "Record volume")}
-            </Button>
-            <Button size="sm" variant="secondary" disabled={!canEdit} onClick={() => setStageMove("PACKAGED")}>
-              {t("brews.bulkAge.moveToPackaged", "Move to Packaged")}
-            </Button>
-            <Button size="sm" variant="secondary" disabled={!canEdit} onClick={() => setStageMove("COMPLETE")}>
-              {t("brews.bulkAge.markComplete", "Mark Complete")}
-            </Button>
-            <Button size="sm" variant="ghost" disabled={!canEdit} onClick={() => openEntry(BREW_ENTRY_TYPE.ISSUE)}>
-              {t("brews.bulkAge.addIssue", "Add issue")}
-            </Button>
+        <Button
+          size="sm"
+          disabled={!canEdit}
+          onClick={() => openEntry(BREW_ENTRY_TYPE.NOTE)}
+        >
+          {t("brews.bulkAge.addNote", "Add note")}
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled={!canEdit}
+          onClick={() => openEntry(BREW_ENTRY_TYPE.TASTING)}
+        >
+          {t("brews.bulkAge.addTasting", "Add tasting")}
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled={!canEdit}
+          onClick={() => openEntry(BREW_ENTRY_TYPE.GRAVITY)}
+        >
+          {t("brews.actions.logGravity", "Log gravity")}
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled={!canEdit}
+          onClick={() => helpers.openRecordVolume?.()}
+        >
+          {t("brews.actions.logVolume", "Record volume")}
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled={!canEdit}
+          onClick={() => setStageMove("PACKAGED")}
+        >
+          {t("brews.bulkAge.moveToPackaged", "Move to Packaged")}
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          disabled={!canEdit}
+          onClick={() => setStageMove("COMPLETE")}
+        >
+          {t("brews.bulkAge.markComplete", "Mark Complete")}
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={!canEdit}
+          onClick={() => openEntry(BREW_ENTRY_TYPE.ISSUE)}
+        >
+          {t("brews.bulkAge.addIssue", "Add issue")}
+        </Button>
       </StageFocusActions>
 
       <WarningsPanel warnings={warnings} />
 
       <div className="space-y-2">
         <div className="text-sm font-medium">
-          {t("brews.bulkAge.outstandingRecipeItems", "Outstanding recipe items")} · {outstandingCount}
+          {t(
+            "brews.bulkAge.outstandingRecipeItems",
+            "Outstanding recipe items"
+          )}{" "}
+          · {outstandingCount}
         </div>
         {outstandingCount > 0 ? (
           <ul className="space-y-1">
             {missingSecondary.map((item) => {
               const loggedAddition = latestLoggedItem(
-                ctx.recipe.actual.additionsByRecipeIngredientId[String(item.line.lineId)]
+                ctx.recipe.actual.additionsByRecipeIngredientId[
+                  String(item.line.lineId)
+                ]
               );
               const { amount, unit } = getIngredientAmount(item.line);
               return (
                 <WorkRow
                   key={`ingredient-${item.line.lineId}`}
                   title={getBrewItemLabel(t, loggedAddition?.name || item.name)}
-                  detail={item.secondary ? `${t("brews.planned.altAmount", "Alt")}: ${item.secondary}` : null}
-                  amount={formatLoggedAmount(loggedAddition, locale) ?? item.primary}
+                  detail={
+                    item.secondary
+                      ? `${t("brews.planned.altAmount", "Alt")}: ${item.secondary}`
+                      : null
+                  }
+                  amount={
+                    formatLoggedAmount(loggedAddition, locale) ?? item.primary
+                  }
                   isLogged={false}
                   disabled={!canEdit}
                   loggedLabel={t("brews.primary.logged", "Logged")}
@@ -158,7 +230,11 @@ export function BulkAgeStagePanel({ t, status, ctx, helpers, warnings = [] }: St
                       unit,
                       ...getPlannedIngredientAmounts(item.line),
                       recipeIngredientId: String(item.line.lineId),
-                      meta: { plannedAmount: amount, plannedUnit: unit, stage: "BULK_AGE" }
+                      meta: {
+                        plannedAmount: amount,
+                        plannedUnit: unit,
+                        stage: "BULK_AGE"
+                      }
                     })
                   }
                 />
@@ -166,14 +242,18 @@ export function BulkAgeStagePanel({ t, status, ctx, helpers, warnings = [] }: St
             })}
             {missingAdditives.map((item) => {
               const loggedAddition = latestLoggedItem(
-                ctx.recipe.actual.additionsByRecipeAdditiveId[String(item.line.lineId)]
+                ctx.recipe.actual.additionsByRecipeAdditiveId[
+                  String(item.line.lineId)
+                ]
               );
               const { amount, unit } = getAdditiveAmount(item.line);
               return (
                 <WorkRow
                   key={`additive-${item.line.lineId}`}
                   title={getBrewItemLabel(t, loggedAddition?.name || item.name)}
-                  amount={formatLoggedAmount(loggedAddition, locale) ?? item.amount}
+                  amount={
+                    formatLoggedAmount(loggedAddition, locale) ?? item.amount
+                  }
                   isLogged={false}
                   disabled={!canEdit}
                   loggedLabel={t("brews.primary.logged", "Logged")}
@@ -187,7 +267,11 @@ export function BulkAgeStagePanel({ t, status, ctx, helpers, warnings = [] }: St
                       amount,
                       unit,
                       recipeAdditiveId: String(item.line.lineId),
-                      meta: { plannedAmount: amount, plannedUnit: unit, stage: "BULK_AGE" }
+                      meta: {
+                        plannedAmount: amount,
+                        plannedUnit: unit,
+                        stage: "BULK_AGE"
+                      }
                     })
                   }
                 />
@@ -196,7 +280,10 @@ export function BulkAgeStagePanel({ t, status, ctx, helpers, warnings = [] }: St
           </ul>
         ) : (
           <div className="text-sm text-muted-foreground">
-            {t("brews.bulkAge.noOutstandingItems", "No outstanding linked recipe items.")}
+            {t(
+              "brews.bulkAge.noOutstandingItems",
+              "No outstanding linked recipe items."
+            )}
           </div>
         )}
       </div>

--- a/components/brews/stages/CompleteStagePanel.tsx
+++ b/components/brews/stages/CompleteStagePanel.tsx
@@ -5,18 +5,29 @@ import { BREW_ENTRY_TYPE } from "@/lib/brewEnums";
 import { calcABV } from "@/lib/utils/unitConverter";
 import type { BrewPackagingData } from "@/lib/utils/entryPayload";
 import type { StagePanelProps } from "../stageConfig";
-import { formatGravity, formatNumber, formatVolume, sortNewestFirst, StageFocusActions, StatusTile } from "./StagePanelShared";
+import {
+  formatGravity,
+  formatNumber,
+  formatVolume,
+  sortNewestFirst,
+  StageFocusActions,
+  StatusTile
+} from "./StagePanelShared";
 import { useTranslation } from "react-i18next";
 
 function fmtAbv(value?: number | null, locale?: string) {
-  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return "-";
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0)
+    return "-";
   return `${formatNumber(value, 2, locale, "-")}%`;
 }
 
 function getLatestPackaging(ctx: StagePanelProps["ctx"]) {
   return (
-    sortNewestFirst(ctx.brew.entries.filter((entry) => entry.type === BREW_ENTRY_TYPE.PACKAGING))[0] ??
-    null
+    sortNewestFirst(
+      ctx.brew.entries.filter(
+        (entry) => entry.type === BREW_ENTRY_TYPE.PACKAGING
+      )
+    )[0] ?? null
   );
 }
 
@@ -27,7 +38,9 @@ function getPackageCount(data?: BrewPackagingData | null) {
 function getCompletionDate(ctx: StagePanelProps["ctx"]) {
   const completionEntry = sortNewestFirst(
     ctx.brew.entries.filter(
-      (entry) => entry.type === BREW_ENTRY_TYPE.STAGE_CHANGE && (entry.data as any)?.to === "COMPLETE"
+      (entry) =>
+        entry.type === BREW_ENTRY_TYPE.STAGE_CHANGE &&
+        (entry.data as any)?.to === "COMPLETE"
     )
   )[0];
 
@@ -58,26 +71,44 @@ function getFinalNotes(ctx: StagePanelProps["ctx"]) {
   );
   if (tastings.length > 0) return tastings.slice(0, 3);
 
-  return sortNewestFirst(ctx.brew.entries.filter((entry) => entry.type === BREW_ENTRY_TYPE.NOTE)).slice(
-    0,
-    3
-  );
+  return sortNewestFirst(
+    ctx.brew.entries.filter((entry) => entry.type === BREW_ENTRY_TYPE.NOTE)
+  ).slice(0, 3);
 }
 
-export function CompleteStagePanel({ t, status, ctx, helpers }: StagePanelProps) {
+export function CompleteStagePanel({
+  t,
+  status,
+  ctx,
+  helpers,
+  readOnly = false
+}: StagePanelProps) {
   const { i18n } = useTranslation();
-  const unit = ctx.recipe.recipeData?.unitDefaults.volume ?? ctx.recipe.derived?.volume.unit ?? "gal";
+  const unit =
+    ctx.recipe.recipeData?.unitDefaults.volume ??
+    ctx.recipe.derived?.volume.unit ??
+    "gal";
   const locale = i18n.resolvedLanguage;
   const latestPackaging = getLatestPackaging(ctx);
-  const latestPackagingData = latestPackaging?.data as BrewPackagingData | null | undefined;
+  const latestPackagingData = latestPackaging?.data as
+    | BrewPackagingData
+    | null
+    | undefined;
   const packagedVolume = latestPackagingData?.packagedVolumeLiters ?? null;
   const packageCount = getPackageCount(latestPackagingData);
   const originalGravity = ctx.recipe.actual.originalGravity?.gravity ?? null;
   const finalGravity = ctx.recipe.actual.finalGravity?.gravity ?? null;
-  const latestGravity = ctx.recipe.actual.latestGravity ?? ctx.brew.latest_gravity ?? ctx.brew.effective_latest_gravity ?? null;
-  const hasTastings = ctx.brew.entries.some((entry) => entry.type === BREW_ENTRY_TYPE.TASTING);
+  const latestGravity =
+    ctx.recipe.actual.latestGravity ??
+    ctx.brew.latest_gravity ??
+    ctx.brew.effective_latest_gravity ??
+    null;
+  const hasTastings = ctx.brew.entries.some(
+    (entry) => entry.type === BREW_ENTRY_TYPE.TASTING
+  );
   const abv =
-    typeof ctx.recipe.actual.currentAbv === "number" && Number.isFinite(ctx.recipe.actual.currentAbv)
+    typeof ctx.recipe.actual.currentAbv === "number" &&
+    Number.isFinite(ctx.recipe.actual.currentAbv)
       ? ctx.recipe.actual.currentAbv
       : typeof originalGravity === "number" &&
           Number.isFinite(originalGravity) &&
@@ -86,7 +117,7 @@ export function CompleteStagePanel({ t, status, ctx, helpers }: StagePanelProps)
         ? calcABV(originalGravity, finalGravity)
         : null;
   const finalNotes = getFinalNotes(ctx);
-  const canAddEntry = status === "current";
+  const canAddEntry = status === "current" && !readOnly;
 
   return (
     <div className="space-y-5">
@@ -108,7 +139,9 @@ export function CompleteStagePanel({ t, status, ctx, helpers }: StagePanelProps)
         />
         <StatusTile
           label={t("brews.packaged.packageCount", "Package count")}
-          value={packageCount > 0 ? formatNumber(packageCount, 0, locale, "-") : "-"}
+          value={
+            packageCount > 0 ? formatNumber(packageCount, 0, locale, "-") : "-"
+          }
           tone={packageCount > 0 ? "ok" : "warn"}
         />
       </div>
@@ -132,9 +165,16 @@ export function CompleteStagePanel({ t, status, ctx, helpers }: StagePanelProps)
       </div>
 
       <div className="rounded-md border border-border bg-background/40 px-3 py-3 text-sm">
-        <div className="font-medium">{t("brews.complete.packagingRecap", "Packaging recap")}</div>
+        <div className="font-medium">
+          {t("brews.complete.packagingRecap", "Packaging recap")}
+        </div>
         <div className="mt-1 text-muted-foreground">
-          {formatVolume(latestPackagingData?.packagedVolumeLiters, unit, locale, { fallback: "-" })}
+          {formatVolume(
+            latestPackagingData?.packagedVolumeLiters,
+            unit,
+            locale,
+            { fallback: "-" }
+          )}
           {packageCount > 0
             ? ` - ${formatNumber(packageCount, 0, locale, "-")} ${t("brews.packaged.packages", "packages")}`
             : ""}
@@ -150,13 +190,19 @@ export function CompleteStagePanel({ t, status, ctx, helpers }: StagePanelProps)
                   {formatNumber(row.quantity, 0, locale, "-")} {row.label}
                 </span>
                 {row.totalLiters > 0 ? (
-                  <span className="text-muted-foreground">{formatVolume(row.totalLiters, unit, locale, { fallback: "-" })}</span>
+                  <span className="text-muted-foreground">
+                    {formatVolume(row.totalLiters, unit, locale, {
+                      fallback: "-"
+                    })}
+                  </span>
                 ) : null}
               </span>
             ))}
           </div>
         ) : null}
-        {latestPackaging?.note ? <div className="mt-3 whitespace-pre-line">{latestPackaging.note}</div> : null}
+        {latestPackaging?.note ? (
+          <div className="mt-3 whitespace-pre-line">{latestPackaging.note}</div>
+        ) : null}
         {!latestPackaging ? (
           <div className="mt-2 text-muted-foreground">
             {t("brews.complete.noPackaging", "No packaging details recorded.")}
@@ -173,7 +219,10 @@ export function CompleteStagePanel({ t, status, ctx, helpers }: StagePanelProps)
         {finalNotes.length > 0 ? (
           <div className="mt-3 space-y-3">
             {finalNotes.map((entry) => (
-              <div key={entry.id} className="border-t border-border/60 pt-3 first:border-t-0 first:pt-0">
+              <div
+                key={entry.id}
+                className="border-t border-border/60 pt-3 first:border-t-0 first:pt-0"
+              >
                 <div className="flex flex-wrap items-baseline justify-between gap-2">
                   <div className="text-sm font-medium">
                     {entry.title ||
@@ -181,45 +230,55 @@ export function CompleteStagePanel({ t, status, ctx, helpers }: StagePanelProps)
                         ? t("tasting", "Tasting")
                         : t("note", "Note"))}
                   </div>
-                  <div className="text-xs text-muted-foreground">{fmtDate(entry.datetime ?? entry.createdAt)}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {fmtDate(entry.datetime ?? entry.createdAt)}
+                  </div>
                 </div>
                 {entry.note ? (
-                  <div className="mt-1 whitespace-pre-line text-sm text-muted-foreground">{entry.note}</div>
+                  <div className="mt-1 whitespace-pre-line text-sm text-muted-foreground">
+                    {entry.note}
+                  </div>
                 ) : null}
               </div>
             ))}
           </div>
         ) : (
           <div className="mt-2 text-sm text-muted-foreground">
-            {t("brews.complete.noFinalNotes", "No tastings or notes recorded yet.")}
+            {t(
+              "brews.complete.noFinalNotes",
+              "No tastings or notes recorded yet."
+            )}
           </div>
         )}
       </div>
 
-      <StageFocusActions
-        title={t("brews.actions.addEntry", "Add entry")}
-        description={t("brews.complete.addEntryHint", "Add any final reading, tasting, issue, or note.")}
-      >
-          {canAddEntry ? (
-            <Button
-              size="sm"
-              onClick={() =>
-                helpers.openAddEntry?.({
-                  allowedTypes: [
-                    BREW_ENTRY_TYPE.GRAVITY,
-                    BREW_ENTRY_TYPE.TEMPERATURE,
-                    BREW_ENTRY_TYPE.PH,
-                    BREW_ENTRY_TYPE.NOTE,
-                    BREW_ENTRY_TYPE.TASTING,
-                    BREW_ENTRY_TYPE.ISSUE
-                  ]
-                })
-              }
-            >
-              {t("brews.actions.addEntry", "Add entry")}
-            </Button>
-          ) : null}
-      </StageFocusActions>
+      {canAddEntry ? (
+        <StageFocusActions
+          title={t("brews.actions.addEntry", "Add entry")}
+          description={t(
+            "brews.complete.addEntryHint",
+            "Add any final reading, tasting, issue, or note."
+          )}
+        >
+          <Button
+            size="sm"
+            onClick={() =>
+              helpers.openAddEntry?.({
+                allowedTypes: [
+                  BREW_ENTRY_TYPE.GRAVITY,
+                  BREW_ENTRY_TYPE.TEMPERATURE,
+                  BREW_ENTRY_TYPE.PH,
+                  BREW_ENTRY_TYPE.NOTE,
+                  BREW_ENTRY_TYPE.TASTING,
+                  BREW_ENTRY_TYPE.ISSUE
+                ]
+              })
+            }
+          >
+            {t("brews.actions.addEntry", "Add entry")}
+          </Button>
+        </StageFocusActions>
+      ) : null}
     </div>
   );
 }

--- a/components/brews/stages/PackagedStagePanel.tsx
+++ b/components/brews/stages/PackagedStagePanel.tsx
@@ -16,10 +16,20 @@ import { Textarea } from "@/components/ui/textarea";
 import { BREW_ENTRY_TYPE } from "@/lib/brewEnums";
 import { entryPayload, type BrewPackagingData } from "@/lib/utils/entryPayload";
 import type { StagePanelProps } from "../stageConfig";
-import { DateConfirmDialog, formatNumber, formatVolume, latestLoggedItem, StageFocusActions, StatusTile, WarningsPanel } from "./StagePanelShared";
+import {
+  DateConfirmDialog,
+  formatNumber,
+  formatVolume,
+  latestLoggedItem,
+  StageFocusActions,
+  StatusTile,
+  WarningsPanel
+} from "./StagePanelShared";
 
 function getLatestPackaging(ctx: StagePanelProps["ctx"]) {
-  return latestLoggedItem(ctx.brew.entries.filter((entry) => entry.type === BREW_ENTRY_TYPE.PACKAGING));
+  return latestLoggedItem(
+    ctx.brew.entries.filter((entry) => entry.type === BREW_ENTRY_TYPE.PACKAGING)
+  );
 }
 
 function getPackageCount(data?: BrewPackagingData | null) {
@@ -28,7 +38,14 @@ function getPackageCount(data?: BrewPackagingData | null) {
 
 const VOLUME_CHANGE_THRESHOLD_L = 0.01;
 
-export function PackagedStagePanel({ t, status, ctx, helpers, warnings = [] }: StagePanelProps) {
+export function PackagedStagePanel({
+  t,
+  status,
+  ctx,
+  helpers,
+  warnings = [],
+  readOnly = false
+}: StagePanelProps) {
   const { i18n } = useTranslation();
   const bottling = useBottlingRows();
   const [datetime, setDatetime] = React.useState<Date>(new Date());
@@ -36,20 +53,33 @@ export function PackagedStagePanel({ t, status, ctx, helpers, warnings = [] }: S
   const [isSaving, setIsSaving] = React.useState(false);
   const [completeDialogOpen, setCompleteDialogOpen] = React.useState(false);
 
-  const unit = ctx.recipe.recipeData?.unitDefaults.volume ?? ctx.recipe.derived?.volume.unit ?? "gal";
-  const canEdit = status === "current";
+  const unit =
+    ctx.recipe.recipeData?.unitDefaults.volume ??
+    ctx.recipe.derived?.volume.unit ??
+    "gal";
+  const canEdit = status === "current" && !readOnly;
   const latestPackaging = getLatestPackaging(ctx);
-  const latestPackagingData = latestPackaging?.data as BrewPackagingData | null | undefined;
+  const latestPackagingData = latestPackaging?.data as
+    | BrewPackagingData
+    | null
+    | undefined;
   const savedPackagedVolume = latestPackagingData?.packagedVolumeLiters ?? null;
   const currentVolume = ctx.brew.current_volume_liters;
   const displayPackagedVolume = savedPackagedVolume ?? currentVolume;
   const packageCount = getPackageCount(latestPackagingData);
   const saveVolumeLiters =
-    bottling.totalVolumeBottledL > 0 ? bottling.totalVolumeBottledL : bottling.totalTargetVolumeL;
+    bottling.totalVolumeBottledL > 0
+      ? bottling.totalVolumeBottledL
+      : bottling.totalTargetVolumeL;
   const displayValue =
-    bottling.volumeUnits === "gallons" ? saveVolumeLiters / L_PER_GAL : saveVolumeLiters;
+    bottling.volumeUnits === "gallons"
+      ? saveVolumeLiters / L_PER_GAL
+      : saveVolumeLiters;
   const displayUnit = bottling.volumeUnits === "gallons" ? "gal" : "L";
-  const bottleRows = getPackagingBottleRows(bottling.bottleRows, bottling.getPerBottleLiters);
+  const bottleRows = getPackagingBottleRows(
+    bottling.bottleRows,
+    bottling.getPerBottleLiters
+  );
   const locale = i18n.resolvedLanguage;
 
   React.useEffect(() => {
@@ -74,14 +104,17 @@ export function PackagedStagePanel({ t, status, ctx, helpers, warnings = [] }: S
     }
 
     const source =
-      typeof currentVolume === "number" && Number.isFinite(currentVolume) && currentVolume > 0
+      typeof currentVolume === "number" &&
+      Number.isFinite(currentVolume) &&
+      currentVolume > 0
         ? currentVolume
         : ctx.brew.effective_current_volume_liters;
-    if (typeof source !== "number" || !Number.isFinite(source) || source <= 0) return;
+    if (typeof source !== "number" || !Number.isFinite(source) || source <= 0)
+      return;
 
     if (unit === "L" || unit === "mL") {
       bottling.setVolumeUnits("liters");
-      bottling.setTotalVolume(String(Number((source).toFixed(2))));
+      bottling.setTotalVolume(String(Number(source.toFixed(2))));
     } else {
       bottling.setVolumeUnits("gallons");
       bottling.setTotalVolume(String(Number((source / L_PER_GAL).toFixed(2))));
@@ -135,7 +168,9 @@ export function PackagedStagePanel({ t, status, ctx, helpers, warnings = [] }: S
       }
 
       if (volumeChanged) {
-        await helpers.patchBrewMetadata({ current_volume_liters: saveVolumeLiters });
+        await helpers.patchBrewMetadata({
+          current_volume_liters: saveVolumeLiters
+        });
         await helpers.addEntry(
           entryPayload.volume({
             liters: saveVolumeLiters,
@@ -176,52 +211,89 @@ export function PackagedStagePanel({ t, status, ctx, helpers, warnings = [] }: S
         />
       </div>
 
-      <StageFocusActions
-        title={t("brews.packaged.focus", "Record packaging details and finish the brew")}
-        description={t(
-          "brews.packaged.workflowHint",
-          "Save package sizes, counts, and volume before marking the brew complete."
-        )}
-      >
-            <Button size="sm" disabled={!canEdit} onClick={() => openEntry(BREW_ENTRY_TYPE.NOTE)}>
-              {t("brews.bulkAge.addNote", "Add note")}
-            </Button>
-            <Button size="sm" variant="secondary" disabled={!canEdit} onClick={() => openEntry(BREW_ENTRY_TYPE.TASTING)}>
-              {t("brews.bulkAge.addTasting", "Add tasting")}
-            </Button>
-            <Button size="sm" variant="ghost" disabled={!canEdit} onClick={() => openEntry(BREW_ENTRY_TYPE.ISSUE)}>
-              {t("brews.bulkAge.addIssue", "Add issue")}
-            </Button>
-            <Button size="sm" variant="secondary" disabled={!canEdit} onClick={() => setCompleteDialogOpen(true)}>
-              {t("brews.bulkAge.markComplete", "Mark Complete")}
-            </Button>
-      </StageFocusActions>
+      {!readOnly ? (
+        <StageFocusActions
+          title={t(
+            "brews.packaged.focus",
+            "Record packaging details and finish the brew"
+          )}
+          description={t(
+            "brews.packaged.workflowHint",
+            "Save package sizes, counts, and volume before marking the brew complete."
+          )}
+        >
+          <Button
+            size="sm"
+            disabled={!canEdit}
+            onClick={() => openEntry(BREW_ENTRY_TYPE.NOTE)}
+          >
+            {t("brews.bulkAge.addNote", "Add note")}
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={!canEdit}
+            onClick={() => openEntry(BREW_ENTRY_TYPE.TASTING)}
+          >
+            {t("brews.bulkAge.addTasting", "Add tasting")}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            disabled={!canEdit}
+            onClick={() => openEntry(BREW_ENTRY_TYPE.ISSUE)}
+          >
+            {t("brews.bulkAge.addIssue", "Add issue")}
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            disabled={!canEdit}
+            onClick={() => setCompleteDialogOpen(true)}
+          >
+            {t("brews.bulkAge.markComplete", "Mark Complete")}
+          </Button>
+        </StageFocusActions>
+      ) : null}
 
       <WarningsPanel warnings={warnings} />
 
-      <div className="rounded-md border border-border bg-background/40 p-3">
-        <div className="space-y-2">
-          <div className="max-w-sm space-y-2">
-            <Label>{t("date", "Date")}</Label>
-            <DateTimePicker value={datetime} onChange={(value) => value && setDatetime(value)} hourCycle={12} />
+      {!readOnly ? (
+        <div className="rounded-md border border-border bg-background/40 p-3">
+          <div className="space-y-2">
+            <div className="max-w-sm space-y-2">
+              <Label>{t("date", "Date")}</Label>
+              <DateTimePicker
+                value={datetime}
+                onChange={(value) => value && setDatetime(value)}
+                hourCycle={12}
+              />
+            </div>
+          </div>
+
+          <div className="mt-4">
+            <BottlingCalculator state={bottling} compact />
+          </div>
+
+          <div className="mt-4 space-y-2">
+            <Label>{t("note", "Note")}</Label>
+            <Textarea
+              value={note}
+              onChange={(event) => setNote(event.target.value)}
+              rows={3}
+            />
+          </div>
+
+          <div className="mt-4 flex justify-end">
+            <Button
+              onClick={savePackaging}
+              disabled={!canEdit || isSaving || saveVolumeLiters <= 0}
+            >
+              {t("brews.packaged.savePackaging", "Save packaging")}
+            </Button>
           </div>
         </div>
-
-        <div className="mt-4">
-          <BottlingCalculator state={bottling} compact />
-        </div>
-
-        <div className="mt-4 space-y-2">
-          <Label>{t("note", "Note")}</Label>
-          <Textarea value={note} onChange={(event) => setNote(event.target.value)} rows={3} />
-        </div>
-
-        <div className="mt-4 flex justify-end">
-          <Button onClick={savePackaging} disabled={!canEdit || isSaving || saveVolumeLiters <= 0}>
-            {t("brews.packaged.savePackaging", "Save packaging")}
-          </Button>
-        </div>
-      </div>
+      ) : null}
 
       {latestPackaging ? (
         <div className="rounded-md border border-border bg-background/40 px-3 py-3 text-sm">
@@ -229,7 +301,11 @@ export function PackagedStagePanel({ t, status, ctx, helpers, warnings = [] }: S
             {t("brews.packaged.latestPackaging", "Latest packaging")}
           </div>
           <div className="mt-1 text-muted-foreground">
-            {formatVolume(latestPackagingData?.packagedVolumeLiters, unit, locale)}
+            {formatVolume(
+              latestPackagingData?.packagedVolumeLiters,
+              unit,
+              locale
+            )}
             {packageCount > 0
               ? ` · ${formatNumber(packageCount, 0, locale)} ${t("brews.packaged.packages", "packages")}`
               : ""}
@@ -253,19 +329,23 @@ export function PackagedStagePanel({ t, status, ctx, helpers, warnings = [] }: S
               ))}
             </div>
           ) : null}
-          {latestPackaging.note ? <div className="mt-2">{latestPackaging.note}</div> : null}
+          {latestPackaging.note ? (
+            <div className="mt-2">{latestPackaging.note}</div>
+          ) : null}
         </div>
       ) : null}
 
-      <DateConfirmDialog
-        open={completeDialogOpen}
-        onOpenChange={setCompleteDialogOpen}
-        title={t("brews.bulkAge.markComplete", "Mark Complete")}
-        onConfirm={async (datetimeIso) => {
-          await helpers.moveToStage("COMPLETE", datetimeIso);
-          setCompleteDialogOpen(false);
-        }}
-      />
+      {!readOnly ? (
+        <DateConfirmDialog
+          open={completeDialogOpen}
+          onOpenChange={setCompleteDialogOpen}
+          title={t("brews.bulkAge.markComplete", "Mark Complete")}
+          onConfirm={async (datetimeIso) => {
+            await helpers.moveToStage("COMPLETE", datetimeIso);
+            setCompleteDialogOpen(false);
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/components/brews/stages/PlannedStagePanel.tsx
+++ b/components/brews/stages/PlannedStagePanel.tsx
@@ -10,7 +10,11 @@ import { cn } from "@/lib/utils";
 import type { NutrientKey } from "@/types/nutrientData";
 
 import type { StagePanelProps } from "../stageConfig";
-import { buildAdditiveLines, buildIngredientLines, formatNumber } from "./StagePanelShared";
+import {
+  buildAdditiveLines,
+  buildIngredientLines,
+  formatNumber
+} from "./StagePanelShared";
 import { getBrewItemLabel } from "./additionDialogShared";
 
 const nutrientLabels: Record<NutrientKey, string> = {
@@ -40,10 +44,15 @@ function buildNutrientRows(
     .filter((row) => row.total > 0);
 }
 
-export function PlannedStagePanel({ t, ctx }: StagePanelProps) {
+export function PlannedStagePanel({
+  t,
+  ctx,
+  readOnly = false
+}: StagePanelProps) {
   const { i18n } = useTranslation();
   const locale = i18n.resolvedLanguage;
-  const fmtNumber = (value?: number | null, decimals = 2) => formatNumber(value, decimals, locale);
+  const fmtNumber = (value?: number | null, decimals = 2) =>
+    formatNumber(value, decimals, locale);
   const primaryList = React.useMemo(
     () => buildIngredientLines(ctx.recipe.primaryIngredients),
     [ctx.recipe.primaryIngredients]
@@ -88,11 +97,13 @@ export function PlannedStagePanel({ t, ctx }: StagePanelProps) {
               )}
             </div>
           </div>
-          <Button asChild size="sm">
-            <Link href={`/account/brews/${ctx.brew.id}/link`}>
-              {t("brews.planned.linkRecipeAction", "Link recipe")}
-            </Link>
-          </Button>
+          {!readOnly ? (
+            <Button asChild size="sm">
+              <Link href={`/account/brews/${ctx.brew.id}/link`}>
+                {t("brews.planned.linkRecipeAction", "Link recipe")}
+              </Link>
+            </Button>
+          ) : null}
         </section>
       ) : null}
 
@@ -123,8 +134,7 @@ export function PlannedStagePanel({ t, ctx }: StagePanelProps) {
                 {
                   label: t("yeastStrain", "Strain"),
                   value:
-                    [yeast.brand, yeast.strain].filter(Boolean).join(" ") ||
-                    "—"
+                    [yeast.brand, yeast.strain].filter(Boolean).join(" ") || "—"
                 },
                 {
                   label: t("brews.planned.yeastAmount", "Amount"),
@@ -227,7 +237,10 @@ export function PlannedStagePanel({ t, ctx }: StagePanelProps) {
           {secondaryList.length > 0 ? (
             <IngredientList
               t={t}
-              title={t("brews.planned.secondaryIngredients", "Secondary ingredients")}
+              title={t(
+                "brews.planned.secondaryIngredients",
+                "Secondary ingredients"
+              )}
               empty=""
               items={secondaryList}
             />
@@ -330,7 +343,12 @@ function InfoBlock({
   rows: Array<{ label: string; value: React.ReactNode }>;
 }) {
   return (
-    <div className={cn("rounded-md border border-border bg-background/40 p-3", className)}>
+    <div
+      className={cn(
+        "rounded-md border border-border bg-background/40 p-3",
+        className
+      )}
+    >
       <div className="flex items-center gap-2 text-sm font-medium">
         {icon}
         {title}

--- a/components/brews/stages/PrimaryStagePanel.tsx
+++ b/components/brews/stages/PrimaryStagePanel.tsx
@@ -5,7 +5,12 @@ import { useTranslation } from "react-i18next";
 import type { NutrientKey } from "@/types/nutrientData";
 import type { StagePanelProps } from "../stageConfig";
 import { Button } from "@/components/ui/button";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger
+} from "@/components/ui/accordion";
 import { BREW_ENTRY_TYPE } from "@/lib/brewEnums";
 import { entryPayload } from "@/lib/utils/entryPayload";
 import { parseNumber } from "@/lib/utils/validateInput";
@@ -39,8 +44,15 @@ const goFermOptions = [
   { value: "sterol-flash", label: "nuteResults.gfTypes.gfSterol" }
 ] as const;
 
-function calculateGoFermFromYeastAmount(type: string, yeastAmountG?: number | null) {
-  if (typeof yeastAmountG !== "number" || !Number.isFinite(yeastAmountG) || yeastAmountG <= 0) {
+function calculateGoFermFromYeastAmount(
+  type: string,
+  yeastAmountG?: number | null
+) {
+  if (
+    typeof yeastAmountG !== "number" ||
+    !Number.isFinite(yeastAmountG) ||
+    yeastAmountG <= 0
+  ) {
     return null;
   }
 
@@ -85,12 +97,20 @@ function loggedNutrientComponents(
   if (!Array.isArray(components)) return fallback;
 
   return fallback.map((planned) => {
-    const actual = components.find((component) => component?.key === planned.key);
+    const actual = components.find(
+      (component) => component?.key === planned.key
+    );
     const amount = actual?.amount;
     return {
       ...planned,
-      amount: typeof amount === "number" && Number.isFinite(amount) ? amount : planned.amount,
-      unit: typeof actual?.unit === "string" && actual.unit ? actual.unit : planned.unit
+      amount:
+        typeof amount === "number" && Number.isFinite(amount)
+          ? amount
+          : planned.amount,
+      unit:
+        typeof actual?.unit === "string" && actual.unit
+          ? actual.unit
+          : planned.unit
     };
   });
 }
@@ -110,8 +130,13 @@ function getNutrientRows(ctx: StagePanelProps["ctx"]) {
   const totals = plan.derived.nutrientAdditions.totalGrams;
   const otherName = plan.effectiveData.settings.other.name.trim();
   const loggedCount = ctx.recipe.actual.loggedNutrientAdditionCount ?? 0;
-  const plannedCount = Math.max(0, Math.floor(plan.derived.numberOfAdditions || 0));
-  const hasComponentLogs = keys.some((key) => (ctx.recipe.actual.loggedNutrientGrams[key] ?? 0) > 0);
+  const plannedCount = Math.max(
+    0,
+    Math.floor(plan.derived.numberOfAdditions || 0)
+  );
+  const hasComponentLogs = keys.some(
+    (key) => (ctx.recipe.actual.loggedNutrientGrams[key] ?? 0) > 0
+  );
   const remaining = keys.reduce<Record<NutrientKey, number>>(
     (acc, key) => {
       const logged = hasComponentLogs
@@ -123,23 +148,32 @@ function getNutrientRows(ctx: StagePanelProps["ctx"]) {
     { fermO: 0, fermK: 0, dap: 0, other: 0 }
   );
   const hasRemaining = keys.some((key) => remaining[key] > 0.01);
-  const suggestedRowsRemaining = Math.max(plannedCount - loggedCount, hasRemaining ? 1 : 0);
-  const targetCount = Math.max(plannedCount, loggedCount + (hasRemaining ? 1 : 0));
+  const suggestedRowsRemaining = Math.max(
+    plannedCount - loggedCount,
+    hasRemaining ? 1 : 0
+  );
+  const targetCount = Math.max(
+    plannedCount,
+    loggedCount + (hasRemaining ? 1 : 0)
+  );
 
-  const buildComponents = (divisor: number, useRemaining: boolean) => keys
-    .filter((key) => selected[key])
-    .map((key) => {
-      const amountSource = useRemaining ? remaining[key] / Math.max(1, divisor) : per[key];
-      const amount = Number.isFinite(amountSource) ? amountSource : 0;
-      return {
-        key,
-        name: key === "other" && otherName ? otherName : nutrientLabels[key],
-        amount,
-        unit: "g",
-        plannedAmount: amount
-      };
-    })
-    .filter((component) => component.amount > 0);
+  const buildComponents = (divisor: number, useRemaining: boolean) =>
+    keys
+      .filter((key) => selected[key])
+      .map((key) => {
+        const amountSource = useRemaining
+          ? remaining[key] / Math.max(1, divisor)
+          : per[key];
+        const amount = Number.isFinite(amountSource) ? amountSource : 0;
+        return {
+          key,
+          name: key === "other" && otherName ? otherName : nutrientLabels[key],
+          amount,
+          unit: "g",
+          plannedAmount: amount
+        };
+      })
+      .filter((component) => component.amount > 0);
 
   return Array.from({ length: targetCount }, (_, index) => {
     const rowIndex = index + 1;
@@ -157,22 +191,36 @@ export function PrimaryStagePanel({
   status,
   ctx,
   helpers,
-  warnings = []
+  warnings = [],
+  readOnly = false
 }: StagePanelProps) {
   const { i18n } = useTranslation();
-  const [additionDialog, setAdditionDialog] = React.useState<PlannedAddition | null>(null);
-  const [yeastDialogMode, setYeastDialogMode] = React.useState<"planned" | "manual" | null>(null);
+  const [additionDialog, setAdditionDialog] =
+    React.useState<PlannedAddition | null>(null);
+  const [yeastDialogMode, setYeastDialogMode] = React.useState<
+    "planned" | "manual" | null
+  >(null);
   const [recipeNoteDialog, setRecipeNoteDialog] = React.useState<{
     text: string;
     recipeNoteId: string;
   } | null>(null);
-  const [loggingMissingIngredients, setLoggingMissingIngredients] = React.useState(false);
+  const [loggingMissingIngredients, setLoggingMissingIngredients] =
+    React.useState(false);
   const primaryLines = React.useMemo(
-    () => buildIngredientLines(ctx.recipe.primaryIngredients, { secondaryOnly: true }),
+    () =>
+      buildIngredientLines(ctx.recipe.primaryIngredients, {
+        secondaryOnly: true
+      }),
     [ctx.recipe.primaryIngredients]
   );
-  const additiveLines = React.useMemo(() => buildAdditiveLines(ctx.recipe.additives), [ctx.recipe.additives]);
-  const primaryNotes = React.useMemo(() => buildNoteLines(ctx.recipe.primaryNotes), [ctx.recipe.primaryNotes]);
+  const additiveLines = React.useMemo(
+    () => buildAdditiveLines(ctx.recipe.additives),
+    [ctx.recipe.additives]
+  );
+  const primaryNotes = React.useMemo(
+    () => buildNoteLines(ctx.recipe.primaryNotes),
+    [ctx.recipe.primaryNotes]
+  );
   const nutrientRows = React.useMemo(() => getNutrientRows(ctx), [ctx]);
 
   const loggedIngredientIds = React.useMemo(
@@ -193,34 +241,51 @@ export function PrimaryStagePanel({
   );
 
   const missingIngredients = React.useMemo(
-    () => primaryLines.filter((line) => !loggedIngredientIds.has(String(line.line.lineId))),
+    () =>
+      primaryLines.filter(
+        (line) => !loggedIngredientIds.has(String(line.line.lineId))
+      ),
     [primaryLines, loggedIngredientIds]
   );
 
-  const canEdit = status === "current";
+  const canEdit = status === "current" && !readOnly;
   const recipeOg = ctx.recipe.derived?.gravity.ogPrimary ?? null;
   const suggestedOg = ctx.recipe.actual.suggestedOriginalGravity ?? recipeOg;
   const nutrientBasis = ctx.recipe.actual.nutrientBasis;
   const hasNutrientBasis = Boolean(nutrientBasis);
   const ogDiffersFromSuggestion = Boolean(
     nutrientBasis &&
-      typeof suggestedOg === "number" &&
-      Number.isFinite(suggestedOg) &&
-      Math.abs(nutrientBasis.basis.chosenOg - suggestedOg) > 0.0005
+    typeof suggestedOg === "number" &&
+    Number.isFinite(suggestedOg) &&
+    Math.abs(nutrientBasis.basis.chosenOg - suggestedOg) > 0.0005
   );
   const estimatedFg = getEstimatedFg(ctx);
   const finalGravity = ctx.recipe.actual.finalGravity?.gravity ?? null;
-  const fgDelta = typeof finalGravity === "number" && estimatedFg != null ? Math.abs(finalGravity - estimatedFg) : null;
+  const fgDelta =
+    typeof finalGravity === "number" && estimatedFg != null
+      ? Math.abs(finalGravity - estimatedFg)
+      : null;
   const fgOutsideEstimate = typeof fgDelta === "number" && fgDelta > 0.005;
   const ingredientDoneCount = primaryLines.length - missingIngredients.length;
-  const additiveDoneCount = additiveLines.filter((line) => loggedAdditiveIds.has(String(line.line.lineId))).length;
-  const notesDoneCount = primaryNotes.filter((item) => loggedNoteIds.has(String(item.note.lineId))).length;
-  const nutrientDoneCount = ctx.recipe.actual.loggedNutrientAdditionCount ?? loggedNutrientIndexes.size;
-  const hasRemainingNutrients = Object.values(ctx.recipe.actual.remainingNutrientGrams ?? {}).some(
-    (amount) => typeof amount === "number" && Number.isFinite(amount) && amount > 0.01
+  const additiveDoneCount = additiveLines.filter((line) =>
+    loggedAdditiveIds.has(String(line.line.lineId))
+  ).length;
+  const notesDoneCount = primaryNotes.filter((item) =>
+    loggedNoteIds.has(String(item.note.lineId))
+  ).length;
+  const nutrientDoneCount =
+    ctx.recipe.actual.loggedNutrientAdditionCount ?? loggedNutrientIndexes.size;
+  const hasRemainingNutrients = Object.values(
+    ctx.recipe.actual.remainingNutrientGrams ?? {}
+  ).some(
+    (amount) =>
+      typeof amount === "number" && Number.isFinite(amount) && amount > 0.01
   );
   const goFerm = ctx.recipe.nutrientPlan?.derived.goFerm;
-  const hasPlannedGoFerm = typeof goFerm?.amount === "number" && Number.isFinite(goFerm.amount) && goFerm.amount > 0;
+  const hasPlannedGoFerm =
+    typeof goFerm?.amount === "number" &&
+    Number.isFinite(goFerm.amount) &&
+    goFerm.amount > 0;
   const hasLoggedGoFerm = Boolean(ctx.recipe.actual.goFermAddition);
   const hasLoggedOg = Boolean(ctx.recipe.actual.originalGravity);
   const hasLoggedYeast = Boolean(ctx.recipe.actual.yeastAddition);
@@ -230,31 +295,49 @@ export function PrimaryStagePanel({
     Number.isFinite(ctx.brew.current_volume_liters) &&
     ctx.brew.current_volume_liters > 0;
   const locale = i18n.resolvedLanguage;
-  const fmtNumber = (value?: number | null, decimals = 2) => formatNumber(value, decimals, locale);
+  const fmtNumber = (value?: number | null, decimals = 2) =>
+    formatNumber(value, decimals, locale);
   const fmtGravity = (value?: number | null) => formatGravity(value, locale);
-  const primaryVolumeUnit = ctx.recipe.recipeData?.unitDefaults.volume ?? ctx.recipe.derived?.volume.unit ?? "gal";
-  const fmtVolume = (value?: number | null) => formatVolume(value, primaryVolumeUnit, locale);
-  const fmtLoggedAmount = (addition?: { amount: number | null; unit: string | null } | null) =>
-    formatLoggedAmount(addition, locale);
+  const primaryVolumeUnit =
+    ctx.recipe.recipeData?.unitDefaults.volume ??
+    ctx.recipe.derived?.volume.unit ??
+    "gal";
+  const fmtVolume = (value?: number | null) =>
+    formatVolume(value, primaryVolumeUnit, locale);
+  const fmtLoggedAmount = (
+    addition?: { amount: number | null; unit: string | null } | null
+  ) => formatLoggedAmount(addition, locale);
   const nutrientDisabledReason = !hasNutrientBasis
     ? t("brews.primary.nutrientsNeedOg", "Log OG first.")
     : !hasLoggedYeast
-      ? t("brews.primary.nutrientsNeedYeast", "Log yeast before nutrient additions.")
+      ? t(
+          "brews.primary.nutrientsNeedYeast",
+          "Log yeast before nutrient additions."
+        )
       : hasPlannedGoFerm && !hasLoggedGoFerm
-        ? t("brews.primary.nutrientsNeedGoFermDecision", "Log Go-Ferm or mark it not used before nutrient additions.")
+        ? t(
+            "brews.primary.nutrientsNeedGoFermDecision",
+            "Log Go-Ferm or mark it not used before nutrient additions."
+          )
         : null;
   const actualYeastAmountG = ctx.recipe.actual.yeastAddition?.amount;
   const yeastRowTitle =
     ctx.recipe.actual.yeastAddition?.name ||
-    [ctx.recipe.yeast?.brand, ctx.recipe.yeast?.strain].filter(Boolean).join(" ");
+    [ctx.recipe.yeast?.brand, ctx.recipe.yeast?.strain]
+      .filter(Boolean)
+      .join(" ");
   const yeastRowAmount =
     typeof ctx.recipe.actual.yeastAddition?.amount === "number"
       ? `${fmtNumber(ctx.recipe.actual.yeastAddition.amount)} ${ctx.recipe.actual.yeastAddition.unit || "g"}`
       : typeof ctx.recipe.yeast?.plannedAmountG === "number"
         ? `${fmtNumber(ctx.recipe.yeast.plannedAmountG)} g`
         : null;
-  const plannedGoFermType = ctx.recipe.nutrientPlan?.effectiveData.inputs.goFermType || "Go-Ferm";
-  const actualYeastGoFerm = calculateGoFermFromYeastAmount(plannedGoFermType, actualYeastAmountG);
+  const plannedGoFermType =
+    ctx.recipe.nutrientPlan?.effectiveData.inputs.goFermType || "Go-Ferm";
+  const actualYeastGoFerm = calculateGoFermFromYeastAmount(
+    plannedGoFermType,
+    actualYeastAmountG
+  );
   const defaultGoFermAmount = actualYeastGoFerm?.amount ?? goFerm?.amount;
   const defaultGoFermWater = actualYeastGoFerm?.water ?? goFerm?.water;
   const loggedGoFerm = ctx.recipe.actual.goFermAddition;
@@ -265,7 +348,8 @@ export function PrimaryStagePanel({
       : typeof loggedGoFerm?.meta?.plannedWaterAmount === "number"
         ? loggedGoFerm.meta.plannedWaterAmount
         : null;
-  const goFermRowTitle = loggedGoFerm?.name || t("brews.primary.goFerm", "Go-Ferm");
+  const goFermRowTitle =
+    loggedGoFerm?.name || t("brews.primary.goFerm", "Go-Ferm");
   const goFermRowAmount =
     loggedGoFerm && !loggedGoFermUsed
       ? "0 g"
@@ -298,7 +382,9 @@ export function PrimaryStagePanel({
         plannedWaterUnit: "mL"
       }
     });
-  const nextNutrientRow = nutrientRows.find((row) => row.index > nutrientDoneCount);
+  const nextNutrientRow = nutrientRows.find(
+    (row) => row.index > nutrientDoneCount
+  );
   const openNutrientRow = (row: (typeof nutrientRows)[number]) => {
     const total = row.components.reduce((sum, item) => sum + item.amount, 0);
     setAdditionDialog({
@@ -320,7 +406,8 @@ export function PrimaryStagePanel({
   };
   const markGoFermNotUsed = async () => {
     await helpers.addAddition({
-      name: ctx.recipe.nutrientPlan?.effectiveData.inputs.goFermType || "Go-Ferm",
+      name:
+        ctx.recipe.nutrientPlan?.effectiveData.inputs.goFermType || "Go-Ferm",
       kind: "NUTRIENT",
       source: "recipe_go_ferm",
       amount: 0,
@@ -357,23 +444,40 @@ export function PrimaryStagePanel({
       setLoggingMissingIngredients(false);
     }
   };
-  const pitchPending = !hasNutrientBasis || !hasLoggedYeast || (hasPlannedGoFerm && !hasLoggedGoFerm);
+  const pitchPending =
+    !hasNutrientBasis ||
+    !hasLoggedYeast ||
+    (hasPlannedGoFerm && !hasLoggedGoFerm);
   const nutrientsPending = !pitchPending && hasRemainingNutrients;
   const fgPending = !pitchPending && !nutrientsPending && !hasLoggedFg;
-  const transferPending = !pitchPending && !nutrientsPending && !fgPending && !hasLoggedSecondaryVolume;
+  const transferPending =
+    !pitchPending &&
+    !nutrientsPending &&
+    !fgPending &&
+    !hasLoggedSecondaryVolume;
   const workflowFocus = pitchPending
     ? t("brews.primary.focusPitch", "Pitch yeast and record starting details")
     : nutrientsPending
       ? t("brews.primary.focusNutrients", "Keep up with nutrient additions")
       : fgPending
-        ? t("brews.primary.focusFg", "Take final gravity when fermentation is finished")
+        ? t(
+            "brews.primary.focusFg",
+            "Take final gravity when fermentation is finished"
+          )
         : transferPending
-          ? t("brews.primary.focusTransfer", "Transfer to secondary and record the new volume")
+          ? t(
+              "brews.primary.focusTransfer",
+              "Transfer to secondary and record the new volume"
+            )
           : t("brews.primary.focusReady", "Ready to move to secondary");
 
   const openReading = () => {
     helpers.openAddEntry?.({
-      allowedTypes: [BREW_ENTRY_TYPE.GRAVITY, BREW_ENTRY_TYPE.TEMPERATURE, BREW_ENTRY_TYPE.PH]
+      allowedTypes: [
+        BREW_ENTRY_TYPE.GRAVITY,
+        BREW_ENTRY_TYPE.TEMPERATURE,
+        BREW_ENTRY_TYPE.PH
+      ]
     });
   };
 
@@ -385,16 +489,31 @@ export function PrimaryStagePanel({
           value={
             ctx.recipe.actual.originalGravity
               ? fmtGravity(ctx.recipe.actual.originalGravity.gravity)
-              : typeof suggestedOg === "number" && Number.isFinite(suggestedOg) && suggestedOg > 1
-                ? t("brews.primary.suggestedOgAvailable", "Suggested OG available")
+              : typeof suggestedOg === "number" &&
+                  Number.isFinite(suggestedOg) &&
+                  suggestedOg > 1
+                ? t(
+                    "brews.primary.suggestedOgAvailable",
+                    "Suggested OG available"
+                  )
                 : "—"
           }
-          tone={ctx.recipe.actual.originalGravity && !ogDiffersFromSuggestion ? "ok" : "warn"}
+          tone={
+            ctx.recipe.actual.originalGravity && !ogDiffersFromSuggestion
+              ? "ok"
+              : "warn"
+          }
         />
         <StatusTile
           label={t("brews.primary.fg", "Final gravity")}
           value={fmtGravity(finalGravity)}
-          tone={ctx.recipe.actual.finalGravity ? (fgOutsideEstimate ? "warn" : "ok") : "warn"}
+          tone={
+            ctx.recipe.actual.finalGravity
+              ? fgOutsideEstimate
+                ? "warn"
+                : "ok"
+              : "warn"
+          }
         />
         <StatusTile
           label={t("brews.primary.currentVolume", "Current volume")}
@@ -421,12 +540,24 @@ export function PrimaryStagePanel({
           </div>
           <div className="flex flex-wrap gap-2">
             {missingIngredients.length > 0 ? (
-              <Button size="sm" variant="secondary" disabled={!canEdit || loggingMissingIngredients} onClick={logMissingIngredients}>
-                {t("brews.primary.logMissingIngredients", "Log missing ingredients")}
+              <Button
+                size="sm"
+                variant="secondary"
+                disabled={!canEdit || loggingMissingIngredients}
+                onClick={logMissingIngredients}
+              >
+                {t(
+                  "brews.primary.logMissingIngredients",
+                  "Log missing ingredients"
+                )}
               </Button>
             ) : null}
             {pitchPending && !hasNutrientBasis ? (
-              <Button size="sm" disabled={!canEdit} onClick={() => helpers.openOriginalGravityDialog?.()}>
+              <Button
+                size="sm"
+                disabled={!canEdit}
+                onClick={() => helpers.openOriginalGravityDialog?.()}
+              >
                 {t("brews.actions.logOg", "Log OG")}
               </Button>
             ) : null}
@@ -434,7 +565,9 @@ export function PrimaryStagePanel({
               <Button
                 size="sm"
                 disabled={!canEdit}
-                onClick={() => setYeastDialogMode(ctx.recipe.yeast ? "planned" : "manual")}
+                onClick={() =>
+                  setYeastDialogMode(ctx.recipe.yeast ? "planned" : "manual")
+                }
               >
                 {t("brews.actions.logYeast", "Log yeast")}
               </Button>
@@ -454,13 +587,24 @@ export function PrimaryStagePanel({
               </Button>
             ) : null}
             {fgPending ? (
-              <Button size="sm" onClick={() => helpers.openFinalGravityDialog?.()} disabled={!canEdit}>
+              <Button
+                size="sm"
+                onClick={() => helpers.openFinalGravityDialog?.()}
+                disabled={!canEdit}
+              >
                 {t("brews.actions.logFg", "Log FG")}
               </Button>
             ) : null}
             {transferPending ? (
-              <Button size="sm" onClick={() => helpers.openRecordVolume?.()} disabled={!canEdit}>
-                {t("brews.actions.logSecondaryVolume", "Record secondary volume")}
+              <Button
+                size="sm"
+                onClick={() => helpers.openRecordVolume?.()}
+                disabled={!canEdit}
+              >
+                {t(
+                  "brews.actions.logSecondaryVolume",
+                  "Record secondary volume"
+                )}
               </Button>
             ) : null}
             <Button
@@ -472,7 +616,12 @@ export function PrimaryStagePanel({
               {t("brews.moveToSecondary", "Move to Secondary")}
             </Button>
             {hasLoggedOg ? (
-              <Button size="sm" variant="secondary" disabled={!canEdit} onClick={openReading}>
+              <Button
+                size="sm"
+                variant="secondary"
+                disabled={!canEdit}
+                onClick={openReading}
+              >
                 {t("brews.actions.logReading", "Log reading")}
               </Button>
             ) : null}
@@ -488,16 +637,21 @@ export function PrimaryStagePanel({
             "brews.warn.finalGravityEstimateMismatchWithValues",
             "Final gravity is not close to the recipe’s estimated FG."
           )}{" "}
-          {t("brews.primary.estimatedFg", "Estimated FG")}: {fmtGravity(estimatedFg)},{" "}
-          {t("brews.primary.loggedFg", "Logged FG")}: {fmtGravity(finalGravity)}.
+          {t("brews.primary.estimatedFg", "Estimated FG")}:{" "}
+          {fmtGravity(estimatedFg)}, {t("brews.primary.loggedFg", "Logged FG")}:{" "}
+          {fmtGravity(finalGravity)}.
         </div>
       ) : null}
 
       {ogDiffersFromSuggestion && nutrientBasis ? (
         <div className="rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3 text-sm">
-          {t("brews.primary.ogDiffersFromSuggestion", "Logged OG differs from the suggested OG used for planning.")}{" "}
-          {t("brews.primary.suggestedOg", "Suggested OG")}: {fmtGravity(suggestedOg)},{" "}
-          {t("brews.primary.loggedOg", "Logged OG")}: {fmtGravity(nutrientBasis.basis.chosenOg)}.
+          {t(
+            "brews.primary.ogDiffersFromSuggestion",
+            "Logged OG differs from the suggested OG used for planning."
+          )}{" "}
+          {t("brews.primary.suggestedOg", "Suggested OG")}:{" "}
+          {fmtGravity(suggestedOg)}, {t("brews.primary.loggedOg", "Logged OG")}:{" "}
+          {fmtGravity(nutrientBasis.basis.chosenOg)}.
         </div>
       ) : null}
 
@@ -536,7 +690,12 @@ export function PrimaryStagePanel({
                     actionLabel={t("brews.primary.log", "Log")}
                   />
                   {!hasLoggedGoFerm ? (
-                    <Button size="sm" variant="secondary" disabled={!canEdit} onClick={markGoFermNotUsed}>
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      disabled={!canEdit}
+                      onClick={markGoFermNotUsed}
+                    >
                       {t("brews.primary.markGoFermNotUsed", "Mark not used")}
                     </Button>
                   ) : null}
@@ -544,9 +703,17 @@ export function PrimaryStagePanel({
               ) : null}
 
               {!hasLoggedYeast ? (
-                <Button size="sm" variant="secondary" disabled={!canEdit} onClick={() => setYeastDialogMode("manual")}>
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  disabled={!canEdit}
+                  onClick={() => setYeastDialogMode("manual")}
+                >
                   {ctx.recipe.yeast
-                    ? t("brews.primary.logDifferentYeast", "Log different yeast")
+                    ? t(
+                        "brews.primary.logDifferentYeast",
+                        "Log different yeast"
+                      )
                     : t("brews.actions.logYeast", "Log yeast")}
                 </Button>
               ) : null}
@@ -556,13 +723,18 @@ export function PrimaryStagePanel({
 
         <AccordionItem value="ingredients">
           <AccordionTrigger>
-            {t("brews.primary.ingredients", "Primary ingredients")} · {ingredientDoneCount}/{primaryLines.length}
+            {t("brews.primary.ingredients", "Primary ingredients")} ·{" "}
+            {ingredientDoneCount}/{primaryLines.length}
           </AccordionTrigger>
           <AccordionContent>
             <div className="space-y-2">
               <Button
                 size="sm"
-                disabled={!canEdit || missingIngredients.length === 0 || loggingMissingIngredients}
+                disabled={
+                  !canEdit ||
+                  missingIngredients.length === 0 ||
+                  loggingMissingIngredients
+                }
                 onClick={logMissingIngredients}
               >
                 {t("brews.primary.logMissing", "Log missing")}
@@ -570,16 +742,27 @@ export function PrimaryStagePanel({
               {primaryLines.length ? (
                 <ul className="space-y-1">
                   {primaryLines.map((item) => {
-                    const isLogged = loggedIngredientIds.has(String(item.line.lineId));
+                    const isLogged = loggedIngredientIds.has(
+                      String(item.line.lineId)
+                    );
                     const loggedAddition = latestLoggedItem(
-                      ctx.recipe.actual.additionsByRecipeIngredientId[String(item.line.lineId)]
+                      ctx.recipe.actual.additionsByRecipeIngredientId[
+                        String(item.line.lineId)
+                      ]
                     );
                     const { amount, unit } = getIngredientAmount(item.line);
                     return (
                       <WorkRow
                         key={item.line.lineId}
-                        title={getBrewItemLabel(t, loggedAddition?.name || item.name)}
-                        detail={item.secondary ? `${t("brews.planned.altAmount", "Alt")}: ${item.secondary}` : null}
+                        title={getBrewItemLabel(
+                          t,
+                          loggedAddition?.name || item.name
+                        )}
+                        detail={
+                          item.secondary
+                            ? `${t("brews.planned.altAmount", "Alt")}: ${item.secondary}`
+                            : null
+                        }
                         amount={fmtLoggedAmount(loggedAddition) ?? item.primary}
                         isLogged={isLogged}
                         disabled={!canEdit}
@@ -587,7 +770,10 @@ export function PrimaryStagePanel({
                         actionLabel={t("brews.primary.log", "Log")}
                         onLog={() =>
                           setAdditionDialog({
-                            title: t("brews.primary.logIngredient", "Log ingredient"),
+                            title: t(
+                              "brews.primary.logIngredient",
+                              "Log ingredient"
+                            ),
                             name: item.name,
                             kind: "INGREDIENT",
                             source: "recipe_ingredient",
@@ -604,7 +790,10 @@ export function PrimaryStagePanel({
                 </ul>
               ) : (
                 <EmptyState>
-                  {t("brews.primary.noPrimaryIngredients", "No primary ingredients found in the linked recipe.")}
+                  {t(
+                    "brews.primary.noPrimaryIngredients",
+                    "No primary ingredients found in the linked recipe."
+                  )}
                 </EmptyState>
               )}
             </div>
@@ -613,21 +802,29 @@ export function PrimaryStagePanel({
 
         <AccordionItem value="additives">
           <AccordionTrigger>
-            {t("brews.primary.additives", "Planned additives")} · {additiveDoneCount}/{additiveLines.length}
+            {t("brews.primary.additives", "Planned additives")} ·{" "}
+            {additiveDoneCount}/{additiveLines.length}
           </AccordionTrigger>
           <AccordionContent>
             {additiveLines.length ? (
               <ul className="space-y-1">
                 {additiveLines.map((item) => {
-                  const isLogged = loggedAdditiveIds.has(String(item.line.lineId));
+                  const isLogged = loggedAdditiveIds.has(
+                    String(item.line.lineId)
+                  );
                   const loggedAddition = latestLoggedItem(
-                    ctx.recipe.actual.additionsByRecipeAdditiveId[String(item.line.lineId)]
+                    ctx.recipe.actual.additionsByRecipeAdditiveId[
+                      String(item.line.lineId)
+                    ]
                   );
                   const { amount, unit } = getAdditiveAmount(item.line);
                   return (
                     <WorkRow
                       key={item.line.lineId}
-                      title={getBrewItemLabel(t, loggedAddition?.name || item.name)}
+                      title={getBrewItemLabel(
+                        t,
+                        loggedAddition?.name || item.name
+                      )}
                       amount={fmtLoggedAmount(loggedAddition) ?? item.amount}
                       isLogged={isLogged}
                       disabled={!canEdit}
@@ -651,7 +848,10 @@ export function PrimaryStagePanel({
               </ul>
             ) : (
               <EmptyState>
-                {t("brews.primary.noAdditives", "No planned additives found in the linked recipe.")}
+                {t(
+                  "brews.primary.noAdditives",
+                  "No planned additives found in the linked recipe."
+                )}
               </EmptyState>
             )}
           </AccordionContent>
@@ -659,7 +859,8 @@ export function PrimaryStagePanel({
 
         <AccordionItem value="nutrients">
           <AccordionTrigger>
-            {t("brews.primary.nutrients", "Nutrients")} · {nutrientDoneCount}/{nutrientRows.length}
+            {t("brews.primary.nutrients", "Nutrients")} · {nutrientDoneCount}/
+            {nutrientRows.length}
           </AccordionTrigger>
           <AccordionContent>
             {nutrientRows.length ? (
@@ -670,7 +871,9 @@ export function PrimaryStagePanel({
                     "This schedule uses logged OG, linked primary additions, yeast, and Go-Ferm. Change the schedule settings in the recipe builder for now."
                   )}
                 </div>
-                {hasNutrientBasis && ctx.recipe.actual.missingActualPrimaryIngredientIds.length > 0 ? (
+                {hasNutrientBasis &&
+                ctx.recipe.actual.missingActualPrimaryIngredientIds.length >
+                  0 ? (
                   <div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-xs text-muted-foreground">
                     {t(
                       "brews.primary.nutrientsUsingPlannedIngredients",
@@ -678,8 +881,13 @@ export function PrimaryStagePanel({
                     )}
                   </div>
                 ) : null}
-                {nutrientDoneCount >= Math.max(0, Math.floor(ctx.recipe.nutrientPlan?.derived.numberOfAdditions || 0)) &&
-                hasRemainingNutrients ? (
+                {nutrientDoneCount >=
+                  Math.max(
+                    0,
+                    Math.floor(
+                      ctx.recipe.nutrientPlan?.derived.numberOfAdditions || 0
+                    )
+                  ) && hasRemainingNutrients ? (
                   <div className="rounded-md border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-xs text-muted-foreground">
                     {t(
                       "brews.primary.nutrientsRemainingAfterPlan",
@@ -690,19 +898,32 @@ export function PrimaryStagePanel({
                 <ul className="space-y-1">
                   {nutrientRows.map((row) => {
                     const isLogged = row.index <= nutrientDoneCount;
-                    const loggedAddition = loggedNutrientAdditionForIndex(ctx.recipe.actual.additions, row.index);
+                    const loggedAddition = loggedNutrientAdditionForIndex(
+                      ctx.recipe.actual.additions,
+                      row.index
+                    );
                     const displayComponents = isLogged
                       ? loggedNutrientComponents(loggedAddition, row.components)
                       : row.components;
-                    const total = displayComponents.reduce((sum, item) => sum + item.amount, 0);
+                    const total = displayComponents.reduce(
+                      (sum, item) => sum + item.amount,
+                      0
+                    );
                     return (
                       <WorkRow
                         key={row.index}
-                        title={t("brews.primary.nutrientAddition", "Nutrient addition {{index}}", {
-                          index: row.index
-                        })}
+                        title={t(
+                          "brews.primary.nutrientAddition",
+                          "Nutrient addition {{index}}",
+                          {
+                            index: row.index
+                          }
+                        )}
                         detail={displayComponents
-                          .map((item) => `${getBrewItemLabel(t, item.name)}: ${fmtNumber(item.amount)} ${item.unit}`)
+                          .map(
+                            (item) =>
+                              `${getBrewItemLabel(t, item.name)}: ${fmtNumber(item.amount)} ${item.unit}`
+                          )
                           .join(", ")}
                         amount={`${fmtNumber(total)} g`}
                         isLogged={isLogged}
@@ -717,14 +938,20 @@ export function PrimaryStagePanel({
                 </ul>
               </div>
             ) : (
-              <EmptyState>{t("brews.primary.noNutrients", "No planned nutrient additions found.")}</EmptyState>
+              <EmptyState>
+                {t(
+                  "brews.primary.noNutrients",
+                  "No planned nutrient additions found."
+                )}
+              </EmptyState>
             )}
           </AccordionContent>
         </AccordionItem>
 
         <AccordionItem value="notes">
           <AccordionTrigger>
-            {t("brews.primary.recipeNotes", "Recipe primary notes")} · {notesDoneCount}/{primaryNotes.length}
+            {t("brews.primary.recipeNotes", "Recipe primary notes")} ·{" "}
+            {notesDoneCount}/{primaryNotes.length}
           </AccordionTrigger>
           <AccordionContent>
             {primaryNotes.length ? (
@@ -751,7 +978,10 @@ export function PrimaryStagePanel({
               </ul>
             ) : (
               <EmptyState>
-                {t("brews.primary.noRecipeNotes", "No primary notes found in the linked recipe.")}
+                {t(
+                  "brews.primary.noRecipeNotes",
+                  "No primary notes found in the linked recipe."
+                )}
               </EmptyState>
             )}
           </AccordionContent>
@@ -789,7 +1019,10 @@ export function PrimaryStagePanel({
         note={
           recipeNoteDialog
             ? {
-                title: t("brews.primary.recipeNoteTitle", "Add recipe primary note"),
+                title: t(
+                  "brews.primary.recipeNoteTitle",
+                  "Add recipe primary note"
+                ),
                 text: recipeNoteDialog.text
               }
             : null

--- a/components/brews/stages/SecondaryStagePanel.tsx
+++ b/components/brews/stages/SecondaryStagePanel.tsx
@@ -3,18 +3,35 @@
 import * as React from "react";
 import { useTranslation } from "react-i18next";
 
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger
+} from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import {
   BREW_TRACKER_DIALOG_CONTENT_CLASS,
   BREW_TRACKER_DIALOG_FOOTER_CLASS,
   BREW_TRACKER_WIDE_DIALOG_CONTENT_CLASS
 } from "@/components/brews/brewTrackerDialog";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog";
 import { DateTimePicker } from "@/components/ui/datetime-picker";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { BREW_ENTRY_TYPE } from "@/lib/brewEnums";
 import { entryPayload } from "@/lib/utils/entryPayload";
@@ -33,7 +50,12 @@ import {
 } from "@/lib/utils/brewTrackingScaling";
 import { calcABV } from "@/lib/utils/unitConverter";
 import { isValidNumber, parseNumber } from "@/lib/utils/validateInput";
-import type { IngredientLine, RecipeUnitDefaults, VolumeUnit, WeightUnit } from "@/types/recipeData";
+import type {
+  IngredientLine,
+  RecipeUnitDefaults,
+  VolumeUnit,
+  WeightUnit
+} from "@/types/recipeData";
 import type { StagePanelProps } from "../stageConfig";
 import {
   AmountUnitField,
@@ -108,18 +130,28 @@ const SUPPLEMENTAL_GRAM_THRESHOLD = 0.01;
 const SUPPLEMENTAL_CAMPDEN_THRESHOLD = 0.01;
 const SUPPLEMENTAL_VOLUME_THRESHOLD_L = 0.04;
 
-function fmtVolumeWithZero(liters?: number | null, unit: RecipeUnitDefaults["volume"] = "gal", locale?: string) {
+function fmtVolumeWithZero(
+  liters?: number | null,
+  unit: RecipeUnitDefaults["volume"] = "gal",
+  locale?: string
+) {
   return formatVolume(liters, unit, locale, { allowZero: true });
 }
 
-function getEntryTime(entry: StagePanelProps["ctx"]["brew"]["entries"][number]) {
+function getEntryTime(
+  entry: StagePanelProps["ctx"]["brew"]["entries"][number]
+) {
   const value = (entry as any).datetime ?? entry.createdAt;
   return typeof value === "string" ? new Date(value).getTime() : 0;
 }
 
 function latestLoggedPh(ctx: StagePanelProps["ctx"]) {
   const entry = ctx.brew.entries
-    .filter((item) => item.type === BREW_ENTRY_TYPE.PH && typeof (item.data as any)?.ph === "number")
+    .filter(
+      (item) =>
+        item.type === BREW_ENTRY_TYPE.PH &&
+        typeof (item.data as any)?.ph === "number"
+    )
     .sort((a, b) => getEntryTime(b) - getEntryTime(a))[0];
 
   const ph = (entry?.data as any)?.ph;
@@ -164,8 +196,20 @@ function plannedSecondaryVolumeL(line: IngredientLine) {
   return amount * VOLUME_TO_L[unit];
 }
 
-function loggedSecondaryVolumeL(line: IngredientLine, addition?: { amount: number | null; unit: string | null; meta: Record<string, any> | null } | null) {
-  if (!addition || typeof addition.amount !== "number" || !Number.isFinite(addition.amount) || addition.amount <= 0) {
+function loggedSecondaryVolumeL(
+  line: IngredientLine,
+  addition?: {
+    amount: number | null;
+    unit: string | null;
+    meta: Record<string, any> | null;
+  } | null
+) {
+  if (
+    !addition ||
+    typeof addition.amount !== "number" ||
+    !Number.isFinite(addition.amount) ||
+    addition.amount <= 0
+  ) {
     return null;
   }
 
@@ -180,8 +224,17 @@ function loggedSecondaryVolumeL(line: IngredientLine, addition?: { amount: numbe
 
   if (addition.meta?.actualBasis === "volume") {
     const metaUnit = normalizeVolumeUnit(addition.meta?.plannedVolumeUnit);
-    const metaAmount = typeof addition.meta?.plannedVolumeAmount === "number" ? addition.meta.plannedVolumeAmount : null;
-    if (metaUnit && metaAmount != null && Number.isFinite(metaAmount) && metaAmount > 0) return metaAmount * VOLUME_TO_L[metaUnit];
+    const metaAmount =
+      typeof addition.meta?.plannedVolumeAmount === "number"
+        ? addition.meta.plannedVolumeAmount
+        : null;
+    if (
+      metaUnit &&
+      metaAmount != null &&
+      Number.isFinite(metaAmount) &&
+      metaAmount > 0
+    )
+      return metaAmount * VOLUME_TO_L[metaUnit];
   }
 
   return null;
@@ -190,7 +243,11 @@ function loggedSecondaryVolumeL(line: IngredientLine, addition?: { amount: numbe
 function toIngredientSg(line: IngredientLine) {
   const brix = parseNumber(line.brix);
   if (!Number.isFinite(brix)) return null;
-  const sg = 1.00001 + 0.0038661 * brix + 1.3488 * 10 ** -5 * brix ** 2 + 4.3074 * 10 ** -8 * brix ** 3;
+  const sg =
+    1.00001 +
+    0.0038661 * brix +
+    1.3488 * 10 ** -5 * brix ** 2 +
+    4.3074 * 10 ** -8 * brix ** 3;
   return Number.isFinite(sg) && sg > 0 ? sg : null;
 }
 
@@ -203,7 +260,9 @@ function getSecondaryVolumeBreakdown(ctx: StagePanelProps["ctx"]) {
 
   for (const line of ctx.recipe.secondaryIngredients) {
     if (!(line.name ?? "").trim()) continue;
-    const logged = latestLoggedItem(ctx.recipe.actual.additionsByRecipeIngredientId[String(line.lineId)]);
+    const logged = latestLoggedItem(
+      ctx.recipe.actual.additionsByRecipeIngredientId[String(line.lineId)]
+    );
     const loggedVolume = loggedSecondaryVolumeL(line, logged);
     if (loggedVolume != null) {
       loggedVolumeL += loggedVolume;
@@ -238,29 +297,50 @@ function getSecondaryVolumeBreakdown(ctx: StagePanelProps["ctx"]) {
   } as const;
 }
 
-function getStabilizerPlan(ctx: StagePanelProps["ctx"], locale?: string): StabilizerPlan | null {
+function getStabilizerPlan(
+  ctx: StagePanelProps["ctx"],
+  locale?: string
+): StabilizerPlan | null {
   const currentVolume = ctx.brew.current_volume_liters;
   const baseVolumeL =
-    typeof currentVolume === "number" && Number.isFinite(currentVolume) && currentVolume > 0
+    typeof currentVolume === "number" &&
+    Number.isFinite(currentVolume) &&
+    currentVolume > 0
       ? currentVolume
       : null;
 
   if (baseVolumeL == null) return null;
 
-  const og = ctx.recipe.actual.originalGravity?.gravity ?? ctx.recipe.derived?.gravity.ogPrimary ?? null;
+  const og =
+    ctx.recipe.actual.originalGravity?.gravity ??
+    ctx.recipe.derived?.gravity.ogPrimary ??
+    null;
   const fg =
     ctx.recipe.actual.finalGravity?.gravity ??
-    (ctx.recipe.recipeData?.fg != null ? parseNumber(String(ctx.recipe.recipeData.fg)) : null);
-  const hasLoggedOgFg = Boolean(ctx.recipe.actual.originalGravity && ctx.recipe.actual.finalGravity);
+    (ctx.recipe.recipeData?.fg != null
+      ? parseNumber(String(ctx.recipe.recipeData.fg))
+      : null);
+  const hasLoggedOgFg = Boolean(
+    ctx.recipe.actual.originalGravity && ctx.recipe.actual.finalGravity
+  );
   const loggedAbv =
-    typeof og === "number" && Number.isFinite(og) && typeof fg === "number" && Number.isFinite(fg) ? calcABV(og, fg) : null;
-  const abv = typeof loggedAbv === "number" && Number.isFinite(loggedAbv) ? loggedAbv : null;
+    typeof og === "number" &&
+    Number.isFinite(og) &&
+    typeof fg === "number" &&
+    Number.isFinite(fg)
+      ? calcABV(og, fg)
+      : null;
+  const abv =
+    typeof loggedAbv === "number" && Number.isFinite(loggedAbv)
+      ? loggedAbv
+      : null;
 
   if (abv == null) return null;
 
   const secondaryVolume = getSecondaryVolumeBreakdown(ctx);
   const adjustedTotalVolumeL = baseVolumeL + secondaryVolume.totalVolumeL;
-  const dilutedAbv = adjustedTotalVolumeL > 0 ? (abv * baseVolumeL) / adjustedTotalVolumeL : abv;
+  const dilutedAbv =
+    adjustedTotalVolumeL > 0 ? (abv * baseVolumeL) / adjustedTotalVolumeL : abv;
 
   const latestPh = latestLoggedPh(ctx);
   const recipePh = ctx.recipe.stabilizerPlan?.phReading?.trim();
@@ -284,19 +364,26 @@ function getStabilizerPlan(ctx: StagePanelProps["ctx"], locale?: string): Stabil
     baseAbv: abv,
     dilutedAbv,
     defaultPh,
-    phSource: latestPh != null ? "latest_logged" : recipePh ? "recipe" : "default",
+    phSource:
+      latestPh != null ? "latest_logged" : recipePh ? "recipe" : "default",
     stabilizerType: ctx.recipe.stabilizerPlan?.type ?? "kmeta",
-    volumeUnit: ctx.recipe.recipeData?.unitDefaults.volume ?? ctx.recipe.derived?.volume.unit ?? "gal"
+    volumeUnit:
+      ctx.recipe.recipeData?.unitDefaults.volume ??
+      ctx.recipe.derived?.volume.unit ??
+      "gal"
   };
 }
 
 function getLoggedStabilizerAdditions(ctx: StagePanelProps["ctx"]) {
   return ctx.recipe.actual.additions.filter(
-    (addition) => addition.meta?.stabilizer === true && addition.meta?.stage === "SECONDARY"
+    (addition) =>
+      addition.meta?.stabilizer === true && addition.meta?.stage === "SECONDARY"
   );
 }
 
-function getLatestLoggedStabilizer(additions: ReturnType<typeof getLoggedStabilizerAdditions>) {
+function getLatestLoggedStabilizer(
+  additions: ReturnType<typeof getLoggedStabilizerAdditions>
+) {
   return latestLoggedItem(additions);
 }
 
@@ -311,11 +398,13 @@ function getSupplementalStabilizerPlan(
 
   const latest = getLatestLoggedStabilizer(additions);
   const latestSecondaryVolumeL =
-    typeof latest?.meta?.secondaryVolumeLiters === "number" && Number.isFinite(latest.meta.secondaryVolumeLiters)
+    typeof latest?.meta?.secondaryVolumeLiters === "number" &&
+    Number.isFinite(latest.meta.secondaryVolumeLiters)
       ? latest.meta.secondaryVolumeLiters
       : null;
   const latestAdjustedTotalVolumeL =
-    typeof latest?.meta?.adjustedTotalVolumeLiters === "number" && Number.isFinite(latest.meta.adjustedTotalVolumeLiters)
+    typeof latest?.meta?.adjustedTotalVolumeLiters === "number" &&
+    Number.isFinite(latest.meta.adjustedTotalVolumeLiters)
       ? latest.meta.adjustedTotalVolumeLiters
       : null;
   const currentVolumeL =
@@ -325,33 +414,46 @@ function getSupplementalStabilizerPlan(
       ? ctx.brew.current_volume_liters
       : null;
   const secondaryDilutionIncreased =
-    latestSecondaryVolumeL != null && plan.secondaryVolumeL > latestSecondaryVolumeL + SUPPLEMENTAL_VOLUME_THRESHOLD_L;
+    latestSecondaryVolumeL != null &&
+    plan.secondaryVolumeL >
+      latestSecondaryVolumeL + SUPPLEMENTAL_VOLUME_THRESHOLD_L;
   const measuredVolumeOverEstimate =
     latestAdjustedTotalVolumeL != null &&
     currentVolumeL != null &&
-    currentVolumeL > latestAdjustedTotalVolumeL + SUPPLEMENTAL_VOLUME_THRESHOLD_L;
+    currentVolumeL >
+      latestAdjustedTotalVolumeL + SUPPLEMENTAL_VOLUME_THRESHOLD_L;
 
   if (latestSecondaryVolumeL != null || latestAdjustedTotalVolumeL != null) {
     if (!secondaryDilutionIncreased && !measuredVolumeOverEstimate) return null;
   }
 
   const stabilizerType =
-    latest?.meta?.stabilizerType === "nameta" || latest?.meta?.stabilizerType === "kmeta"
+    latest?.meta?.stabilizerType === "nameta" ||
+    latest?.meta?.stabilizerType === "kmeta"
       ? latest.meta.stabilizerType
       : plan.stabilizerType;
-  const sulfiteForm = latest?.meta?.sulfiteForm === "campden" ? "campden" : "powder";
+  const sulfiteForm =
+    latest?.meta?.sulfiteForm === "campden" ? "campden" : "powder";
   const ph =
     typeof latest?.meta?.ph === "number" && Number.isFinite(latest.meta.ph)
       ? String(latest.meta.ph)
       : plan.defaultPh;
   const latestBaseVolumeL =
-    typeof latest?.meta?.baseVolumeLiters === "number" && Number.isFinite(latest.meta.baseVolumeLiters)
+    typeof latest?.meta?.baseVolumeLiters === "number" &&
+    Number.isFinite(latest.meta.baseVolumeLiters)
       ? latest.meta.baseVolumeLiters
       : null;
   const latestBaseAbv =
-    typeof latest?.meta?.baseAbv === "number" && Number.isFinite(latest.meta.baseAbv) ? latest.meta.baseAbv : null;
+    typeof latest?.meta?.baseAbv === "number" &&
+    Number.isFinite(latest.meta.baseAbv)
+      ? latest.meta.baseAbv
+      : null;
   const requiredVolumeL =
-    measuredVolumeOverEstimate && !secondaryDilutionIncreased && currentVolumeL != null ? currentVolumeL : plan.volumeL;
+    measuredVolumeOverEstimate &&
+    !secondaryDilutionIncreased &&
+    currentVolumeL != null
+      ? currentVolumeL
+      : plan.volumeL;
   const requiredAbv =
     measuredVolumeOverEstimate &&
     !secondaryDilutionIncreased &&
@@ -371,7 +473,10 @@ function getSupplementalStabilizerPlan(
   const logged = additions.reduce(
     (acc, addition) => {
       const kind = addition.meta?.stabilizerKind;
-      const amount = typeof addition.amount === "number" && Number.isFinite(addition.amount) ? addition.amount : 0;
+      const amount =
+        typeof addition.amount === "number" && Number.isFinite(addition.amount)
+          ? addition.amount
+          : 0;
       const unit = addition.unit ?? "";
 
       if (kind === "sorbate") {
@@ -411,27 +516,39 @@ function getSupplementalStabilizerPlan(
   };
 }
 
-export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: StagePanelProps) {
+export function SecondaryStagePanel({
+  t,
+  status,
+  ctx,
+  helpers,
+  warnings = [],
+  readOnly = false
+}: StagePanelProps) {
   const { i18n } = useTranslation();
-  const [additionDialog, setAdditionDialog] = React.useState<PlannedSecondaryAddition | null>(null);
+  const [additionDialog, setAdditionDialog] =
+    React.useState<PlannedSecondaryAddition | null>(null);
   const [stabilizerDialogOpen, setStabilizerDialogOpen] = React.useState(false);
   const [bulkAgeConfirmOpen, setBulkAgeConfirmOpen] = React.useState(false);
   const [packageConfirmOpen, setPackageConfirmOpen] = React.useState(false);
-  const [secondaryBeforeStabilizersOpen, setSecondaryBeforeStabilizersOpen] = React.useState(false);
+  const [secondaryBeforeStabilizersOpen, setSecondaryBeforeStabilizersOpen] =
+    React.useState(false);
   const [recipeNoteDialog, setRecipeNoteDialog] = React.useState<{
     text: string;
     recipeNoteId: string;
   } | null>(null);
-  const [scaledSecondarySuggestions, setScaledSecondarySuggestions] = React.useState<
-    Map<string, ScaledIngredientSuggestion>
-  >(new Map());
-  const [scaledAdditiveSuggestions, setScaledAdditiveSuggestions] = React.useState<
-    Map<string, ScaledAdditiveSuggestion>
-  >(new Map());
-  const [loggingMissingSecondary, setLoggingMissingSecondary] = React.useState(false);
-  const [loggingMissingAdditives, setLoggingMissingAdditives] = React.useState(false);
-  const [loggingSupplementalStabilizers, setLoggingSupplementalStabilizers] = React.useState(false);
-  const pendingSecondaryIngredientAction = React.useRef<(() => void | Promise<void>) | null>(null);
+  const [scaledSecondarySuggestions, setScaledSecondarySuggestions] =
+    React.useState<Map<string, ScaledIngredientSuggestion>>(new Map());
+  const [scaledAdditiveSuggestions, setScaledAdditiveSuggestions] =
+    React.useState<Map<string, ScaledAdditiveSuggestion>>(new Map());
+  const [loggingMissingSecondary, setLoggingMissingSecondary] =
+    React.useState(false);
+  const [loggingMissingAdditives, setLoggingMissingAdditives] =
+    React.useState(false);
+  const [loggingSupplementalStabilizers, setLoggingSupplementalStabilizers] =
+    React.useState(false);
+  const pendingSecondaryIngredientAction = React.useRef<
+    (() => void | Promise<void>) | null
+  >(null);
 
   const secondaryLines = React.useMemo(
     () => buildIngredientLines(ctx.recipe.secondaryIngredients),
@@ -441,7 +558,10 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
     () => buildNoteLines(ctx.recipe.secondaryNotes),
     [ctx.recipe.secondaryNotes]
   );
-  const additiveLines = React.useMemo(() => buildAdditiveLines(ctx.recipe.additives), [ctx.recipe.additives]);
+  const additiveLines = React.useMemo(
+    () => buildAdditiveLines(ctx.recipe.additives),
+    [ctx.recipe.additives]
+  );
   const loggedIngredientIds = React.useMemo(
     () => new Set(ctx.recipe.actual.loggedRecipeIngredientIds),
     [ctx.recipe.actual.loggedRecipeIngredientIds]
@@ -455,38 +575,57 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
     [ctx.recipe.actual.loggedRecipeSecondaryNoteIds]
   );
 
-  const canEdit = status === "current";
+  const canEdit = status === "current" && !readOnly;
   const recipeBaseVolumeL =
-    typeof ctx.recipe.derived?.volume.totalL === "number" && Number.isFinite(ctx.recipe.derived.volume.totalL)
+    typeof ctx.recipe.derived?.volume.totalL === "number" &&
+    Number.isFinite(ctx.recipe.derived.volume.totalL)
       ? ctx.recipe.derived.volume.totalL
       : null;
   const locale = i18n.resolvedLanguage;
-  const fmtNumber = (value?: number | null, decimals = 2) => formatNumber(value, decimals, locale);
+  const fmtNumber = (value?: number | null, decimals = 2) =>
+    formatNumber(value, decimals, locale);
   const fmtGravity = (value?: number | null) => formatGravity(value, locale);
-  const fmtVolume = (value?: number | null, unit: RecipeUnitDefaults["volume"] = "gal") =>
-    formatVolume(value, unit, locale);
-  const fmtLoggedAmount = (addition?: { amount: number | null; unit: string | null } | null) =>
-    formatLoggedAmount(addition, locale);
-  const missingSecondary = secondaryLines.filter((line) => !loggedIngredientIds.has(String(line.line.lineId)));
-  const missingAdditives = additiveLines.filter((line) => !loggedAdditiveIds.has(String(line.line.lineId)));
+  const fmtVolume = (
+    value?: number | null,
+    unit: RecipeUnitDefaults["volume"] = "gal"
+  ) => formatVolume(value, unit, locale);
+  const fmtLoggedAmount = (
+    addition?: { amount: number | null; unit: string | null } | null
+  ) => formatLoggedAmount(addition, locale);
+  const missingSecondary = secondaryLines.filter(
+    (line) => !loggedIngredientIds.has(String(line.line.lineId))
+  );
+  const missingAdditives = additiveLines.filter(
+    (line) => !loggedAdditiveIds.has(String(line.line.lineId))
+  );
   const ingredientDoneCount = secondaryLines.length - missingSecondary.length;
   const additiveDoneCount = additiveLines.length - missingAdditives.length;
-  const notesDoneCount = secondaryNotes.filter((item) => loggedNoteIds.has(String(item.note.lineId))).length;
+  const notesDoneCount = secondaryNotes.filter((item) =>
+    loggedNoteIds.has(String(item.note.lineId))
+  ).length;
   const hasCurrentVolume =
     typeof ctx.brew.current_volume_liters === "number" &&
     Number.isFinite(ctx.brew.current_volume_liters) &&
     ctx.brew.current_volume_liters > 0;
-  const canScaleSuggestions = canEdit && hasCurrentVolume && recipeBaseVolumeL != null && recipeBaseVolumeL > 0;
+  const canScaleSuggestions =
+    canEdit &&
+    hasCurrentVolume &&
+    recipeBaseVolumeL != null &&
+    recipeBaseVolumeL > 0;
   const readyForBulkAge = hasCurrentVolume;
   const stabilizerPlan = getStabilizerPlan(ctx, locale);
   const usesRecipeStabilizers = Boolean(ctx.recipe.stabilizerPlan?.enabled);
   const loggedStabilizerAdditions = getLoggedStabilizerAdditions(ctx);
   const hasLoggedStabilizers = loggedStabilizerAdditions.length > 0;
   const supplementalStabilizerPlan =
-    usesRecipeStabilizers && hasLoggedStabilizers ? getSupplementalStabilizerPlan(ctx, stabilizerPlan) : null;
+    usesRecipeStabilizers && hasLoggedStabilizers
+      ? getSupplementalStabilizerPlan(ctx, stabilizerPlan)
+      : null;
 
-  const getScaledIngredientSuggestion = (lineId: string) => scaledSecondarySuggestions.get(String(lineId));
-  const getScaledAdditiveSuggestion = (lineId: string) => scaledAdditiveSuggestions.get(String(lineId));
+  const getScaledIngredientSuggestion = (lineId: string) =>
+    scaledSecondarySuggestions.get(String(lineId));
+  const getScaledAdditiveSuggestion = (lineId: string) =>
+    scaledAdditiveSuggestions.get(String(lineId));
 
   const getSecondaryIngredientAmount = (line: IngredientLine) => {
     const scaled = getScaledIngredientSuggestion(line.lineId);
@@ -508,12 +647,16 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
     };
   };
 
-  const getSecondaryIngredientDisplay = (item: (typeof secondaryLines)[number]) => {
+  const getSecondaryIngredientDisplay = (
+    item: (typeof secondaryLines)[number]
+  ) => {
     const scaled = getScaledIngredientSuggestion(item.line.lineId);
     if (!scaled) {
       return {
         amount: item.primary,
-        detail: item.secondary ? `${t("brews.planned.altAmount", "Alt")}: ${item.secondary}` : null
+        detail: item.secondary
+          ? `${t("brews.planned.altAmount", "Alt")}: ${item.secondary}`
+          : null
       };
     }
 
@@ -528,13 +671,18 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
     };
   };
 
-  const getSecondaryAdditiveAmount = (lineId: string, fallback: ReturnType<typeof getAdditiveAmount>) => {
+  const getSecondaryAdditiveAmount = (
+    lineId: string,
+    fallback: ReturnType<typeof getAdditiveAmount>
+  ) => {
     const scaled = getScaledAdditiveSuggestion(lineId);
     if (scaled) return { amount: scaled.amount, unit: scaled.unit };
     return fallback;
   };
 
-  const getSecondaryAdditiveDisplay = (item: (typeof additiveLines)[number]) => {
+  const getSecondaryAdditiveDisplay = (
+    item: (typeof additiveLines)[number]
+  ) => {
     const scaled = getScaledAdditiveSuggestion(item.line.lineId);
     return scaled ? `${fmtNumber(scaled.amount)} ${scaled.unit}` : item.amount;
   };
@@ -606,7 +754,10 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
     try {
       await helpers.addAdditions(
         missingAdditives.map((item) => {
-          const { amount, unit } = getSecondaryAdditiveAmount(item.line.lineId, getAdditiveAmount(item.line));
+          const { amount, unit } = getSecondaryAdditiveAmount(
+            item.line.lineId,
+            getAdditiveAmount(item.line)
+          );
           return {
             name: item.name,
             amount,
@@ -643,9 +794,11 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
         supplementalStabilizerPlan.sulfiteForm === "campden"
           ? supplementalStabilizerPlan.additional.campden
           : supplementalStabilizerPlan.additional.sulfite;
-      const sulfiteUnit = supplementalStabilizerPlan.sulfiteForm === "campden" ? "tablets" : "g";
+      const sulfiteUnit =
+        supplementalStabilizerPlan.sulfiteForm === "campden" ? "tablets" : "g";
       const inputs = [
-        supplementalStabilizerPlan.additional.sorbate > SUPPLEMENTAL_GRAM_THRESHOLD
+        supplementalStabilizerPlan.additional.sorbate >
+        SUPPLEMENTAL_GRAM_THRESHOLD
           ? {
               name: "Potassium sorbate",
               amount: supplementalStabilizerPlan.additional.sorbate,
@@ -667,7 +820,8 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
                 secondaryVolumeLiters: stabilizerPlan.secondaryVolumeL,
                 abv: stabilizerPlan.abv,
                 dilutedAbv: stabilizerPlan.dilutedAbv,
-                recalculatedRequiredAmount: supplementalStabilizerPlan.required.sorbate,
+                recalculatedRequiredAmount:
+                  supplementalStabilizerPlan.required.sorbate,
                 priorLoggedAmount: supplementalStabilizerPlan.logged.sorbate,
                 additionalAmount: supplementalStabilizerPlan.additional.sorbate,
                 calculatedUnit: "g",
@@ -734,7 +888,10 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
       <div className="grid gap-3 sm:grid-cols-4">
         <StatusTile
           label={t("brews.secondary.currentVolume", "Current volume")}
-          value={fmtVolume(ctx.brew.current_volume_liters, stabilizerPlan?.volumeUnit)}
+          value={fmtVolume(
+            ctx.brew.current_volume_liters,
+            stabilizerPlan?.volumeUnit
+          )}
           tone={hasCurrentVolume ? "ok" : "warn"}
         />
         <StatusTile
@@ -749,7 +906,11 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
         />
         <StatusTile
           label={t("brewStage.BULK_AGE", "Bulk Age")}
-          value={readyForBulkAge ? t("brews.secondary.ready", "Ready") : t("brews.secondary.needsReview", "Needs review")}
+          value={
+            readyForBulkAge
+              ? t("brews.secondary.ready", "Ready")
+              : t("brews.secondary.needsReview", "Needs review")
+          }
           tone={readyForBulkAge ? "ok" : "warn"}
         />
       </div>
@@ -759,8 +920,14 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
           <div className="min-w-0">
             <div className="text-sm font-medium">
               {readyForBulkAge
-                ? t("brews.secondary.focusReady", "Ready to move into bulk aging")
-                : t("brews.secondary.focusTracking", "Keep secondary additions and volume current")}
+                ? t(
+                    "brews.secondary.focusReady",
+                    "Ready to move into bulk aging"
+                  )
+                : t(
+                    "brews.secondary.focusTracking",
+                    "Keep secondary additions and volume current"
+                  )}
             </div>
             <div className="mt-1 text-xs text-muted-foreground">
               {t(
@@ -775,15 +942,29 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
                 size="sm"
                 variant="secondary"
                 disabled={!canEdit || loggingMissingSecondary}
-                onClick={() => runSecondaryIngredientAction(logMissingSecondary)}
+                onClick={() =>
+                  runSecondaryIngredientAction(logMissingSecondary)
+                }
               >
-                {t("brews.secondary.logMissingAdditions", "Log missing additions")}
+                {t(
+                  "brews.secondary.logMissingAdditions",
+                  "Log missing additions"
+                )}
               </Button>
             ) : null}
-            <Button size="sm" disabled={!canEdit} onClick={() => setBulkAgeConfirmOpen(true)}>
+            <Button
+              size="sm"
+              disabled={!canEdit}
+              onClick={() => setBulkAgeConfirmOpen(true)}
+            >
               {t("brews.secondary.moveToBulkAge", "Move to Bulk Age")}
             </Button>
-            <Button size="sm" variant="secondary" disabled={!canEdit} onClick={() => setPackageConfirmOpen(true)}>
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={!canEdit}
+              onClick={() => setPackageConfirmOpen(true)}
+            >
               {t("brews.secondary.bottlePackage", "Bottle / Package")}
             </Button>
             {usesRecipeStabilizers && !hasLoggedStabilizers ? (
@@ -796,13 +977,31 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
                 {t("brews.secondary.logStabilizers", "Log stabilizers")}
               </Button>
             ) : null}
-            <Button size="sm" variant="secondary" disabled={!canEdit} onClick={() => helpers.openRecordVolume?.()}>
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={!canEdit}
+              onClick={() => helpers.openRecordVolume?.()}
+            >
               {t("brews.actions.logVolume", "Record volume")}
             </Button>
-            <Button size="sm" variant="secondary" disabled={!canScaleSuggestions} onClick={scaleSecondaryToCurrentVolume}>
-              {t("brews.secondary.scaleSecondaryIngredients", "Scale secondary ingredients")}
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={!canScaleSuggestions}
+              onClick={scaleSecondaryToCurrentVolume}
+            >
+              {t(
+                "brews.secondary.scaleSecondaryIngredients",
+                "Scale secondary ingredients"
+              )}
             </Button>
-            <Button size="sm" variant="secondary" disabled={!canScaleSuggestions} onClick={scaleAdditivesToCurrentVolume}>
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={!canScaleSuggestions}
+              onClick={scaleAdditivesToCurrentVolume}
+            >
               {t("brews.secondary.scaleAdditives", "Scale additives")}
             </Button>
           </div>
@@ -812,7 +1011,10 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
       {supplementalStabilizerPlan ? (
         <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-3 py-3 text-sm">
           <div className="font-medium text-destructive">
-            {t("brews.secondary.supplementalStabilizersTitle", "Additional stabilizers may be needed")}
+            {t(
+              "brews.secondary.supplementalStabilizersTitle",
+              "Additional stabilizers may be needed"
+            )}
           </div>
           <div className="mt-1 text-muted-foreground">
             {t(
@@ -856,7 +1058,10 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
               disabled={!canEdit || loggingSupplementalStabilizers}
               onClick={logSupplementalStabilizers}
             >
-              {t("brews.secondary.logSupplementalStabilizers", "Log supplemental stabilizers")}
+              {t(
+                "brews.secondary.logSupplementalStabilizers",
+                "Log supplemental stabilizers"
+              )}
             </Button>
           </div>
         </div>
@@ -864,35 +1069,56 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
 
       <WarningsPanel warnings={warnings} defaultOpen />
 
-      <Accordion type="multiple" defaultValue={["secondary-ingredients", "additives", "notes"]}>
+      <Accordion
+        type="multiple"
+        defaultValue={["secondary-ingredients", "additives", "notes"]}
+      >
         <AccordionItem value="secondary-ingredients">
           <AccordionTrigger>
-            {t("brews.secondary.ingredients", "Secondary ingredients")} · {ingredientDoneCount}/{secondaryLines.length}
+            {t("brews.secondary.ingredients", "Secondary ingredients")} ·{" "}
+            {ingredientDoneCount}/{secondaryLines.length}
           </AccordionTrigger>
           <AccordionContent>
             <div className="space-y-2">
               <Button
                 size="sm"
-                disabled={!canEdit || missingSecondary.length === 0 || loggingMissingSecondary}
-                onClick={() => runSecondaryIngredientAction(logMissingSecondary)}
+                disabled={
+                  !canEdit ||
+                  missingSecondary.length === 0 ||
+                  loggingMissingSecondary
+                }
+                onClick={() =>
+                  runSecondaryIngredientAction(logMissingSecondary)
+                }
               >
                 {t("brews.secondary.logMissing", "Log missing")}
               </Button>
               {secondaryLines.length ? (
                 <ul className="space-y-1">
                   {secondaryLines.map((item) => {
-                    const isLogged = loggedIngredientIds.has(String(item.line.lineId));
-                    const loggedAddition = latestLoggedItem(
-                      ctx.recipe.actual.additionsByRecipeIngredientId[String(item.line.lineId)]
+                    const isLogged = loggedIngredientIds.has(
+                      String(item.line.lineId)
                     );
-                    const { amount, unit } = getSecondaryIngredientAmount(item.line);
+                    const loggedAddition = latestLoggedItem(
+                      ctx.recipe.actual.additionsByRecipeIngredientId[
+                        String(item.line.lineId)
+                      ]
+                    );
+                    const { amount, unit } = getSecondaryIngredientAmount(
+                      item.line
+                    );
                     const display = getSecondaryIngredientDisplay(item);
                     return (
                       <WorkRow
                         key={item.line.lineId}
-                        title={getBrewItemLabel(t, loggedAddition?.name || item.name)}
+                        title={getBrewItemLabel(
+                          t,
+                          loggedAddition?.name || item.name
+                        )}
                         detail={display.detail}
-                        amount={fmtLoggedAmount(loggedAddition) ?? display.amount}
+                        amount={
+                          fmtLoggedAmount(loggedAddition) ?? display.amount
+                        }
                         isLogged={isLogged}
                         disabled={!canEdit}
                         loggedLabel={t("brews.primary.logged", "Logged")}
@@ -900,15 +1126,24 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
                         onLog={() =>
                           runSecondaryIngredientAction(() =>
                             setAdditionDialog({
-                              title: t("brews.secondary.logIngredient", "Log secondary ingredient"),
+                              title: t(
+                                "brews.secondary.logIngredient",
+                                "Log secondary ingredient"
+                              ),
                               name: item.name,
                               kind: "INGREDIENT",
                               source: "recipe_ingredient",
                               amount,
                               unit,
-                              ...getSecondaryIngredientPlannedAmounts(item.line),
+                              ...getSecondaryIngredientPlannedAmounts(
+                                item.line
+                              ),
                               recipeIngredientId: String(item.line.lineId),
-                              meta: { plannedAmount: amount, plannedUnit: unit, stage: "SECONDARY" }
+                              meta: {
+                                plannedAmount: amount,
+                                plannedUnit: unit,
+                                stage: "SECONDARY"
+                              }
                             })
                           )
                         }
@@ -918,7 +1153,10 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
                 </ul>
               ) : (
                 <EmptyState>
-                  {t("brews.secondary.noSecondaryIngredients", "No secondary ingredients found in the linked recipe.")}
+                  {t(
+                    "brews.secondary.noSecondaryIngredients",
+                    "No secondary ingredients found in the linked recipe."
+                  )}
                 </EmptyState>
               )}
             </div>
@@ -927,44 +1165,72 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
 
         <AccordionItem value="additives">
           <AccordionTrigger>
-            {t("brews.secondary.recipeAdditives", "Recipe additives")} · {additiveDoneCount}/{additiveLines.length}
+            {t("brews.secondary.recipeAdditives", "Recipe additives")} ·{" "}
+            {additiveDoneCount}/{additiveLines.length}
           </AccordionTrigger>
           <AccordionContent>
             <div className="space-y-2">
               <Button
                 size="sm"
-                disabled={!canEdit || missingAdditives.length === 0 || loggingMissingAdditives}
+                disabled={
+                  !canEdit ||
+                  missingAdditives.length === 0 ||
+                  loggingMissingAdditives
+                }
                 onClick={logMissingAdditives}
               >
-                {t("brews.secondary.logMissingAdditives", "Log missing additives")}
+                {t(
+                  "brews.secondary.logMissingAdditives",
+                  "Log missing additives"
+                )}
               </Button>
               {additiveLines.length ? (
                 <ul className="space-y-1">
                   {additiveLines.map((item) => {
-                    const isLogged = loggedAdditiveIds.has(String(item.line.lineId));
-                    const loggedAddition = latestLoggedItem(
-                      ctx.recipe.actual.additionsByRecipeAdditiveId[String(item.line.lineId)]
+                    const isLogged = loggedAdditiveIds.has(
+                      String(item.line.lineId)
                     );
-                    const { amount, unit } = getSecondaryAdditiveAmount(item.line.lineId, getAdditiveAmount(item.line));
+                    const loggedAddition = latestLoggedItem(
+                      ctx.recipe.actual.additionsByRecipeAdditiveId[
+                        String(item.line.lineId)
+                      ]
+                    );
+                    const { amount, unit } = getSecondaryAdditiveAmount(
+                      item.line.lineId,
+                      getAdditiveAmount(item.line)
+                    );
                     return (
                       <WorkRow
                         key={item.line.lineId}
-                        title={getBrewItemLabel(t, loggedAddition?.name || item.name)}
-                        amount={fmtLoggedAmount(loggedAddition) ?? getSecondaryAdditiveDisplay(item)}
+                        title={getBrewItemLabel(
+                          t,
+                          loggedAddition?.name || item.name
+                        )}
+                        amount={
+                          fmtLoggedAmount(loggedAddition) ??
+                          getSecondaryAdditiveDisplay(item)
+                        }
                         isLogged={isLogged}
                         disabled={!canEdit}
                         loggedLabel={t("brews.primary.logged", "Logged")}
                         actionLabel={t("brews.primary.log", "Log")}
                         onLog={() =>
                           setAdditionDialog({
-                            title: t("brews.secondary.logAdditive", "Log additive"),
+                            title: t(
+                              "brews.secondary.logAdditive",
+                              "Log additive"
+                            ),
                             name: item.name,
                             kind: "OTHER",
                             source: "recipe_additive",
                             amount,
                             unit,
                             recipeAdditiveId: String(item.line.lineId),
-                            meta: { plannedAmount: amount, plannedUnit: unit, stage: "SECONDARY" }
+                            meta: {
+                              plannedAmount: amount,
+                              plannedUnit: unit,
+                              stage: "SECONDARY"
+                            }
                           })
                         }
                       />
@@ -972,7 +1238,12 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
                   })}
                 </ul>
               ) : (
-                <EmptyState>{t("brews.secondary.noRecipeAdditives", "No recipe additives found.")}</EmptyState>
+                <EmptyState>
+                  {t(
+                    "brews.secondary.noRecipeAdditives",
+                    "No recipe additives found."
+                  )}
+                </EmptyState>
               )}
             </div>
           </AccordionContent>
@@ -980,7 +1251,8 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
 
         <AccordionItem value="notes">
           <AccordionTrigger>
-            {t("brews.secondary.recipeNotes", "Recipe secondary notes")} · {notesDoneCount}/{secondaryNotes.length}
+            {t("brews.secondary.recipeNotes", "Recipe secondary notes")} ·{" "}
+            {notesDoneCount}/{secondaryNotes.length}
           </AccordionTrigger>
           <AccordionContent>
             {secondaryNotes.length ? (
@@ -1007,7 +1279,10 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
               </ul>
             ) : (
               <EmptyState>
-                {t("brews.secondary.noRecipeNotes", "No secondary notes found in the linked recipe.")}
+                {t(
+                  "brews.secondary.noRecipeNotes",
+                  "No secondary notes found in the linked recipe."
+                )}
               </EmptyState>
             )}
           </AccordionContent>
@@ -1034,7 +1309,10 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
             await helpers.addEntry(
               entryPayload.ph(
                 extra.phReading,
-                t("brews.secondary.stabilizerPhNote", "pH reading recorded while logging stabilizers."),
+                t(
+                  "brews.secondary.stabilizerPhNote",
+                  "pH reading recorded while logging stabilizers."
+                ),
                 extra.datetime
               )
             );
@@ -1073,7 +1351,10 @@ export function SecondaryStagePanel({ t, status, ctx, helpers, warnings = [] }: 
         note={
           recipeNoteDialog
             ? {
-                title: t("brews.secondary.recipeNoteTitle", "Add recipe secondary note"),
+                title: t(
+                  "brews.secondary.recipeNoteTitle",
+                  "Add recipe secondary note"
+                ),
                 text: recipeNoteDialog.text
               }
             : null
@@ -1126,15 +1407,24 @@ function LogStabilizersDialog({
 }) {
   const { t, i18n } = useTranslation();
   const locale = i18n.resolvedLanguage;
-  const fmtNumber = (value?: number | null, decimals = 2) => formatNumber(value, decimals, locale);
-  const fmtVolume = (value?: number | null, unit: RecipeUnitDefaults["volume"] = "gal") =>
-    formatVolume(value, unit, locale);
-  const fmtVolumeWithLocale = (value?: number | null, unit: RecipeUnitDefaults["volume"] = "gal") =>
-    fmtVolumeWithZero(value, unit, locale);
+  const fmtNumber = (value?: number | null, decimals = 2) =>
+    formatNumber(value, decimals, locale);
+  const fmtVolume = (
+    value?: number | null,
+    unit: RecipeUnitDefaults["volume"] = "gal"
+  ) => formatVolume(value, unit, locale);
+  const fmtVolumeWithLocale = (
+    value?: number | null,
+    unit: RecipeUnitDefaults["volume"] = "gal"
+  ) => fmtVolumeWithZero(value, unit, locale);
   const [ph, setPh] = React.useState("");
   const [takingPh, setTakingPh] = React.useState(true);
-  const [stabilizerType, setStabilizerType] = React.useState<"kmeta" | "nameta">("kmeta");
-  const [sulfiteForm, setSulfiteForm] = React.useState<"powder" | "campden">("powder");
+  const [stabilizerType, setStabilizerType] = React.useState<
+    "kmeta" | "nameta"
+  >("kmeta");
+  const [sulfiteForm, setSulfiteForm] = React.useState<"powder" | "campden">(
+    "powder"
+  );
   const [sorbateAmount, setSorbateAmount] = React.useState("");
   const [sulfiteActualAmount, setSulfiteActualAmount] = React.useState("");
   const [phTouched, setPhTouched] = React.useState(false);
@@ -1165,25 +1455,41 @@ function LogStabilizersDialog({
     totalVolumeL: plan?.volumeL ?? 0,
     abv: plan?.abv ?? 0
   });
-  const sulfiteName = stabilizerType === "kmeta" ? "Potassium metabisulfite" : "Sodium metabisulfite";
+  const sulfiteName =
+    stabilizerType === "kmeta"
+      ? "Potassium metabisulfite"
+      : "Sodium metabisulfite";
   const sulfiteShortName = stabilizerType === "kmeta" ? "K-Meta" : "Na-Meta";
-  const sulfiteAdditionName = sulfiteForm === "powder" ? sulfiteName : "Campden tablets";
-  const sulfiteAmount = sulfiteForm === "powder" ? results.sulfite : results.campden;
+  const sulfiteAdditionName =
+    sulfiteForm === "powder" ? sulfiteName : "Campden tablets";
+  const sulfiteAmount =
+    sulfiteForm === "powder" ? results.sulfite : results.campden;
   const sulfiteUnit = sulfiteForm === "powder" ? "g" : "tablets";
   const editableSorbateAmount = roundEditableAmount(results.sorbate);
   const editableSulfiteAmount = roundEditableAmount(sulfiteAmount);
   const actualSorbateAmount = parseNumber(sorbateAmount);
   const actualSulfiteAmount = parseNumber(sulfiteActualAmount);
   const sorbateChanged =
-    Number.isFinite(actualSorbateAmount) && Math.abs(actualSorbateAmount - editableSorbateAmount) > 0.0005;
+    Number.isFinite(actualSorbateAmount) &&
+    Math.abs(actualSorbateAmount - editableSorbateAmount) > 0.0005;
   const sulfiteChanged =
-    Number.isFinite(actualSulfiteAmount) && Math.abs(actualSulfiteAmount - editableSulfiteAmount) > 0.0005;
+    Number.isFinite(actualSulfiteAmount) &&
+    Math.abs(actualSulfiteAmount - editableSulfiteAmount) > 0.0005;
 
   React.useEffect(() => {
     if (!open || !plan) return;
     if (!sorbateTouched) setSorbateAmount(fmtNumber(editableSorbateAmount, 2));
-    if (!sulfiteTouched) setSulfiteActualAmount(fmtNumber(editableSulfiteAmount, 2));
-  }, [open, plan, editableSorbateAmount, sorbateTouched, editableSulfiteAmount, sulfiteForm, sulfiteTouched]);
+    if (!sulfiteTouched)
+      setSulfiteActualAmount(fmtNumber(editableSulfiteAmount, 2));
+  }, [
+    open,
+    plan,
+    editableSorbateAmount,
+    sorbateTouched,
+    editableSulfiteAmount,
+    sulfiteForm,
+    sulfiteTouched
+  ]);
 
   if (!plan) return null;
 
@@ -1229,30 +1535,42 @@ function LogStabilizersDialog({
         [
           {
             name: "Potassium sorbate",
-            amount: Number.isFinite(actualSorbateAmount) ? actualSorbateAmount : results.sorbate,
+            amount: Number.isFinite(actualSorbateAmount)
+              ? actualSorbateAmount
+              : results.sorbate,
             unit: "g",
             kind: "OTHER",
             source: "manual",
             datetime: datetime.toISOString(),
-            note: t("brews.secondary.stabilizerAdditionNote", "Stabilizer addition calculated for secondary."),
+            note: t(
+              "brews.secondary.stabilizerAdditionNote",
+              "Stabilizer addition calculated for secondary."
+            ),
             meta: {
               ...commonMeta,
               stabilizerKind: "sorbate",
               calculatedAmount: results.sorbate,
               calculatedUnit: "g",
               actualAmountChanged: sorbateChanged,
-              plannedAmount: Number.isFinite(actualSorbateAmount) ? actualSorbateAmount : results.sorbate,
+              plannedAmount: Number.isFinite(actualSorbateAmount)
+                ? actualSorbateAmount
+                : results.sorbate,
               plannedUnit: "g"
             }
           },
           {
             name: sulfiteAdditionName,
-            amount: Number.isFinite(actualSulfiteAmount) ? actualSulfiteAmount : sulfiteAmount,
+            amount: Number.isFinite(actualSulfiteAmount)
+              ? actualSulfiteAmount
+              : sulfiteAmount,
             unit: sulfiteUnit,
             kind: "OTHER",
             source: "manual",
             datetime: datetime.toISOString(),
-            note: t("brews.secondary.stabilizerAdditionNote", "Stabilizer addition calculated for secondary."),
+            note: t(
+              "brews.secondary.stabilizerAdditionNote",
+              "Stabilizer addition calculated for secondary."
+            ),
             meta: {
               ...commonMeta,
               stabilizerKind: "sulfite",
@@ -1260,7 +1578,9 @@ function LogStabilizersDialog({
               calculatedAmount: sulfiteAmount,
               calculatedUnit: sulfiteUnit,
               actualAmountChanged: sulfiteChanged,
-              plannedAmount: Number.isFinite(actualSulfiteAmount) ? actualSulfiteAmount : sulfiteAmount,
+              plannedAmount: Number.isFinite(actualSulfiteAmount)
+                ? actualSulfiteAmount
+                : sulfiteAmount,
               plannedUnit: sulfiteUnit,
               sulfiteAmount: results.sulfite,
               sulfiteUnit: "g",
@@ -1269,7 +1589,9 @@ function LogStabilizersDialog({
             }
           }
         ],
-        shouldLogPhReading ? { phReading: Number(phForCalc), datetime: datetime.toISOString() } : undefined
+        shouldLogPhReading
+          ? { phReading: Number(phForCalc), datetime: datetime.toISOString() }
+          : undefined
       );
     } finally {
       setIsSaving(false);
@@ -1280,24 +1602,41 @@ function LogStabilizersDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className={BREW_TRACKER_WIDE_DIALOG_CONTENT_CLASS}>
         <DialogHeader>
-          <DialogTitle>{t("brews.secondary.logStabilizers", "Log stabilizers")}</DialogTitle>
+          <DialogTitle>
+            {t("brews.secondary.logStabilizers", "Log stabilizers")}
+          </DialogTitle>
         </DialogHeader>
 
         <div className="space-y-4">
           <div className="grid gap-2 sm:grid-cols-3">
             <InfoRow
-              label={t("brews.secondary.baseVolumeForStabilizers", "Base volume")}
+              label={t(
+                "brews.secondary.baseVolumeForStabilizers",
+                "Base volume"
+              )}
               value={fmtVolume(plan.baseVolumeL, plan.volumeUnit)}
             />
             <InfoRow
-              label={t("brews.secondary.secondaryVolumeForStabilizers", "Secondary volume")}
-              value={fmtVolumeWithLocale(plan.secondaryVolumeL, plan.volumeUnit)}
+              label={t(
+                "brews.secondary.secondaryVolumeForStabilizers",
+                "Secondary volume"
+              )}
+              value={fmtVolumeWithLocale(
+                plan.secondaryVolumeL,
+                plan.volumeUnit
+              )}
             />
             <InfoRow
-              label={t("brews.secondary.adjustedVolumeForStabilizers", "Adjusted volume")}
+              label={t(
+                "brews.secondary.adjustedVolumeForStabilizers",
+                "Adjusted volume"
+              )}
               value={fmtVolume(plan.adjustedTotalVolumeL, plan.volumeUnit)}
             />
-            <InfoRow label={t("brews.secondary.baseAbv", "Base ABV")} value={`${fmtNumber(plan.baseAbv)}%`} />
+            <InfoRow
+              label={t("brews.secondary.baseAbv", "Base ABV")}
+              value={`${fmtNumber(plan.baseAbv)}%`}
+            />
             <InfoRow
               label={t("brews.secondary.dilutedAbv", "Diluted ABV")}
               value={`${fmtNumber(plan.dilutedAbv)}%`}
@@ -1314,7 +1653,9 @@ function LogStabilizersDialog({
 
           <div className="space-y-3">
             <div className="flex items-center justify-between gap-4">
-              <Label>{t("brews.secondary.takingPh", "Taking a pH reading?")}</Label>
+              <Label>
+                {t("brews.secondary.takingPh", "Taking a pH reading?")}
+              </Label>
               <Switch checked={takingPh} onCheckedChange={setTakingPh} />
             </div>
             {takingPh ? (
@@ -1338,46 +1679,70 @@ function LogStabilizersDialog({
           <div className="grid gap-3 sm:grid-cols-2">
             <div className="space-y-2">
               <Label>{t("type", "Type")}</Label>
-              <Select value={stabilizerType} onValueChange={(value) => setStabilizerType(value as "kmeta" | "nameta")}>
+              <Select
+                value={stabilizerType}
+                onValueChange={(value) =>
+                  setStabilizerType(value as "kmeta" | "nameta")
+                }
+              >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="kmeta">{t("kMeta", "K-Meta")}</SelectItem>
-                  <SelectItem value="nameta">{t("naMeta", "Na-Meta")}</SelectItem>
+                  <SelectItem value="nameta">
+                    {t("naMeta", "Na-Meta")}
+                  </SelectItem>
                 </SelectContent>
               </Select>
             </div>
 
             <div className="space-y-2">
               <Label>{t("brews.secondary.sulfiteForm", "Sulfite form")}</Label>
-              <Select value={sulfiteForm} onValueChange={(value) => setSulfiteForm(value as "powder" | "campden")}>
+              <Select
+                value={sulfiteForm}
+                onValueChange={(value) =>
+                  setSulfiteForm(value as "powder" | "campden")
+                }
+              >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="powder">{sulfiteShortName}</SelectItem>
-                  <SelectItem value="campden">{t("campden", "Campden Tablets")}</SelectItem>
+                  <SelectItem value="campden">
+                    {t("campden", "Campden Tablets")}
+                  </SelectItem>
                 </SelectContent>
               </Select>
             </div>
           </div>
 
           <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm">
-            <div className="font-medium">{t("brews.secondary.calculatedStabilizers", "Calculated additions")}</div>
+            <div className="font-medium">
+              {t(
+                "brews.secondary.calculatedStabilizers",
+                "Calculated additions"
+              )}
+            </div>
             <div className="mt-2 space-y-1 text-muted-foreground">
               <div>
                 {t("sorbate", "Sorbate")}: {fmtNumber(results.sorbate, 3)} g
               </div>
               <div>
-                {sulfiteForm === "powder" ? sulfiteShortName : t("campden", "Campden Tablets")}:{" "}
-                {fmtNumber(sulfiteAmount, sulfiteForm === "powder" ? 3 : 2)} {sulfiteUnit}
+                {sulfiteForm === "powder"
+                  ? sulfiteShortName
+                  : t("campden", "Campden Tablets")}
+                : {fmtNumber(sulfiteAmount, sulfiteForm === "powder" ? 3 : 2)}{" "}
+                {sulfiteUnit}
               </div>
             </div>
           </div>
 
           <div className="space-y-3 rounded-md border border-border bg-background/40 px-3 py-3">
-            <div className="text-sm font-medium">{t("brews.secondary.actualAmounts", "Actual amounts")}</div>
+            <div className="text-sm font-medium">
+              {t("brews.secondary.actualAmounts", "Actual amounts")}
+            </div>
             <div className="grid gap-3 sm:grid-cols-2">
               <div className="space-y-2">
                 <Label>{t("sorbate", "Sorbate")}</Label>
@@ -1392,7 +1757,11 @@ function LogStabilizersDialog({
                 />
               </div>
               <div className="space-y-2">
-                <Label>{sulfiteForm === "powder" ? sulfiteShortName : t("campden", "Campden Tablets")}</Label>
+                <Label>
+                  {sulfiteForm === "powder"
+                    ? sulfiteShortName
+                    : t("campden", "Campden Tablets")}
+                </Label>
                 <AmountUnitField
                   amount={sulfiteActualAmount}
                   unit={sulfiteUnit}
@@ -1416,12 +1785,20 @@ function LogStabilizersDialog({
 
           <div className="space-y-2">
             <Label>{t("date", "Date")}</Label>
-            <DateTimePicker value={datetime} onChange={(value) => value && setDatetime(value)} hourCycle={12} />
+            <DateTimePicker
+              value={datetime}
+              onChange={(value) => value && setDatetime(value)}
+              hourCycle={12}
+            />
           </div>
         </div>
 
         <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
-          <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
+          <Button
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            disabled={isSaving}
+          >
             {t("cancel", "Cancel")}
           </Button>
           <Button onClick={save} disabled={isSaving}>
@@ -1470,19 +1847,34 @@ function ConfirmBulkAgeDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[480px]`}>
+      <DialogContent
+        className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[480px]`}
+      >
         <DialogHeader>
-          <DialogTitle>{t("brews.secondary.confirmBulkAgeTitle", "Move to bulk aging?")}</DialogTitle>
+          <DialogTitle>
+            {t("brews.secondary.confirmBulkAgeTitle", "Move to bulk aging?")}
+          </DialogTitle>
         </DialogHeader>
         <div className="text-sm text-muted-foreground">
-          {t("brews.secondary.confirmBulkAgeHelp", "This moves the brew out of Secondary and into the bulk age stage.")}
+          {t(
+            "brews.secondary.confirmBulkAgeHelp",
+            "This moves the brew out of Secondary and into the bulk age stage."
+          )}
         </div>
         <div className="space-y-2">
           <Label>{t("date", "Date")}</Label>
-          <DateTimePicker value={datetime} onChange={(value) => value && setDatetime(value)} hourCycle={12} />
+          <DateTimePicker
+            value={datetime}
+            onChange={(value) => value && setDatetime(value)}
+            hourCycle={12}
+          />
         </div>
         <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
-          <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
+          <Button
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            disabled={isSaving}
+          >
             {t("cancel", "Cancel")}
           </Button>
           <Button onClick={confirm} disabled={isSaving}>
@@ -1522,9 +1914,13 @@ function ConfirmPackageDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[480px]`}>
+      <DialogContent
+        className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[480px]`}
+      >
         <DialogHeader>
-          <DialogTitle>{t("brews.secondary.confirmPackageTitle", "Move to packaging?")}</DialogTitle>
+          <DialogTitle>
+            {t("brews.secondary.confirmPackageTitle", "Move to packaging?")}
+          </DialogTitle>
         </DialogHeader>
         <div className="text-sm text-muted-foreground">
           {t(
@@ -1534,10 +1930,18 @@ function ConfirmPackageDialog({
         </div>
         <div className="space-y-2">
           <Label>{t("date", "Date")}</Label>
-          <DateTimePicker value={datetime} onChange={(value) => value && setDatetime(value)} hourCycle={12} />
+          <DateTimePicker
+            value={datetime}
+            onChange={(value) => value && setDatetime(value)}
+            hourCycle={12}
+          />
         </div>
         <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
-          <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
+          <Button
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            disabled={isSaving}
+          >
             {t("cancel", "Cancel")}
           </Button>
           <Button onClick={confirm} disabled={isSaving}>
@@ -1572,9 +1976,16 @@ function ConfirmSecondaryBeforeStabilizersDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[480px]`}>
+      <DialogContent
+        className={`${BREW_TRACKER_DIALOG_CONTENT_CLASS} sm:max-w-[480px]`}
+      >
         <DialogHeader>
-          <DialogTitle>{t("brews.secondary.secondaryBeforeStabilizersTitle", "Log additions before stabilizers?")}</DialogTitle>
+          <DialogTitle>
+            {t(
+              "brews.secondary.secondaryBeforeStabilizersTitle",
+              "Log additions before stabilizers?"
+            )}
+          </DialogTitle>
         </DialogHeader>
         <div className="text-sm text-muted-foreground">
           {t(
@@ -1583,7 +1994,11 @@ function ConfirmSecondaryBeforeStabilizersDialog({
           )}
         </div>
         <DialogFooter className={BREW_TRACKER_DIALOG_FOOTER_CLASS}>
-          <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSaving}>
+          <Button
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            disabled={isSaving}
+          >
             {t("cancel", "Cancel")}
           </Button>
           <Button onClick={confirm} disabled={isSaving}>

--- a/components/navbar/AccountLinks.tsx
+++ b/components/navbar/AccountLinks.tsx
@@ -33,6 +33,13 @@ function AccountLinks() {
             <DropdownMenuItem onClick={() => router.push("/account")}>
               <p className="text-center w-full"> {t("account.label")}</p>
             </DropdownMenuItem>
+            {user.role === "admin" ? (
+              <DropdownMenuItem onClick={() => router.push("/admin")}>
+                <p className="w-full text-center">
+                  {t("admin.title", "Admin")}
+                </p>
+              </DropdownMenuItem>
+            ) : null}
             <DropdownMenuItem onClick={() => router.push("/account/brews")}>
               <p className="text-center w-full"> {t("brews.title")}</p>
             </DropdownMenuItem>

--- a/components/recipes/PublicRecipe.tsx
+++ b/components/recipes/PublicRecipe.tsx
@@ -12,26 +12,57 @@ import RateRecipe from "./RateRecipe";
 import useRecipeVersionGate from "@/hooks/useRecipeVersionGate";
 import { useRecipe } from "../providers/RecipeProvider";
 import SaveRecipeCopy from "./SaveRecipeCopy";
+import { cn } from "@/lib/utils";
+import { usePublicRecipeBrews } from "@/hooks/reactQuery/usePublicRecipeBrews";
+
+export type RecipeViewCapabilities = {
+  canSaveCopy: boolean;
+  canRate: boolean;
+  canComment: boolean;
+};
+
+const PUBLIC_RECIPE_CAPABILITIES: RecipeViewCapabilities = {
+  canSaveCopy: true,
+  canRate: true,
+  canComment: true
+};
 
 function PublicRecipe({
   recipe,
-  userRating
+  userRating,
+  capabilities = PUBLIC_RECIPE_CAPABILITIES,
+  embedded = false,
+  backHref = "/public-recipes"
 }: {
   recipe: RecipeWithParsedFields;
   userRating?: number;
+  capabilities?: RecipeViewCapabilities;
+  embedded?: boolean;
+  backHref?: string;
 }) {
   useRecipeVersionGate(recipe);
 
   const { t } = useTranslation();
   const { id } = useParams();
+  const { data: publicBrews = [] } = usePublicRecipeBrews(id as string);
   const {
     derived: { nutrientValueForRecipe },
     meta: { setNutrients }
   } = useRecipe();
   return (
-    <div className="w-full flex flex-col justify-center items-center py-[6rem] relative">
-      <div className="flex flex-col p-12 py-8 rounded-xl bg-background gap-4 w-11/12 max-w-[1000px] relative">
-        <SaveRecipeCopy />
+    <div
+      className={cn(
+        "w-full",
+        !embedded && "flex flex-col items-center justify-center py-[6rem]"
+      )}
+    >
+      <div
+        className={cn(
+          "relative flex w-full max-w-[1000px] flex-col gap-4",
+          !embedded && "w-11/12 rounded-xl bg-background p-8 sm:p-12"
+        )}
+      >
+        {capabilities.canSaveCopy ? <SaveRecipeCopy /> : null}
         <h1 className="text-3xl text-center">{recipe.name}</h1>
 
         <p className="w-full text-right">
@@ -44,7 +75,7 @@ function PublicRecipe({
           averageRating={recipe.averageRating ?? 0}
           numberOfRatings={recipe.numberOfRatings ?? 0}
         />
-        <RateRecipe userRating={userRating} />
+        {capabilities.canRate ? <RateRecipe userRating={userRating} /> : null}
         <NutrientProvider
           mode="controlled"
           value={nutrientValueForRecipe}
@@ -55,12 +86,69 @@ function PublicRecipe({
             title={recipe.name}
           />
         </NutrientProvider>
-        <CommentsSection recipeId={Number(id)} />
+        <section className="rounded-lg border border-border bg-card p-4">
+          <div className="mb-3">
+            <h2 className="text-lg font-semibold">
+              {t("publicBrews.title", "Public brews")}
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              {t(
+                "publicBrews.description",
+                "Brewers have shared these batches from this recipe."
+              )}
+            </p>
+          </div>
+          {publicBrews.length ? (
+            <div className="divide-y divide-border">
+              {publicBrews.map((brew) => (
+                <div
+                  key={brew.id}
+                  className="flex flex-col gap-2 py-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0">
+                    <div className="truncate font-medium">
+                      {brew.name || brew.id}
+                    </div>
+                    <div className="text-sm text-muted-foreground">
+                      {t(`brewStage.${brew.stage}`, brew.stage)}
+                      {brew.owner?.displayName
+                        ? ` · ${t("byUser", {
+                            public_username: brew.owner.displayName
+                          })}`
+                        : ""}
+                    </div>
+                  </div>
+                  <Link
+                    href={`/recipes/${recipe.id}/brews/${brew.id}`}
+                    className={buttonVariants({
+                      variant: "secondary",
+                      size: "sm"
+                    })}
+                  >
+                    {t("publicBrews.viewBrew", "View brew")}
+                  </Link>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              {t(
+                "publicBrews.empty",
+                "No public brews have been shared for this recipe yet."
+              )}
+            </p>
+          )}
+        </section>
+        {capabilities.canComment ? (
+          <CommentsSection recipeId={Number(id)} />
+        ) : null}
         <Link
-          href={"/public-recipes"}
+          href={backHref}
           className={buttonVariants({ variant: "secondary" })}
         >
-          {t("backToList")}
+          {embedded
+            ? t("admin.recipes.back", "Back to recipes")
+            : t("backToList")}
         </Link>
       </div>
     </div>

--- a/components/recipes/RecipeClient.tsx
+++ b/components/recipes/RecipeClient.tsx
@@ -13,7 +13,11 @@ import { useAuth } from "@/hooks/auth/useAuth";
 import { RecipeProvider } from "../providers/RecipeProvider";
 import { useTranslation } from "react-i18next";
 
-const RecipePage = () => {
+const RecipePage = ({
+  mode = "default"
+}: {
+  mode?: "default" | "admin-readonly";
+}) => {
   const params = useParams<{ id: string }>();
   const id = params.id;
 
@@ -84,13 +88,24 @@ const RecipePage = () => {
       : recipe.ratings.find((r) => r.user_id === userId)?.rating;
 
   const isOwner = userId === ownerId;
+  const isAdminReadOnly = mode === "admin-readonly";
 
   return (
     <RecipeProvider>
-      {isOwner ? (
+      {isOwner && !isAdminReadOnly ? (
         <OwnerRecipe pdfRedirect={pdfRedirect} recipe={recipe} />
       ) : (
-        <PublicRecipe recipe={recipe} userRating={userRating} />
+        <PublicRecipe
+          recipe={recipe}
+          userRating={userRating}
+          embedded={isAdminReadOnly}
+          backHref={isAdminReadOnly ? "/admin/recipes" : undefined}
+          capabilities={
+            isAdminReadOnly
+              ? { canSaveCopy: false, canRate: false, canComment: false }
+              : undefined
+          }
+        />
       )}
     </RecipeProvider>
   );

--- a/content/release-notes.mdx
+++ b/content/release-notes.mdx
@@ -56,6 +56,30 @@ Public recipe search now keeps the search input and results in sync more reliabl
 
 ---
 
+### Public Brew Sharing
+
+Brewers can now share selected brew trackers from their public recipes.
+
+- Brews remain private by default and can only be published when their recipe is public
+- Public recipe pages link to published brews with their stage history, notes, metrics, and charts
+- Account brew pages include a share action that uses the public recipe-scoped link
+- Shared brew trackers are read-only and retain the familiar account tracker layout
+
+---
+
+## Admin Updates
+
+The admin area has been refreshed to match the rest of MeadTools more closely.
+
+- A new admin overview links to users, brews, recipes, and catalog data
+- Admins can review complete brew trackers and private recipes without mutation controls
+- Admin tables, search, pagination, navigation, and responsive layouts are more consistent
+- User administration can send password reset links directly from the user editor
+- Admin access is available from the account menu for administrators
+- Ingredient and yeast creation now recovers from stale database ID sequences
+
+---
+
 ## UI Polish and Reliability
 
 This release includes a broad polish pass across the new brew tracking surfaces.
@@ -64,7 +88,8 @@ This release includes a broad polish pass across the new brew tracking surfaces.
 - Stage panels share more consistent patterns
 - Account navigation better reflects the available brew tools
 - Brew data handling is more resilient across the new workflow
-- OpenAPI and seed data have been updated for the expanded brew model
+- OpenAPI documentation now covers the expanded brew model, admin endpoints, and public recipe brew routes
+- Seed data has been updated for the expanded brew model
 
 ---
 

--- a/hooks/reactQuery/useAccountBrews.ts
+++ b/hooks/reactQuery/useAccountBrews.ts
@@ -25,9 +25,11 @@ export type AccountBrewListItem = {
   current_volume_liters: number | null;
   requested_email_alerts: boolean;
   gravity_unit_preference: GravityUnit;
+  public: boolean;
 
   recipe_id: number | null;
   recipe_name: string | null;
+  recipe_private: boolean | null;
 
   entry_count: number;
   latest_gravity: number | null;
@@ -69,11 +71,13 @@ export type AccountBrew = {
   current_volume_liters: number | null;
   requested_email_alerts: boolean;
   gravity_unit_preference: GravityUnit;
+  public: boolean;
 
   latest_gravity: number | null;
 
   recipe_id: number | null;
   recipe_name: string | null;
+  recipe_private: boolean | null;
 
   recipe_snapshot: BrewRecipeSnapshot | null;
   entry_count: number;
@@ -233,6 +237,7 @@ export type PatchAccountBrewMetadataInput = {
   current_volume_liters?: number | null;
   requested_email_alerts?: boolean;
   gravity_unit_preference?: GravityUnit;
+  public?: boolean;
   end_date?: string | null; // ISO or null
   stage_change_datetime?: string;
 };

--- a/hooks/reactQuery/useAdminDashboard.ts
+++ b/hooks/reactQuery/useAdminDashboard.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import { useFetchWithAuth } from "@/hooks/auth/useFetchWithAuth";
+import type { AdminBrewsPage, AdminSummary } from "@/lib/db/admin";
+import { qk } from "@/lib/db/queryKeys";
+import type { BrewViewDetail } from "@/types/brewView";
+
+export function useAdminSummary() {
+  const fetchWithAuth = useFetchWithAuth();
+
+  return useQuery<AdminSummary>({
+    queryKey: qk.adminSummary,
+    queryFn: () => fetchWithAuth<AdminSummary>("/api/admin/summary"),
+    staleTime: 60 * 1000
+  });
+}
+
+export function useAdminBrews({
+  page,
+  limit,
+  query,
+  stage,
+  status
+}: {
+  page: number;
+  limit: number;
+  query?: string;
+  stage?: string;
+  status?: string;
+}) {
+  const fetchWithAuth = useFetchWithAuth();
+  const searchParams = new URLSearchParams({
+    page: String(page),
+    limit: String(limit)
+  });
+
+  if (query) searchParams.set("query", query);
+  if (stage) searchParams.set("stage", stage);
+  if (status) searchParams.set("status", status);
+
+  return useQuery<AdminBrewsPage>({
+    queryKey: qk.adminBrews.list(
+      page,
+      limit,
+      query ?? "",
+      stage ?? "",
+      status ?? ""
+    ),
+    queryFn: () =>
+      fetchWithAuth<AdminBrewsPage>(
+        `/api/admin/brews?${searchParams.toString()}`
+      ),
+    placeholderData: keepPreviousData,
+    staleTime: 60 * 1000
+  });
+}
+
+export function useAdminBrew(brewId?: string) {
+  const fetchWithAuth = useFetchWithAuth();
+
+  return useQuery<BrewViewDetail>({
+    queryKey: qk.adminBrews.detail(brewId ?? ""),
+    enabled: Boolean(brewId),
+    queryFn: () => fetchWithAuth<BrewViewDetail>(`/api/admin/brews/${brewId}`),
+    staleTime: 60 * 1000
+  });
+}

--- a/hooks/reactQuery/usePublicRecipeBrews.ts
+++ b/hooks/reactQuery/usePublicRecipeBrews.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { qk } from "@/lib/db/queryKeys";
+import type { BrewViewListItem } from "@/types/brewView";
+
+export function usePublicRecipeBrews(recipeId?: string | number) {
+  return useQuery<BrewViewListItem[]>({
+    queryKey: qk.publicRecipeBrews.list(recipeId ?? ""),
+    enabled: recipeId != null && String(recipeId).length > 0,
+    queryFn: async () => {
+      const response = await fetch(`/api/recipes/${recipeId}/brews`);
+
+      if (!response.ok) {
+        const err: any = new Error(`HTTP ${response.status}`);
+        err.status = response.status;
+        throw err;
+      }
+
+      const json = (await response.json()) as { brews: BrewViewListItem[] };
+      return json.brews;
+    },
+    staleTime: 60 * 1000
+  });
+}

--- a/lib/auth/passwordReset.ts
+++ b/lib/auth/passwordReset.ts
@@ -1,0 +1,34 @@
+import jwt from "jsonwebtoken";
+
+import { escapeHtml, sendEmail } from "@/lib/db/emailHelpers";
+
+export async function sendPasswordResetEmail({
+  userId,
+  email
+}: {
+  userId: number;
+  email: string;
+}) {
+  const secret = process.env.RESET_PASSWORD_SECRET;
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+
+  if (!secret || !baseUrl) {
+    throw new Error("Password reset email is not configured.");
+  }
+
+  const token = jwt.sign({ userId }, secret, { expiresIn: "15m" });
+  const resetUrl = `${baseUrl}/reset-password?token=${encodeURIComponent(token)}`;
+  const safeResetUrl = escapeHtml(resetUrl);
+
+  await sendEmail({
+    to: email,
+    fromName: "MeadTools",
+    subject: "Reset your MeadTools password",
+    text: `Reset your MeadTools password using this link: ${resetUrl}\n\nThis link expires in 15 minutes.`,
+    html: `
+      <p>Click the link below to reset your password:</p>
+      <p><a href="${safeResetUrl}">Reset your password</a></p>
+      <p>This link will expire in 15 minutes.</p>
+    `
+  });
+}

--- a/lib/brews/projectBrewView.test.ts
+++ b/lib/brews/projectBrewView.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { projectBrewView } from "@/lib/brews/projectBrewView";
+
+test("projectBrewView excludes authorization, alert, and device fields", () => {
+  const projected = projectBrewView({
+    id: "brew-1",
+    name: "Read only batch",
+    start_date: new Date("2026-01-01T00:00:00.000Z"),
+    end_date: null,
+    stage: "PRIMARY",
+    batch_number: 4,
+    current_volume_liters: 18.5,
+    gravity_unit_preference: "SG",
+    latest_gravity: 1.052,
+    public: true,
+    recipe_id: 12,
+    recipe_name: "Test recipe",
+    entry_count: 1,
+    owner: { displayName: "Brewer" },
+    user_id: 99,
+    requested_email_alerts: true,
+    entries: [
+      {
+        id: "entry-1",
+        datetime: "2026-01-02T00:00:00.000Z",
+        type: "GRAVITY",
+        title: "Gravity",
+        note: "Visible to the selected controller",
+        gravity: 1.052,
+        temperature: null,
+        temp_units: null,
+        data: null,
+        user_id: 99
+      }
+    ],
+    entries_by_stage: [],
+    logs: [
+      {
+        id: "log-1",
+        brew_id: "brew-1",
+        device_id: "device-secret",
+        datetime: "2026-01-02T01:00:00.000Z",
+        temperature: 68,
+        temp_units: "F",
+        battery: 3.9,
+        gravity: 1.051,
+        calculated_gravity: 1.05
+      }
+    ]
+  });
+
+  const serialized = JSON.stringify(projected);
+
+  assert.equal("user_id" in projected, false);
+  assert.equal("requested_email_alerts" in projected, false);
+  assert.equal(projected.public, true);
+  assert.equal("user_id" in projected.entries[0], false);
+  assert.equal("device_id" in projected.logs[0], false);
+  assert.equal("brew_id" in projected.logs[0], false);
+  assert.equal("id" in projected.logs[0], false);
+  assert.doesNotMatch(serialized, /device-secret|requested_email_alerts|user_id|device_id/);
+});
+
+test("projectBrewView supports a sanitized payload with optional content omitted", () => {
+  const projected = projectBrewView({
+    id: "brew-2",
+    name: null,
+    start_date: "2026-02-01T00:00:00.000Z",
+    end_date: null,
+    stage: "PLANNED",
+    batch_number: null,
+    current_volume_liters: null,
+    gravity_unit_preference: "SG",
+    latest_gravity: null,
+    public: null,
+    recipe_id: null,
+    recipe_name: null,
+    entry_count: 0
+  });
+
+  assert.deepEqual(projected.entries, []);
+  assert.deepEqual(projected.entries_by_stage, []);
+  assert.deepEqual(projected.logs, []);
+  assert.equal(projected.recipe_snapshot, null);
+  assert.equal(projected.owner, null);
+  assert.equal(projected.public, false);
+});

--- a/lib/brews/projectBrewView.ts
+++ b/lib/brews/projectBrewView.ts
@@ -1,0 +1,130 @@
+import type { Prisma } from "@prisma/client";
+
+import type { BrewEntryType, BrewStage, GravityUnit } from "@/lib/brewEnums";
+import type { BrewRecipeSnapshot } from "@/lib/utils/buildBrewRecipeStageData";
+import type {
+  BrewViewDetail,
+  BrewViewEntry,
+  BrewViewListItem,
+  BrewViewLog,
+  BrewViewOwner
+} from "@/types/brewView";
+
+type DateValue = Date | string;
+
+export type BrewViewEntrySource = {
+  id: string;
+  datetime: DateValue;
+  type: string;
+  title: string | null;
+  note: string | null;
+  gravity: number | null;
+  temperature: number | null;
+  temp_units: string | null;
+  data: Prisma.JsonValue | null;
+  user_id?: number | null;
+};
+
+export type BrewViewLogSource = {
+  datetime: DateValue;
+  temperature: number;
+  temp_units: string;
+  battery: number | null;
+  gravity: number;
+  calculated_gravity: number | null;
+  id?: string;
+  brew_id?: string | null;
+  device_id?: string | null;
+};
+
+export type BrewViewSource = {
+  id: string;
+  name: string | null;
+  start_date: DateValue;
+  end_date: DateValue | null;
+  stage: string;
+  batch_number: number | null;
+  current_volume_liters: number | null;
+  gravity_unit_preference: string;
+  latest_gravity: number | null;
+  public?: boolean | null;
+  recipe_id: number | null;
+  recipe_name: string | null;
+  recipe_snapshot?: Prisma.JsonValue | null;
+  entry_count: number;
+  owner?: BrewViewOwner | null;
+  entries?: BrewViewEntrySource[];
+  entries_by_stage?: Array<{
+    stage: string;
+    entries: BrewViewEntrySource[];
+  }>;
+  logs?: BrewViewLogSource[];
+  user_id?: number | null;
+  requested_email_alerts?: boolean | null;
+};
+
+function toIso(value: DateValue) {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+export function projectBrewViewEntry(
+  entry: BrewViewEntrySource
+): BrewViewEntry {
+  return {
+    id: entry.id,
+    datetime: toIso(entry.datetime),
+    type: entry.type as BrewEntryType,
+    title: entry.title,
+    note: entry.note,
+    gravity: entry.gravity,
+    temperature: entry.temperature,
+    temp_units: entry.temp_units,
+    data: entry.data
+  };
+}
+
+export function projectBrewViewLog(log: BrewViewLogSource): BrewViewLog {
+  return {
+    datetime: toIso(log.datetime),
+    temperature: log.temperature,
+    temp_units: log.temp_units as BrewViewLog["temp_units"],
+    battery: log.battery,
+    gravity: log.gravity,
+    calculated_gravity: log.calculated_gravity
+  };
+}
+
+export function projectBrewViewListItem(
+  brew: BrewViewSource
+): BrewViewListItem {
+  return {
+    id: brew.id,
+    name: brew.name,
+    start_date: toIso(brew.start_date),
+    end_date: brew.end_date ? toIso(brew.end_date) : null,
+    stage: brew.stage as BrewStage,
+    batch_number: brew.batch_number,
+    current_volume_liters: brew.current_volume_liters,
+    gravity_unit_preference: brew.gravity_unit_preference as GravityUnit,
+    latest_gravity: brew.latest_gravity,
+    public: brew.public ?? false,
+    recipe_id: brew.recipe_id,
+    recipe_name: brew.recipe_name,
+    entry_count: brew.entry_count,
+    owner: brew.owner ?? null
+  };
+}
+
+export function projectBrewView(brew: BrewViewSource): BrewViewDetail {
+  return {
+    ...projectBrewViewListItem(brew),
+    recipe_snapshot:
+      (brew.recipe_snapshot as BrewRecipeSnapshot | null | undefined) ?? null,
+    entries: (brew.entries ?? []).map(projectBrewViewEntry),
+    entries_by_stage: (brew.entries_by_stage ?? []).map((bucket) => ({
+      stage: bucket.stage as BrewStage,
+      entries: bucket.entries.map(projectBrewViewEntry)
+    })),
+    logs: (brew.logs ?? []).map(projectBrewViewLog)
+  };
+}

--- a/lib/db/admin.ts
+++ b/lib/db/admin.ts
@@ -1,0 +1,225 @@
+import { brew_stage, Prisma } from "@prisma/client";
+
+import prisma from "@/lib/prisma";
+import { groupEntriesByStage, type BrewEntryForApp } from "@/lib/db/brews";
+import {
+  projectBrewView,
+  projectBrewViewListItem
+} from "@/lib/brews/projectBrewView";
+import type { BrewViewDetail, BrewViewListItem } from "@/types/brewView";
+
+export type AdminSummary = {
+  users: number;
+  brews: number;
+  activeBrews: number;
+  recipes: number;
+  privateRecipes: number;
+  yeasts: number;
+  ingredients: number;
+  additives: number;
+};
+
+export async function getAdminSummary(): Promise<AdminSummary> {
+  const [
+    users,
+    brews,
+    activeBrews,
+    recipes,
+    privateRecipes,
+    yeasts,
+    ingredients,
+    additives
+  ] = await prisma.$transaction([
+    prisma.users.count(),
+    prisma.brews.count(),
+    prisma.brews.count({ where: { end_date: null } }),
+    prisma.recipes.count(),
+    prisma.recipes.count({ where: { private: true } }),
+    prisma.yeasts.count(),
+    prisma.ingredients.count(),
+    prisma.additives.count()
+  ]);
+
+  return {
+    users,
+    brews,
+    activeBrews,
+    recipes,
+    privateRecipes,
+    yeasts,
+    ingredients,
+    additives
+  };
+}
+
+export type AdminBrewsPage = {
+  brews: BrewViewListItem[];
+  totalCount: number;
+  totalPages: number;
+  page: number;
+  limit: number;
+};
+
+export async function getAdminBrewsPage({
+  page = 1,
+  limit = 10,
+  query = "",
+  stage,
+  status
+}: {
+  page?: number;
+  limit?: number;
+  query?: string;
+  stage?: string;
+  status?: "active" | "complete";
+}): Promise<AdminBrewsPage> {
+  const normalizedPage = Math.max(1, Number(page) || 1);
+  const take = Math.min(Math.max(Number(limit) || 10, 1), 50);
+  const search = query.trim();
+  const where: Prisma.brewsWhereInput = {};
+
+  if (stage && Object.values(brew_stage).includes(stage as brew_stage)) {
+    where.stage = stage as brew_stage;
+  }
+
+  if (status === "active") where.end_date = null;
+  if (status === "complete") where.end_date = { not: null };
+
+  if (search) {
+    where.OR = [
+      { name: { contains: search, mode: "insensitive" } },
+      { recipes: { name: { contains: search, mode: "insensitive" } } },
+      {
+        users: {
+          OR: [
+            {
+              public_username: {
+                contains: search,
+                mode: "insensitive"
+              }
+            },
+            { email: { contains: search, mode: "insensitive" } }
+          ]
+        }
+      }
+    ];
+  }
+
+  const [rows, totalCount] = await prisma.$transaction([
+    prisma.brews.findMany({
+      where,
+      skip: (normalizedPage - 1) * take,
+      take,
+      orderBy: [{ end_date: "desc" }, { start_date: "desc" }],
+      select: {
+        id: true,
+        name: true,
+        start_date: true,
+        end_date: true,
+        stage: true,
+        batch_number: true,
+        current_volume_liters: true,
+        gravity_unit_preference: true,
+        public: true,
+        latest_gravity: true,
+        recipe_id: true,
+        recipes: { select: { name: true } },
+        users: { select: { public_username: true, email: true } },
+        _count: { select: { entries: true } }
+      }
+    }),
+    prisma.brews.count({ where })
+  ]);
+
+  return {
+    brews: rows.map((brew) =>
+      projectBrewViewListItem({
+        ...brew,
+        recipe_name: brew.recipes?.name ?? null,
+        entry_count: brew._count.entries,
+        owner: brew.users
+          ? {
+              displayName:
+                brew.users.public_username?.trim() || brew.users.email
+            }
+          : null
+      })
+    ),
+    totalCount,
+    totalPages: Math.ceil(totalCount / take),
+    page: normalizedPage,
+    limit: take
+  };
+}
+
+export async function getAdminBrew(
+  brewId: string
+): Promise<BrewViewDetail | null> {
+  const brew = await prisma.brews.findUnique({
+    where: { id: brewId },
+    select: {
+      id: true,
+      name: true,
+      start_date: true,
+      end_date: true,
+      stage: true,
+      batch_number: true,
+      current_volume_liters: true,
+      gravity_unit_preference: true,
+      public: true,
+      latest_gravity: true,
+      recipe_id: true,
+      recipe_snapshot: true,
+      recipes: { select: { name: true } },
+      users: { select: { public_username: true, email: true } },
+      entries: {
+        orderBy: [{ datetime: "asc" }, { id: "asc" }],
+        select: {
+          id: true,
+          datetime: true,
+          type: true,
+          title: true,
+          note: true,
+          gravity: true,
+          temperature: true,
+          temp_units: true,
+          data: true
+        }
+      },
+      logs: {
+        orderBy: { datetime: "asc" },
+        select: {
+          datetime: true,
+          temperature: true,
+          temp_units: true,
+          battery: true,
+          gravity: true,
+          calculated_gravity: true
+        }
+      },
+      _count: { select: { entries: true } }
+    }
+  });
+
+  if (!brew) return null;
+
+  const entries: BrewEntryForApp[] = brew.entries.map((entry) => ({
+    ...entry,
+    data: entry.data ?? null,
+    user_id: null
+  }));
+
+  return projectBrewView({
+    ...brew,
+    recipe_name: brew.recipes?.name ?? null,
+    entry_count: brew._count.entries,
+    owner: brew.users
+      ? {
+          displayName: brew.users.public_username?.trim() || brew.users.email
+        }
+      : null,
+    entries,
+    entries_by_stage: groupEntriesByStage(brew.stage, entries),
+    logs: brew.logs
+  });
+}

--- a/lib/db/brews.ts
+++ b/lib/db/brews.ts
@@ -8,6 +8,11 @@ import {
 } from "@prisma/client";
 import { calcABV } from "@/lib/utils/unitConverter";
 import { buildBrewRecipeStageData } from "@/lib/utils/buildBrewRecipeStageData";
+import {
+  projectBrewView,
+  projectBrewViewListItem
+} from "@/lib/brews/projectBrewView";
+import type { BrewViewDetail, BrewViewListItem } from "@/types/brewView";
 
 export type BrewListItem = {
   id: string;
@@ -20,9 +25,11 @@ export type BrewListItem = {
   current_volume_liters: number | null;
   requested_email_alerts: boolean;
   gravity_unit_preference: gravity_unit;
+  public: boolean;
 
   recipe_id: number | null;
   recipe_name: string | null;
+  recipe_private: boolean | null;
 
   entry_count: number;
   latest_gravity: number | null;
@@ -59,11 +66,13 @@ export type BrewForApp = {
   current_volume_liters: number | null;
   requested_email_alerts: boolean;
   gravity_unit_preference: gravity_unit;
+  public: boolean;
 
   latest_gravity: number | null;
 
   recipe_id: number | null;
   recipe_name: string | null;
+  recipe_private: boolean | null;
 
   recipe_snapshot: Prisma.JsonValue | null;
   entry_count: number;
@@ -85,6 +94,7 @@ export type PatchBrewMetadataInput = {
   current_volume_liters?: number | null;
   requested_email_alerts?: boolean;
   gravity_unit_preference?: gravity_unit;
+  public?: boolean;
   end_date?: string | Date | null; // allow ISO string from client
   stage_change_datetime?: string | Date;
 };
@@ -135,9 +145,10 @@ export async function getBrewsForApp(userId: number): Promise<BrewListItem[]> {
       current_volume_liters: true,
       requested_email_alerts: true,
       gravity_unit_preference: true,
+      public: true,
       latest_gravity: true,
       recipe_id: true,
-      recipes: { select: { name: true } },
+      recipes: { select: { name: true, private: true } },
       _count: { select: { entries: true } }
     }
   });
@@ -153,9 +164,11 @@ export async function getBrewsForApp(userId: number): Promise<BrewListItem[]> {
     current_volume_liters: b.current_volume_liters,
     requested_email_alerts: b.requested_email_alerts ?? false,
     gravity_unit_preference: b.gravity_unit_preference ?? gravity_unit.SG,
+    public: b.public ?? false,
 
     recipe_id: b.recipe_id,
     recipe_name: b.recipes?.name ?? null,
+    recipe_private: b.recipes?.private ?? null,
 
     entry_count: b._count.entries,
     latest_gravity: b.latest_gravity
@@ -253,7 +266,7 @@ export async function createBrewForApp(userId: number, input: CreateBrewInput) {
     };
 
     // 5) Create brew
-    return tx.brews.create({
+    const brew = await tx.brews.create({
       data: {
         user_id: userId,
         recipe_id: recipeId,
@@ -273,10 +286,20 @@ export async function createBrewForApp(userId: number, input: CreateBrewInput) {
         current_volume_liters: true,
         requested_email_alerts: true,
         gravity_unit_preference: true,
+        public: true,
         latest_gravity: true,
-        recipe_id: true
+        recipe_id: true,
+        recipes: { select: { name: true, private: true } }
       }
     });
+
+    return {
+      ...brew,
+      recipe_name: brew.recipes?.name ?? null,
+      recipe_private: brew.recipes?.private ?? null,
+      entry_count: 0,
+      recipes: undefined
+    };
   });
 }
 
@@ -297,12 +320,13 @@ export async function getBrewForApp(
       current_volume_liters: true,
       requested_email_alerts: true,
       gravity_unit_preference: true,
+      public: true,
       latest_gravity: true,
 
       recipe_id: true,
       recipe_snapshot: true,
 
-      recipes: { select: { name: true } },
+      recipes: { select: { name: true, private: true } },
       devices: {
         orderBy: [{ device_name: "asc" }, { id: "asc" }],
         select: {
@@ -360,11 +384,13 @@ export async function getBrewForApp(
     current_volume_liters: brew.current_volume_liters,
     requested_email_alerts: brew.requested_email_alerts ?? false,
     gravity_unit_preference: brew.gravity_unit_preference ?? gravity_unit.SG,
+    public: brew.public ?? false,
 
     latest_gravity: brew.latest_gravity,
 
     recipe_id: brew.recipe_id,
     recipe_name: brew.recipes?.name ?? null,
+    recipe_private: brew.recipes?.private ?? null,
 
     recipe_snapshot: (brew.recipe_snapshot as Prisma.JsonValue) ?? null,
     entry_count: brew._count.entries,
@@ -393,7 +419,8 @@ export async function patchBrewMetadata(
         batch_number: true,
         stage: true,
         start_date: true,
-        end_date: true
+        end_date: true,
+        recipe_id: true
       }
     });
 
@@ -510,6 +537,24 @@ export async function patchBrewMetadata(
       data.gravity_unit_preference = input.gravity_unit_preference;
     }
 
+    if ("public" in input) {
+      if (input.public) {
+        const recipeId = (data.recipe_id ?? existing.recipe_id) as
+          | number
+          | null;
+        if (recipeId == null) throw new Error("Recipe not found");
+
+        const publicRecipe = await tx.recipes.findFirst({
+          where: { id: recipeId, user_id: userId, private: false },
+          select: { id: true }
+        });
+        if (!publicRecipe) {
+          throw new Error("Recipe must be public before publishing brew");
+        }
+      }
+      data.public = Boolean(input.public);
+    }
+
     // end_date (null to reopen)
     if ("end_date" in input) {
       const v = input.end_date;
@@ -618,9 +663,10 @@ export async function patchBrewMetadata(
         current_volume_liters: true,
         requested_email_alerts: true,
         gravity_unit_preference: true,
+        public: true,
         latest_gravity: true,
         recipe_id: true,
-        recipes: { select: { name: true } }
+        recipes: { select: { name: true, private: true } }
       }
     });
 
@@ -629,6 +675,7 @@ export async function patchBrewMetadata(
     return {
       ...updatedBrew,
       recipe_name: updatedBrew.recipes?.name ?? null,
+      recipe_private: updatedBrew.recipes?.private ?? null,
       recipes: undefined
     };
   });
@@ -667,6 +714,120 @@ export async function deleteBrewForApp(brewId: string, userId: number) {
   return { message: "Brew deleted successfully." };
 }
 
+export async function getPublicBrewsForRecipe(
+  recipeId: number
+): Promise<BrewViewListItem[]> {
+  const rows = await prisma.brews.findMany({
+    where: {
+      recipe_id: recipeId,
+      public: true,
+      recipes: { private: false }
+    },
+    orderBy: [{ start_date: "desc" }, { id: "asc" }],
+    select: {
+      id: true,
+      name: true,
+      start_date: true,
+      end_date: true,
+      stage: true,
+      batch_number: true,
+      current_volume_liters: true,
+      gravity_unit_preference: true,
+      public: true,
+      latest_gravity: true,
+      recipe_id: true,
+      recipes: { select: { name: true } },
+      users: { select: { public_username: true, active: true } },
+      _count: { select: { entries: true } }
+    }
+  });
+
+  return rows.map((brew) =>
+    projectBrewViewListItem({
+      ...brew,
+      recipe_name: brew.recipes?.name ?? null,
+      entry_count: brew._count.entries,
+      owner:
+        brew.users?.active && brew.users.public_username
+          ? { displayName: brew.users.public_username }
+          : null
+    })
+  );
+}
+
+export async function getPublicBrewForRecipe(
+  recipeId: number,
+  brewId: string
+): Promise<BrewViewDetail | null> {
+  const brew = await prisma.brews.findFirst({
+    where: {
+      id: brewId,
+      recipe_id: recipeId,
+      public: true,
+      recipes: { private: false }
+    },
+    select: {
+      id: true,
+      name: true,
+      start_date: true,
+      end_date: true,
+      stage: true,
+      batch_number: true,
+      current_volume_liters: true,
+      gravity_unit_preference: true,
+      public: true,
+      latest_gravity: true,
+      recipe_id: true,
+      recipe_snapshot: true,
+      recipes: { select: { name: true } },
+      users: { select: { public_username: true, active: true } },
+      entries: {
+        orderBy: [{ datetime: "asc" }, { id: "asc" }],
+        select: {
+          id: true,
+          datetime: true,
+          type: true,
+          title: true,
+          note: true,
+          gravity: true,
+          temperature: true,
+          temp_units: true,
+          data: true
+        }
+      },
+      _count: { select: { entries: true } }
+    }
+  });
+
+  if (!brew) return null;
+
+  const entries: BrewEntryForApp[] = brew.entries.map((entry) => ({
+    id: entry.id,
+    datetime: entry.datetime,
+    type: entry.type,
+    title: entry.title ?? null,
+    note: entry.note ?? null,
+    gravity: entry.gravity ?? null,
+    temperature: entry.temperature ?? null,
+    temp_units: entry.temp_units ?? null,
+    data: (entry.data as Prisma.JsonValue) ?? null,
+    user_id: null
+  }));
+
+  return projectBrewView({
+    ...brew,
+    recipe_name: brew.recipes?.name ?? null,
+    entry_count: brew._count.entries,
+    owner:
+      brew.users?.active && brew.users.public_username
+        ? { displayName: brew.users.public_username }
+        : null,
+    entries,
+    entries_by_stage: groupEntriesByStage(brew.stage, entries),
+    logs: []
+  });
+}
+
 function isBrewStage(v: any): v is brew_stage {
   return (
     typeof v === "string" && Object.values(brew_stage).includes(v as brew_stage)
@@ -693,7 +854,7 @@ function getInitialStageForEntries(
  * entry to the current stage, then advance whenever a STAGE_CHANGE entry moves
  * the brew to a new stage.
  */
-function groupEntriesByStage(
+export function groupEntriesByStage(
   currentStage: brew_stage,
   entries: BrewEntryForApp[]
 ): EntriesByStage {
@@ -790,7 +951,9 @@ async function syncEstimatedAbvEntry(
     });
   }
 
-  const visibleEntries = entries.filter((entry) => !(entry.data as any)?.hidden);
+  const visibleEntries = entries.filter(
+    (entry) => !(entry.data as any)?.hidden
+  );
   const snapshotEntries = visibleEntries.filter((entry) => {
     const data = entry.data as any;
     if (entry.type === brew_entry_type.VOLUME) return true;
@@ -798,7 +961,11 @@ async function syncEstimatedAbvEntry(
       return data?.kind === "INGREDIENT" && data?.meta?.stage === "SECONDARY";
     }
     if (entry.type !== brew_entry_type.GRAVITY) return false;
-    return data?.readingRole === "OG" || (data?.readingRole === "FG" && (data?.source ?? "measured") === "measured");
+    return (
+      data?.readingRole === "OG" ||
+      (data?.readingRole === "FG" &&
+        (data?.source ?? "measured") === "measured")
+    );
   });
 
   const createdSnapshots = new Set<string>();
@@ -807,12 +974,20 @@ async function syncEstimatedAbvEntry(
     const entriesThroughEvent = visibleEntries.filter((entry) => {
       const entryTime = entry.datetime.getTime();
       const eventTime = event.datetime.getTime();
-      return entryTime < eventTime || (entryTime === eventTime && entry.id <= event.id);
+      return (
+        entryTime < eventTime ||
+        (entryTime === eventTime && entry.id <= event.id)
+      );
     });
     const isOriginalGravityEvent =
-      event.type === brew_entry_type.GRAVITY && (event.data as any)?.readingRole === "OG";
+      event.type === brew_entry_type.GRAVITY &&
+      (event.data as any)?.readingRole === "OG";
 
-    if (isOriginalGravityEvent && typeof event.gravity === "number" && Number.isFinite(event.gravity)) {
+    if (
+      isOriginalGravityEvent &&
+      typeof event.gravity === "number" &&
+      Number.isFinite(event.gravity)
+    ) {
       const snapshotKey = `${event.id}:0`;
       if (createdSnapshots.has(snapshotKey)) continue;
       createdSnapshots.add(snapshotKey);
@@ -849,10 +1024,16 @@ async function syncEstimatedAbvEntry(
       .reverse()
       .find((entry) => {
         const liters = (entry.data as any)?.liters;
-        return entry.type === brew_entry_type.VOLUME && typeof liters === "number" && Number.isFinite(liters) && liters > 0;
+        return (
+          entry.type === brew_entry_type.VOLUME &&
+          typeof liters === "number" &&
+          Number.isFinite(liters) &&
+          liters > 0
+        );
       });
     const currentVolumeLiters =
-      typeof (latestVolumeEntry?.data as any)?.liters === "number" && Number.isFinite((latestVolumeEntry?.data as any).liters)
+      typeof (latestVolumeEntry?.data as any)?.liters === "number" &&
+      Number.isFinite((latestVolumeEntry?.data as any).liters)
         ? (latestVolumeEntry?.data as any).liters
         : brew.current_volume_liters;
     const stageData = buildBrewRecipeStageData({
@@ -892,11 +1073,13 @@ async function syncEstimatedAbvEntry(
         ? (fallbackAbv * volumeData.startingLiters) / volumeData.liters
         : null;
     const abv =
-      typeof volumeAdjustedAbv === "number" && Number.isFinite(volumeAdjustedAbv)
+      typeof volumeAdjustedAbv === "number" &&
+      Number.isFinite(volumeAdjustedAbv)
         ? volumeAdjustedAbv
-        : typeof stageData.actual.currentAbv === "number" && Number.isFinite(stageData.actual.currentAbv)
-        ? stageData.actual.currentAbv
-        : fallbackAbv;
+        : typeof stageData.actual.currentAbv === "number" &&
+            Number.isFinite(stageData.actual.currentAbv)
+          ? stageData.actual.currentAbv
+          : fallbackAbv;
 
     if (
       !originalGravityEntry ||
@@ -940,13 +1123,20 @@ async function syncEstimatedAbvEntry(
   }
 }
 
-function shouldSyncEstimatedAbvForEntry(entry: { type: brew_entry_type; data?: Prisma.JsonValue | null }) {
+function shouldSyncEstimatedAbvForEntry(entry: {
+  type: brew_entry_type;
+  data?: Prisma.JsonValue | null;
+}) {
   const data = entry.data as any;
   if (data?.source === "abv_estimate") return false;
   if (entry.type === brew_entry_type.VOLUME) return true;
-  if (entry.type === brew_entry_type.ADDITION) return data?.kind === "INGREDIENT" && data?.meta?.stage === "SECONDARY";
+  if (entry.type === brew_entry_type.ADDITION)
+    return data?.kind === "INGREDIENT" && data?.meta?.stage === "SECONDARY";
   if (entry.type !== brew_entry_type.GRAVITY) return false;
-  return data?.readingRole === "OG" || (data?.readingRole === "FG" && (data?.source ?? "measured") === "measured");
+  return (
+    data?.readingRole === "OG" ||
+    (data?.readingRole === "FG" && (data?.source ?? "measured") === "measured")
+  );
 }
 
 async function syncCurrentVolume(
@@ -1026,7 +1216,9 @@ export async function createBrewEntryForApp(
     });
 
     await syncLatestGravity(tx, brewId);
-    if (shouldSyncEstimatedAbvForEntry({ type: input.type, data: input.data })) {
+    if (
+      shouldSyncEstimatedAbvForEntry({ type: input.type, data: input.data })
+    ) {
       await syncEstimatedAbvEntry(tx, brewId, userId);
     }
     if (input.type === brew_entry_type.VOLUME) {
@@ -1129,7 +1321,12 @@ export async function patchBrewEntryForApp(
     });
 
     await syncLatestGravity(tx, brewId);
-    if (shouldSyncEstimatedAbvForEntry({ type: entry.type, data: ("data" in input ? input.data : entry.data) ?? entry.data })) {
+    if (
+      shouldSyncEstimatedAbvForEntry({
+        type: entry.type,
+        data: ("data" in input ? input.data : entry.data) ?? entry.data
+      })
+    ) {
       await syncEstimatedAbvEntry(tx, brewId, userId);
     }
     if (entry.type === brew_entry_type.VOLUME) {

--- a/lib/db/emailHelpers.ts
+++ b/lib/db/emailHelpers.ts
@@ -42,11 +42,13 @@ export function stripMarkdown(md: string): string {
 
 export async function sendEmail({
   to,
+  fromName = "MeadTools Alerts",
   subject,
   text,
   html
 }: {
   to: string;
+  fromName?: string;
   subject: string;
   text: string;
   html?: string;
@@ -63,7 +65,7 @@ export async function sendEmail({
   });
 
   await transporter.sendMail({
-    from: { name: "MeadTools Alerts", address: user },
+    from: { name: fromName, address: user },
     to,
     subject,
     text,

--- a/lib/db/ingredients.ts
+++ b/lib/db/ingredients.ts
@@ -1,4 +1,5 @@
 import prisma from "../prisma"; // Import Prisma client
+import { Prisma } from "@prisma/client";
 
 // Fetch all ingredients
 export async function getAllIngredients() {
@@ -60,9 +61,35 @@ export async function createIngredient(data: {
   water_content: number;
   category: string;
 }) {
-  return prisma.ingredients.create({
-    data,
-  });
+  try {
+    return await prisma.ingredients.create({
+      data,
+    });
+  } catch (error) {
+    if (!isIdUniqueConstraintError(error)) throw error;
+
+    await prisma.$executeRaw`
+      SELECT setval(
+        pg_get_serial_sequence('ingredients', 'id'),
+        COALESCE((SELECT MAX(id) FROM ingredients), 0) + 1,
+        false
+      )
+    `;
+
+    return prisma.ingredients.create({
+      data,
+    });
+  }
+}
+
+function isIdUniqueConstraintError(error: unknown) {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    error.code === "P2002" &&
+    (Array.isArray(error.meta?.target)
+      ? error.meta.target.includes("id")
+      : error.meta?.target === "id")
+  );
 }
 
 export async function updateIngredient(

--- a/lib/db/queryKeys.ts
+++ b/lib/db/queryKeys.ts
@@ -44,6 +44,24 @@ export const qk = {
   adminUsers: ["admin", "users"] as const,
   adminRecipes: (page: number, limit: number, query: string) =>
     ["admin", "recipes", { page, limit, query }] as const,
+  adminSummary: ["admin", "summary"] as const,
+  adminBrews: {
+    all: ["admin", "brews"] as const,
+    list: (
+      page: number,
+      limit: number,
+      query: string,
+      stage: string,
+      status: string
+    ) =>
+      [
+        "admin",
+        "brews",
+        "list",
+        { page, limit, query, stage, status }
+      ] as const,
+    detail: (brewId: string) => ["admin", "brews", "detail", brewId] as const
+  },
 
   accountBrews: {
     all: ["accountBrews"] as const,
@@ -54,5 +72,12 @@ export const qk = {
   accountBrewEntries: {
     list: (brewId: string) => ["accountBrews", brewId, "entries"] as const
     // optional if you ever fetch entries separately
+  },
+
+  publicRecipeBrews: {
+    list: (recipeId: string | number) =>
+      ["publicRecipeBrews", String(recipeId)] as const,
+    detail: (recipeId: string | number, brewId: string) =>
+      ["publicRecipeBrews", String(recipeId), brewId] as const
   }
 };

--- a/lib/db/recipes.ts
+++ b/lib/db/recipes.ts
@@ -255,9 +255,27 @@ export async function getRecipeInfo(recipeId: number) {
   }
 }
 export async function updateRecipe(id: string, fields: Partial<RecipeData>) {
-  return prisma.recipes.update({
-    where: { id: parseInt(id, 10) }, // Ensure id is converted to an integer
-    data: fields
+  const recipeId = parseInt(id, 10);
+
+  if (fields.private !== true) {
+    return prisma.recipes.update({
+      where: { id: recipeId },
+      data: fields
+    });
+  }
+
+  return prisma.$transaction(async (tx) => {
+    const recipe = await tx.recipes.update({
+      where: { id: recipeId },
+      data: fields
+    });
+
+    await tx.brews.updateMany({
+      where: { recipe_id: recipeId },
+      data: { public: false }
+    });
+
+    return recipe;
   });
 }
 

--- a/lib/db/yeasts.ts
+++ b/lib/db/yeasts.ts
@@ -1,4 +1,5 @@
 import prisma from "../prisma";
+import { Prisma } from "@prisma/client";
 
 // Get all yeasts
 export async function getAllYeasts() {
@@ -64,7 +65,31 @@ export async function createYeast(data: {
   low_temp: number;
   high_temp: number;
 }) {
-  return prisma.yeasts.create({ data });
+  try {
+    return await prisma.yeasts.create({ data });
+  } catch (error) {
+    if (!isIdUniqueConstraintError(error)) throw error;
+
+    await prisma.$executeRaw`
+      SELECT setval(
+        pg_get_serial_sequence('yeasts', 'id'),
+        COALESCE((SELECT MAX(id) FROM yeasts), 0) + 1,
+        false
+      )
+    `;
+
+    return prisma.yeasts.create({ data });
+  }
+}
+
+function isIdUniqueConstraintError(error: unknown) {
+  return (
+    error instanceof Prisma.PrismaClientKnownRequestError &&
+    error.code === "P2002" &&
+    (Array.isArray(error.meta?.target)
+      ? error.meta.target.includes("id")
+      : error.meta?.target === "id")
+  );
 }
 
 export async function updateYeast(

--- a/locales/de/default.json
+++ b/locales/de/default.json
@@ -142,6 +142,53 @@
   "additivesHeading": "Zusätze und weitere Zutaten",
   "adjunctAmount": "Zusatzmenge in Probe (g):",
   "adjunctConcentration": "Zusatzkonzentration (PPM):",
+  "admin": {
+    "additives": {
+      "add": "Zusatzstoff hinzufügen"
+    },
+    "brews": {
+      "description": "Alle Ansätze im Tracker ansehen, ohne die Daten der Besitzer zu ändern.",
+      "searchPlaceholder": "Ansätze, Rezepte oder Besitzer suchen"
+    },
+    "ingredients": {
+      "add": "Zutat hinzufügen"
+    },
+    "nav": {
+      "additives": "Zusatzstoffe",
+      "brews": "Ansätze",
+      "ingredients": "Zutaten",
+      "overview": "Übersicht",
+      "recipes": "Rezepte",
+      "users": "Benutzer",
+      "yeasts": "Hefen"
+    },
+    "overview": {
+      "activeBrews": "{{count}} aktiv",
+      "description": "Website-Aktivitäten prüfen und einen Administrationsbereich öffnen.",
+      "privateRecipes": "{{count}} privat",
+      "title": "Übersicht"
+    },
+    "owner": "Besitzer",
+    "readOnly": "Schreibgeschützt",
+    "recipes": {
+      "back": "Zurück zu den Rezepten",
+      "description": "Öffentliche und private Rezepte in einer schreibgeschützten Verwaltungsansicht öffnen.",
+      "searchPlaceholder": "Name oder Besitzer suchen"
+    },
+    "title": "Administratorbereich",
+    "users": {
+      "confirmResetDescription": "Einen Link zum Zurücksetzen des Passworts an {{email}} senden? Der Link läuft nach 15 Minuten ab.",
+      "confirmResetTitle": "Link zum Zurücksetzen senden?",
+      "resetError": "Der Link zum Zurücksetzen des Passworts konnte nicht gesendet werden.",
+      "resetSentDescription": "Ein Link zum Zurücksetzen des Passworts wurde an {{email}} gesendet.",
+      "resetSentTitle": "Link zum Zurücksetzen gesendet",
+      "sendingReset": "Wird gesendet...",
+      "sendReset": "Link zum Zurücksetzen senden"
+    },
+    "yeasts": {
+      "add": "Hefe hinzufügen"
+    }
+  },
   "advancedNutrition": {
     "label": "Erweiterte Einstellungen",
     "yanContribution": "YAN-Anteil bearbeiten",
@@ -412,6 +459,7 @@
       },
       "noFilteredEntries": "Keine Einträge entsprechen den ausgewählten Filtern.",
       "noMetricEntries": "Keine passenden Metrikeinträge.",
+      "notes": "Notizen",
       "sort": {
         "label": "Sortieren",
         "newest": "Neueste zuerst",
@@ -606,6 +654,11 @@
       "takingPh": "pH-Messung erfassen?",
       "workflowHint": "Protokolliere Zugaben, sobald sie passieren, und halte das Volumen vor der Reifelagerung aktuell."
     },
+    "share": {
+      "action": "Ansatz teilen",
+      "copied": "Link zum öffentlichen Ansatz kopiert.",
+      "title": "Geteilter Ansatz: {{name}}"
+    },
     "stage": "Bühne",
     "stageChange": "Phasenwechsel",
     "stageDesc": {
@@ -621,6 +674,14 @@
     "startDate": "Startdatum",
     "stayHere": "Du bist hier",
     "title": "Brew Tracker",
+    "visibility": {
+      "label": "Sichtbarkeit",
+      "private": "Privat",
+      "privateDescription": "Nur du und Admins können diesen Ansatz ansehen.",
+      "public": "Öffentlich",
+      "publicDescription": "Öffentliche Ansätze können über öffentliche Rezeptseiten angesehen werden.",
+      "recipeMustBePublic": "Veröffentliche zuerst das Rezept, bevor du diesen Ansatz teilst."
+    },
     "volume": {
       "currentVolume": "Aktuelles Volumen",
       "enterVolume": "Volumen",
@@ -1364,6 +1425,13 @@
   },
   "private": "Privates Rezept?",
   "prunes": "Trockenpflaumen",
+  "publicBrews": {
+    "backToRecipe": "Zurück zum Rezept",
+    "description": "Brauer haben diese Chargen aus diesem Rezept geteilt.",
+    "empty": "Für dieses Rezept wurden noch keine öffentlichen Ansätze geteilt.",
+    "title": "Öffentliche Ansätze",
+    "viewBrew": "Ansatz ansehen"
+  },
   "publicRecipes": {
     "fail": " Rezepte konnten nicht geladen werden. Bitte versuche es später noch einmal.",
     "title": "Öffentliche Rezepte"

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -142,6 +142,53 @@
   "additivesHeading": "Additives and Additional Ingredients",
   "adjunctAmount": "Adjunct Amount in sample (g):",
   "adjunctConcentration": "Adjunct Concentration (PPM):",
+  "admin": {
+    "additives": {
+      "add": "Add additive"
+    },
+    "brews": {
+      "description": "Inspect every brew in the tracker without changing owner data.",
+      "searchPlaceholder": "Search brews, recipes, or owners"
+    },
+    "ingredients": {
+      "add": "Add ingredient"
+    },
+    "nav": {
+      "additives": "Additives",
+      "brews": "Brews",
+      "ingredients": "Ingredients",
+      "overview": "Overview",
+      "recipes": "Recipes",
+      "users": "Users",
+      "yeasts": "Yeasts"
+    },
+    "overview": {
+      "activeBrews": "{{count}} active",
+      "description": "Review site activity and open an administrative workspace.",
+      "privateRecipes": "{{count}} private",
+      "title": "Overview"
+    },
+    "owner": "Owner",
+    "readOnly": "Read only",
+    "recipes": {
+      "back": "Back to recipes",
+      "description": "Open public and private recipes in a read-only administrative view.",
+      "searchPlaceholder": "Search name or owner"
+    },
+    "title": "Admin",
+    "users": {
+      "confirmResetDescription": "Send a password reset link to {{email}}? The link will expire in 15 minutes.",
+      "confirmResetTitle": "Send password reset?",
+      "resetError": "The password reset link could not be sent.",
+      "resetSentDescription": "A password reset link was sent to {{email}}.",
+      "resetSentTitle": "Reset link sent",
+      "sendingReset": "Sending...",
+      "sendReset": "Send password reset"
+    },
+    "yeasts": {
+      "add": "Add yeast"
+    }
+  },
   "advancedNutrition": {
     "label": "Advanced Nutrition",
     "yanContribution": "Edit YAN Contribution",
@@ -412,6 +459,7 @@
       },
       "noFilteredEntries": "No entries match the selected filters.",
       "noMetricEntries": "No matching metric entries.",
+      "notes": "Notes",
       "sort": {
         "label": "Sort",
         "newest": "Newest first",
@@ -606,6 +654,11 @@
       "takingPh": "Taking a pH reading?",
       "workflowHint": "Log additions as they happen and keep volume current before bulk aging."
     },
+    "share": {
+      "action": "Share brew",
+      "copied": "Public brew link copied.",
+      "title": "Shared brew: {{name}}"
+    },
     "stage": "Stage",
     "stageChange": "Stage change",
     "stageDesc": {
@@ -621,6 +674,14 @@
     "startDate": "Start Date",
     "stayHere": "You are here",
     "title": "Brew Tracker",
+    "visibility": {
+      "label": "Visibility",
+      "private": "Private",
+      "privateDescription": "Only you and admins can view this brew.",
+      "public": "Public",
+      "publicDescription": "Public brews can be viewed from public recipe pages.",
+      "recipeMustBePublic": "Make the recipe public before sharing this brew."
+    },
     "volume": {
       "currentVolume": "Current volume",
       "enterVolume": "Volume",
@@ -1364,6 +1425,13 @@
   },
   "private": "Private Recipe?",
   "prunes": "Prunes",
+  "publicBrews": {
+    "backToRecipe": "Back to recipe",
+    "description": "Brewers have shared these batches from this recipe.",
+    "empty": "No public brews have been shared for this recipe yet.",
+    "title": "Public brews",
+    "viewBrew": "View brew"
+  },
   "publicRecipes": {
     "fail": " Failed to load recipes. Please try again later.",
     "title": "Public Recipes"

--- a/prisma/migrations/20260613000000_add_public_brews/migration.sql
+++ b/prisma/migrations/20260613000000_add_public_brews/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "brews"
+ADD COLUMN "public" BOOLEAN NOT NULL DEFAULT false;
+
+UPDATE "brews"
+SET "public" = false
+FROM "recipes"
+WHERE "brews"."recipe_id" = "recipes"."id"
+  AND "recipes"."private" = true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model brews {
   requested_email_alerts Boolean?  @default(false)
   sb_alert_sent          Boolean?  @default(false)
   fg_alert_sent          Boolean?  @default(false)
+  public                 Boolean   @default(false)
 
   // brew-tracking additions
   stage                   brew_stage   @default(PLANNED)

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3672,6 +3672,19 @@
                 "type": "number",
                 "nullable": true
               },
+              "requested_email_alerts": {
+                "type": "boolean"
+              },
+              "gravity_unit_preference": {
+                "type": "string",
+                "enum": [
+                  "SG",
+                  "BRIX"
+                ]
+              },
+              "public": {
+                "type": "boolean"
+              },
               "latest_gravity": {
                 "type": "number",
                 "nullable": true
@@ -3682,6 +3695,10 @@
               },
               "recipe_name": {
                 "type": "string",
+                "nullable": true
+              },
+              "recipe_private": {
+                "type": "boolean",
                 "nullable": true
               },
               "recipe_snapshot": {
@@ -4319,6 +4336,19 @@
             "type": "number",
             "nullable": true
           },
+          "requested_email_alerts": {
+            "type": "boolean"
+          },
+          "gravity_unit_preference": {
+            "type": "string",
+            "enum": [
+              "SG",
+              "BRIX"
+            ]
+          },
+          "public": {
+            "type": "boolean"
+          },
           "latest_gravity": {
             "type": "number",
             "nullable": true
@@ -4329,6 +4359,10 @@
           },
           "recipe_name": {
             "type": "string",
+            "nullable": true
+          },
+          "recipe_private": {
+            "type": "boolean",
             "nullable": true
           },
           "recipe_snapshot": {
@@ -4925,6 +4959,13 @@
             }
           }
         }
+      },
+      "GravityUnitResponse": {
+        "type": "string",
+        "enum": [
+          "SG",
+          "BRIX"
+        ]
       },
       "BrewRecipeSnapshotResponse": {
         "type": "object",
@@ -5563,6 +5604,18 @@
             "type": "boolean",
             "nullable": true
           },
+          "gravity_unit_preference": {
+            "type": "string",
+            "enum": [
+              "SG",
+              "BRIX"
+            ],
+            "nullable": true
+          },
+          "public": {
+            "type": "boolean",
+            "nullable": true
+          },
           "end_date": {
             "type": "string",
             "nullable": true
@@ -5611,12 +5664,30 @@
             "type": "boolean",
             "nullable": true
           },
+          "gravity_unit_preference": {
+            "type": "string",
+            "enum": [
+              "SG",
+              "BRIX"
+            ]
+          },
+          "public": {
+            "type": "boolean"
+          },
           "latest_gravity": {
             "type": "number",
             "nullable": true
           },
           "recipe_id": {
             "type": "number",
+            "nullable": true
+          },
+          "recipe_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "recipe_private": {
+            "type": "boolean",
             "nullable": true
           }
         },
@@ -5692,9 +5763,26 @@
                     "COMPLETE"
                   ]
                 },
+                "batch_number": {
+                  "type": "number",
+                  "nullable": true
+                },
                 "current_volume_liters": {
                   "type": "number",
                   "nullable": true
+                },
+                "requested_email_alerts": {
+                  "type": "boolean"
+                },
+                "gravity_unit_preference": {
+                  "type": "string",
+                  "enum": [
+                    "SG",
+                    "BRIX"
+                  ]
+                },
+                "public": {
+                  "type": "boolean"
                 },
                 "recipe_id": {
                   "type": "number",
@@ -5702,6 +5790,10 @@
                 },
                 "recipe_name": {
                   "type": "string",
+                  "nullable": true
+                },
+                "recipe_private": {
+                  "type": "boolean",
                   "nullable": true
                 },
                 "entry_count": {
@@ -5746,9 +5838,26 @@
               "COMPLETE"
             ]
           },
+          "batch_number": {
+            "type": "number",
+            "nullable": true
+          },
           "current_volume_liters": {
             "type": "number",
             "nullable": true
+          },
+          "requested_email_alerts": {
+            "type": "boolean"
+          },
+          "gravity_unit_preference": {
+            "type": "string",
+            "enum": [
+              "SG",
+              "BRIX"
+            ]
+          },
+          "public": {
+            "type": "boolean"
           },
           "recipe_id": {
             "type": "number",
@@ -5756,6 +5865,10 @@
           },
           "recipe_name": {
             "type": "string",
+            "nullable": true
+          },
+          "recipe_private": {
+            "type": "boolean",
             "nullable": true
           },
           "entry_count": {
@@ -5825,9 +5938,38 @@
                 "type": "number",
                 "nullable": true
               },
+              "requested_email_alerts": {
+                "type": "boolean",
+                "nullable": true
+              },
+              "gravity_unit_preference": {
+                "type": "string",
+                "enum": [
+                  "SG",
+                  "BRIX"
+                ]
+              },
+              "public": {
+                "type": "boolean"
+              },
+              "latest_gravity": {
+                "type": "number",
+                "nullable": true
+              },
               "recipe_id": {
                 "type": "number",
                 "nullable": true
+              },
+              "recipe_name": {
+                "type": "string",
+                "nullable": true
+              },
+              "recipe_private": {
+                "type": "boolean",
+                "nullable": true
+              },
+              "entry_count": {
+                "type": "number"
               }
             }
           }
@@ -7728,6 +7870,1776 @@
         "properties": {
           "error": {
             "type": "string"
+          }
+        }
+      },
+      "PublicRecipeBrewPathParams": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "brew_id": {
+            "type": "string"
+          }
+        }
+      },
+      "PublicRecipeBrewResponse": {
+        "type": "object",
+        "properties": {
+          "brew": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string",
+                "nullable": true
+              },
+              "start_date": {
+                "type": "string"
+              },
+              "end_date": {
+                "type": "string",
+                "nullable": true
+              },
+              "stage": {
+                "type": "string",
+                "enum": [
+                  "PLANNED",
+                  "PRIMARY",
+                  "SECONDARY",
+                  "BULK_AGE",
+                  "STABILIZED",
+                  "BACKSWEETENED",
+                  "PACKAGED",
+                  "COMPLETE"
+                ]
+              },
+              "batch_number": {
+                "type": "number",
+                "nullable": true
+              },
+              "current_volume_liters": {
+                "type": "number",
+                "nullable": true
+              },
+              "gravity_unit_preference": {
+                "type": "string",
+                "enum": [
+                  "SG",
+                  "BRIX"
+                ]
+              },
+              "latest_gravity": {
+                "type": "number",
+                "nullable": true
+              },
+              "public": {
+                "type": "boolean"
+              },
+              "recipe_id": {
+                "type": "number",
+                "nullable": true
+              },
+              "recipe_name": {
+                "type": "string",
+                "nullable": true
+              },
+              "entry_count": {
+                "type": "number"
+              },
+              "owner": {
+                "type": "object",
+                "properties": {
+                  "displayName": {
+                    "type": "string"
+                  }
+                },
+                "nullable": true
+              },
+              "recipe_snapshot": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "number"
+                  },
+                  "dataV2": {
+                    "type": "object",
+                    "properties": {
+                      "version": {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      "unitDefaults": {
+                        "type": "object",
+                        "properties": {
+                          "weight": {
+                            "type": "string",
+                            "enum": [
+                              "kg",
+                              "g",
+                              "lb",
+                              "oz"
+                            ]
+                          },
+                          "volume": {
+                            "type": "string",
+                            "enum": [
+                              "L",
+                              "mL",
+                              "gal",
+                              "qt",
+                              "pt",
+                              "fl_oz",
+                              "imp_gal",
+                              "imp_qt",
+                              "imp_pt",
+                              "imp_fl_oz"
+                            ]
+                          }
+                        }
+                      },
+                      "ingredients": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "lineId": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "ref": {
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": [
+                                        "catalog"
+                                      ]
+                                    },
+                                    "ingredientId": {
+                                      "oneOf": [
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "string"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": [
+                                        "custom"
+                                      ]
+                                    }
+                                  }
+                                }
+                              ]
+                            },
+                            "category": {
+                              "type": "string"
+                            },
+                            "brix": {
+                              "type": "string"
+                            },
+                            "secondary": {
+                              "type": "boolean"
+                            },
+                            "amounts": {
+                              "type": "object",
+                              "properties": {
+                                "weight": {
+                                  "type": "object",
+                                  "properties": {
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "unit": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "volume": {
+                                  "type": "object",
+                                  "properties": {
+                                    "value": {
+                                      "type": "string"
+                                    },
+                                    "unit": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "basis": {
+                                  "type": "string",
+                                  "enum": [
+                                    "weight",
+                                    "volume"
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "fg": {
+                        "type": "string"
+                      },
+                      "additives": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "lineId": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "amount": {
+                              "type": "string"
+                            },
+                            "unit": {
+                              "type": "string"
+                            },
+                            "amountTouched": {
+                              "type": "boolean"
+                            },
+                            "amountDim": {
+                              "type": "string",
+                              "enum": [
+                                "weight",
+                                "volume",
+                                "count",
+                                "unknown"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "stabilizers": {
+                        "type": "object",
+                        "properties": {
+                          "adding": {
+                            "type": "boolean"
+                          },
+                          "takingPh": {
+                            "type": "boolean"
+                          },
+                          "phReading": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "kmeta",
+                              "nameta"
+                            ]
+                          }
+                        }
+                      },
+                      "notes": {
+                        "type": "object",
+                        "properties": {
+                          "primary": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "lineId": {
+                                  "type": "string"
+                                },
+                                "content": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "secondary": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "lineId": {
+                                  "type": "string"
+                                },
+                                "content": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "nutrients": {
+                        "type": "object",
+                        "properties": {
+                          "version": {
+                            "type": "number",
+                            "enum": [
+                              2
+                            ]
+                          },
+                          "inputs": {
+                            "type": "object",
+                            "properties": {
+                              "volume": {
+                                "type": "string"
+                              },
+                              "volumeUnits": {
+                                "type": "string",
+                                "enum": [
+                                  "gal",
+                                  "liter"
+                                ]
+                              },
+                              "sg": {
+                                "type": "string"
+                              },
+                              "offsetPpm": {
+                                "type": "string"
+                              },
+                              "numberOfAdditions": {
+                                "type": "string"
+                              },
+                              "goFermType": {
+                                "type": "string",
+                                "enum": [
+                                  "Go-Ferm",
+                                  "protect",
+                                  "sterol-flash",
+                                  "none"
+                                ]
+                              },
+                              "yeastAmountG": {
+                                "type": "string"
+                              },
+                              "yeastAmountTouched": {
+                                "type": "boolean"
+                              }
+                            }
+                          },
+                          "selected": {
+                            "type": "object",
+                            "properties": {
+                              "yeastBrand": {
+                                "type": "string"
+                              },
+                              "yeastStrain": {
+                                "type": "string"
+                              },
+                              "yeastId": {
+                                "type": "number"
+                              },
+                              "nitrogenRequirement": {
+                                "type": "string",
+                                "enum": [
+                                  "Very Low",
+                                  "Low",
+                                  "Medium",
+                                  "High",
+                                  "Very High"
+                                ]
+                              },
+                              "schedule": {
+                                "type": "string",
+                                "enum": [
+                                  "tbe",
+                                  "tosna",
+                                  "justK",
+                                  "dap",
+                                  "oAndk",
+                                  "oAndDap",
+                                  "kAndDap",
+                                  "other"
+                                ]
+                              },
+                              "selectedNutrients": {
+                                "type": "object",
+                                "properties": {
+                                  "fermO": {
+                                    "type": "boolean"
+                                  },
+                                  "fermK": {
+                                    "type": "boolean"
+                                  },
+                                  "dap": {
+                                    "type": "boolean"
+                                  },
+                                  "other": {
+                                    "type": "boolean"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "settings": {
+                            "type": "object",
+                            "properties": {
+                              "yanContribution": {
+                                "type": "object",
+                                "properties": {
+                                  "fermO": {
+                                    "type": "string"
+                                  },
+                                  "fermK": {
+                                    "type": "string"
+                                  },
+                                  "dap": {
+                                    "type": "string"
+                                  },
+                                  "other": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "maxGpl": {
+                                "type": "object",
+                                "properties": {
+                                  "fermO": {
+                                    "type": "string"
+                                  },
+                                  "fermK": {
+                                    "type": "string"
+                                  },
+                                  "dap": {
+                                    "type": "string"
+                                  },
+                                  "other": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "maxGplTouched": {
+                                "type": "boolean"
+                              },
+                              "other": {
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "adjustments": {
+                            "type": "object",
+                            "properties": {
+                              "adjustAllowed": {
+                                "type": "boolean"
+                              },
+                              "providedYanPpm": {
+                                "type": "object",
+                                "properties": {
+                                  "fermO": {
+                                    "type": "string"
+                                  },
+                                  "fermK": {
+                                    "type": "string"
+                                  },
+                                  "dap": {
+                                    "type": "string"
+                                  },
+                                  "other": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "flags": {
+                        "type": "object",
+                        "properties": {
+                          "advanced": {
+                            "type": "boolean"
+                          },
+                          "private": {
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    },
+                    "nullable": true
+                  },
+                  "snapshottedAt": {
+                    "type": "string"
+                  }
+                },
+                "nullable": true
+              },
+              "entries": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "datetime": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string",
+                      "enum": [
+                        "NOTE",
+                        "GRAVITY",
+                        "VOLUME",
+                        "TEMPERATURE",
+                        "PH",
+                        "ADDITION",
+                        "NUTRIENT",
+                        "RACKING",
+                        "STABILIZATION",
+                        "BACKSWEETENING",
+                        "PACKAGING",
+                        "TASTING",
+                        "STAGE_CHANGE",
+                        "ISSUE"
+                      ]
+                    },
+                    "title": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "note": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "gravity": {
+                      "type": "number",
+                      "nullable": true
+                    },
+                    "temperature": {
+                      "type": "number",
+                      "nullable": true
+                    },
+                    "temp_units": {
+                      "type": "string",
+                      "enum": [
+                        "F",
+                        "C",
+                        "K"
+                      ],
+                      "nullable": true
+                    },
+                    "data": {
+                      "type": "object",
+                      "nullable": true
+                    }
+                  }
+                }
+              },
+              "entries_by_stage": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "stage": {
+                      "type": "string",
+                      "enum": [
+                        "PLANNED",
+                        "PRIMARY",
+                        "SECONDARY",
+                        "BULK_AGE",
+                        "STABILIZED",
+                        "BACKSWEETENED",
+                        "PACKAGED",
+                        "COMPLETE"
+                      ]
+                    },
+                    "entries": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "datetime": {
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "NOTE",
+                              "GRAVITY",
+                              "VOLUME",
+                              "TEMPERATURE",
+                              "PH",
+                              "ADDITION",
+                              "NUTRIENT",
+                              "RACKING",
+                              "STABILIZATION",
+                              "BACKSWEETENING",
+                              "PACKAGING",
+                              "TASTING",
+                              "STAGE_CHANGE",
+                              "ISSUE"
+                            ]
+                          },
+                          "title": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "note": {
+                            "type": "string",
+                            "nullable": true
+                          },
+                          "gravity": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "temperature": {
+                            "type": "number",
+                            "nullable": true
+                          },
+                          "temp_units": {
+                            "type": "string",
+                            "enum": [
+                              "F",
+                              "C",
+                              "K"
+                            ],
+                            "nullable": true
+                          },
+                          "data": {
+                            "type": "object",
+                            "nullable": true
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "logs": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "datetime": {
+                      "type": "string"
+                    },
+                    "temperature": {
+                      "type": "number"
+                    },
+                    "temp_units": {
+                      "type": "string",
+                      "enum": [
+                        "F",
+                        "C",
+                        "K"
+                      ]
+                    },
+                    "battery": {
+                      "type": "number",
+                      "nullable": true
+                    },
+                    "gravity": {
+                      "type": "number"
+                    },
+                    "calculated_gravity": {
+                      "type": "number",
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "PublicBrewDetailResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "start_date": {
+            "type": "string"
+          },
+          "end_date": {
+            "type": "string",
+            "nullable": true
+          },
+          "stage": {
+            "type": "string",
+            "enum": [
+              "PLANNED",
+              "PRIMARY",
+              "SECONDARY",
+              "BULK_AGE",
+              "STABILIZED",
+              "BACKSWEETENED",
+              "PACKAGED",
+              "COMPLETE"
+            ]
+          },
+          "batch_number": {
+            "type": "number",
+            "nullable": true
+          },
+          "current_volume_liters": {
+            "type": "number",
+            "nullable": true
+          },
+          "gravity_unit_preference": {
+            "type": "string",
+            "enum": [
+              "SG",
+              "BRIX"
+            ]
+          },
+          "latest_gravity": {
+            "type": "number",
+            "nullable": true
+          },
+          "public": {
+            "type": "boolean"
+          },
+          "recipe_id": {
+            "type": "number",
+            "nullable": true
+          },
+          "recipe_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "entry_count": {
+            "type": "number"
+          },
+          "owner": {
+            "type": "object",
+            "properties": {
+              "displayName": {
+                "type": "string"
+              }
+            },
+            "nullable": true
+          },
+          "recipe_snapshot": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "name": {
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              },
+              "dataV2": {
+                "type": "object",
+                "properties": {
+                  "version": {
+                    "type": "number",
+                    "enum": [
+                      2
+                    ]
+                  },
+                  "unitDefaults": {
+                    "type": "object",
+                    "properties": {
+                      "weight": {
+                        "type": "string",
+                        "enum": [
+                          "kg",
+                          "g",
+                          "lb",
+                          "oz"
+                        ]
+                      },
+                      "volume": {
+                        "type": "string",
+                        "enum": [
+                          "L",
+                          "mL",
+                          "gal",
+                          "qt",
+                          "pt",
+                          "fl_oz",
+                          "imp_gal",
+                          "imp_qt",
+                          "imp_pt",
+                          "imp_fl_oz"
+                        ]
+                      }
+                    }
+                  },
+                  "ingredients": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "lineId": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "ref": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": [
+                                    "catalog"
+                                  ]
+                                },
+                                "ingredientId": {
+                                  "oneOf": [
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "string"
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "kind": {
+                                  "type": "string",
+                                  "enum": [
+                                    "custom"
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "category": {
+                          "type": "string"
+                        },
+                        "brix": {
+                          "type": "string"
+                        },
+                        "secondary": {
+                          "type": "boolean"
+                        },
+                        "amounts": {
+                          "type": "object",
+                          "properties": {
+                            "weight": {
+                              "type": "object",
+                              "properties": {
+                                "value": {
+                                  "type": "string"
+                                },
+                                "unit": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "volume": {
+                              "type": "object",
+                              "properties": {
+                                "value": {
+                                  "type": "string"
+                                },
+                                "unit": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "basis": {
+                              "type": "string",
+                              "enum": [
+                                "weight",
+                                "volume"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "fg": {
+                    "type": "string"
+                  },
+                  "additives": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "lineId": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "amount": {
+                          "type": "string"
+                        },
+                        "unit": {
+                          "type": "string"
+                        },
+                        "amountTouched": {
+                          "type": "boolean"
+                        },
+                        "amountDim": {
+                          "type": "string",
+                          "enum": [
+                            "weight",
+                            "volume",
+                            "count",
+                            "unknown"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "stabilizers": {
+                    "type": "object",
+                    "properties": {
+                      "adding": {
+                        "type": "boolean"
+                      },
+                      "takingPh": {
+                        "type": "boolean"
+                      },
+                      "phReading": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "kmeta",
+                          "nameta"
+                        ]
+                      }
+                    }
+                  },
+                  "notes": {
+                    "type": "object",
+                    "properties": {
+                      "primary": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "lineId": {
+                              "type": "string"
+                            },
+                            "content": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "secondary": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "lineId": {
+                              "type": "string"
+                            },
+                            "content": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "nutrients": {
+                    "type": "object",
+                    "properties": {
+                      "version": {
+                        "type": "number",
+                        "enum": [
+                          2
+                        ]
+                      },
+                      "inputs": {
+                        "type": "object",
+                        "properties": {
+                          "volume": {
+                            "type": "string"
+                          },
+                          "volumeUnits": {
+                            "type": "string",
+                            "enum": [
+                              "gal",
+                              "liter"
+                            ]
+                          },
+                          "sg": {
+                            "type": "string"
+                          },
+                          "offsetPpm": {
+                            "type": "string"
+                          },
+                          "numberOfAdditions": {
+                            "type": "string"
+                          },
+                          "goFermType": {
+                            "type": "string",
+                            "enum": [
+                              "Go-Ferm",
+                              "protect",
+                              "sterol-flash",
+                              "none"
+                            ]
+                          },
+                          "yeastAmountG": {
+                            "type": "string"
+                          },
+                          "yeastAmountTouched": {
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "selected": {
+                        "type": "object",
+                        "properties": {
+                          "yeastBrand": {
+                            "type": "string"
+                          },
+                          "yeastStrain": {
+                            "type": "string"
+                          },
+                          "yeastId": {
+                            "type": "number"
+                          },
+                          "nitrogenRequirement": {
+                            "type": "string",
+                            "enum": [
+                              "Very Low",
+                              "Low",
+                              "Medium",
+                              "High",
+                              "Very High"
+                            ]
+                          },
+                          "schedule": {
+                            "type": "string",
+                            "enum": [
+                              "tbe",
+                              "tosna",
+                              "justK",
+                              "dap",
+                              "oAndk",
+                              "oAndDap",
+                              "kAndDap",
+                              "other"
+                            ]
+                          },
+                          "selectedNutrients": {
+                            "type": "object",
+                            "properties": {
+                              "fermO": {
+                                "type": "boolean"
+                              },
+                              "fermK": {
+                                "type": "boolean"
+                              },
+                              "dap": {
+                                "type": "boolean"
+                              },
+                              "other": {
+                                "type": "boolean"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "settings": {
+                        "type": "object",
+                        "properties": {
+                          "yanContribution": {
+                            "type": "object",
+                            "properties": {
+                              "fermO": {
+                                "type": "string"
+                              },
+                              "fermK": {
+                                "type": "string"
+                              },
+                              "dap": {
+                                "type": "string"
+                              },
+                              "other": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "maxGpl": {
+                            "type": "object",
+                            "properties": {
+                              "fermO": {
+                                "type": "string"
+                              },
+                              "fermK": {
+                                "type": "string"
+                              },
+                              "dap": {
+                                "type": "string"
+                              },
+                              "other": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "maxGplTouched": {
+                            "type": "boolean"
+                          },
+                          "other": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "adjustments": {
+                        "type": "object",
+                        "properties": {
+                          "adjustAllowed": {
+                            "type": "boolean"
+                          },
+                          "providedYanPpm": {
+                            "type": "object",
+                            "properties": {
+                              "fermO": {
+                                "type": "string"
+                              },
+                              "fermK": {
+                                "type": "string"
+                              },
+                              "dap": {
+                                "type": "string"
+                              },
+                              "other": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "flags": {
+                    "type": "object",
+                    "properties": {
+                      "advanced": {
+                        "type": "boolean"
+                      },
+                      "private": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                },
+                "nullable": true
+              },
+              "snapshottedAt": {
+                "type": "string"
+              }
+            },
+            "nullable": true
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "datetime": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "NOTE",
+                    "GRAVITY",
+                    "VOLUME",
+                    "TEMPERATURE",
+                    "PH",
+                    "ADDITION",
+                    "NUTRIENT",
+                    "RACKING",
+                    "STABILIZATION",
+                    "BACKSWEETENING",
+                    "PACKAGING",
+                    "TASTING",
+                    "STAGE_CHANGE",
+                    "ISSUE"
+                  ]
+                },
+                "title": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "note": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "gravity": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "temperature": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "temp_units": {
+                  "type": "string",
+                  "enum": [
+                    "F",
+                    "C",
+                    "K"
+                  ],
+                  "nullable": true
+                },
+                "data": {
+                  "type": "object",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "entries_by_stage": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "stage": {
+                  "type": "string",
+                  "enum": [
+                    "PLANNED",
+                    "PRIMARY",
+                    "SECONDARY",
+                    "BULK_AGE",
+                    "STABILIZED",
+                    "BACKSWEETENED",
+                    "PACKAGED",
+                    "COMPLETE"
+                  ]
+                },
+                "entries": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "datetime": {
+                        "type": "string"
+                      },
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "NOTE",
+                          "GRAVITY",
+                          "VOLUME",
+                          "TEMPERATURE",
+                          "PH",
+                          "ADDITION",
+                          "NUTRIENT",
+                          "RACKING",
+                          "STABILIZATION",
+                          "BACKSWEETENING",
+                          "PACKAGING",
+                          "TASTING",
+                          "STAGE_CHANGE",
+                          "ISSUE"
+                        ]
+                      },
+                      "title": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "note": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "gravity": {
+                        "type": "number",
+                        "nullable": true
+                      },
+                      "temperature": {
+                        "type": "number",
+                        "nullable": true
+                      },
+                      "temp_units": {
+                        "type": "string",
+                        "enum": [
+                          "F",
+                          "C",
+                          "K"
+                        ],
+                        "nullable": true
+                      },
+                      "data": {
+                        "type": "object",
+                        "nullable": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "logs": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "datetime": {
+                  "type": "string"
+                },
+                "temperature": {
+                  "type": "number"
+                },
+                "temp_units": {
+                  "type": "string",
+                  "enum": [
+                    "F",
+                    "C",
+                    "K"
+                  ]
+                },
+                "battery": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "gravity": {
+                  "type": "number"
+                },
+                "calculated_gravity": {
+                  "type": "number",
+                  "nullable": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "PublicBrewOwnerResponse": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string"
+          }
+        }
+      },
+      "PublicBrewEntryResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "datetime": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "NOTE",
+              "GRAVITY",
+              "VOLUME",
+              "TEMPERATURE",
+              "PH",
+              "ADDITION",
+              "NUTRIENT",
+              "RACKING",
+              "STABILIZATION",
+              "BACKSWEETENING",
+              "PACKAGING",
+              "TASTING",
+              "STAGE_CHANGE",
+              "ISSUE"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "note": {
+            "type": "string",
+            "nullable": true
+          },
+          "gravity": {
+            "type": "number",
+            "nullable": true
+          },
+          "temperature": {
+            "type": "number",
+            "nullable": true
+          },
+          "temp_units": {
+            "type": "string",
+            "enum": [
+              "F",
+              "C",
+              "K"
+            ],
+            "nullable": true
+          },
+          "data": {
+            "type": "object",
+            "nullable": true
+          }
+        }
+      },
+      "PublicBrewEntriesByStageResponse": {
+        "type": "object",
+        "properties": {
+          "stage": {
+            "type": "string",
+            "enum": [
+              "PLANNED",
+              "PRIMARY",
+              "SECONDARY",
+              "BULK_AGE",
+              "STABILIZED",
+              "BACKSWEETENED",
+              "PACKAGED",
+              "COMPLETE"
+            ]
+          },
+          "entries": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "datetime": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "NOTE",
+                    "GRAVITY",
+                    "VOLUME",
+                    "TEMPERATURE",
+                    "PH",
+                    "ADDITION",
+                    "NUTRIENT",
+                    "RACKING",
+                    "STABILIZATION",
+                    "BACKSWEETENING",
+                    "PACKAGING",
+                    "TASTING",
+                    "STAGE_CHANGE",
+                    "ISSUE"
+                  ]
+                },
+                "title": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "note": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "gravity": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "temperature": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "temp_units": {
+                  "type": "string",
+                  "enum": [
+                    "F",
+                    "C",
+                    "K"
+                  ],
+                  "nullable": true
+                },
+                "data": {
+                  "type": "object",
+                  "nullable": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "PublicBrewLogResponse": {
+        "type": "object",
+        "properties": {
+          "datetime": {
+            "type": "string"
+          },
+          "temperature": {
+            "type": "number"
+          },
+          "temp_units": {
+            "type": "string",
+            "enum": [
+              "F",
+              "C",
+              "K"
+            ]
+          },
+          "battery": {
+            "type": "number",
+            "nullable": true
+          },
+          "gravity": {
+            "type": "number"
+          },
+          "calculated_gravity": {
+            "type": "number",
+            "nullable": true
+          }
+        }
+      },
+      "PublicBrewValidationErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "enum": [
+              "Invalid recipe ID",
+              "Missing brew_id"
+            ]
+          }
+        }
+      },
+      "PublicBrewNotFoundErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "enum": [
+              "Brew not found"
+            ]
+          }
+        }
+      },
+      "PublicBrewFetchErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "enum": [
+              "Failed to fetch public brews",
+              "Failed to fetch public brew"
+            ]
+          }
+        }
+      },
+      "PublicRecipeBrewsPathParams": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        }
+      },
+      "PublicRecipeBrewsResponse": {
+        "type": "object",
+        "properties": {
+          "brews": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "start_date": {
+                  "type": "string"
+                },
+                "end_date": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "stage": {
+                  "type": "string",
+                  "enum": [
+                    "PLANNED",
+                    "PRIMARY",
+                    "SECONDARY",
+                    "BULK_AGE",
+                    "STABILIZED",
+                    "BACKSWEETENED",
+                    "PACKAGED",
+                    "COMPLETE"
+                  ]
+                },
+                "batch_number": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "current_volume_liters": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "gravity_unit_preference": {
+                  "type": "string",
+                  "enum": [
+                    "SG",
+                    "BRIX"
+                  ]
+                },
+                "latest_gravity": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "public": {
+                  "type": "boolean"
+                },
+                "recipe_id": {
+                  "type": "number",
+                  "nullable": true
+                },
+                "recipe_name": {
+                  "type": "string",
+                  "nullable": true
+                },
+                "entry_count": {
+                  "type": "number"
+                },
+                "owner": {
+                  "type": "object",
+                  "properties": {
+                    "displayName": {
+                      "type": "string"
+                    }
+                  },
+                  "nullable": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "PublicBrewListItemResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "start_date": {
+            "type": "string"
+          },
+          "end_date": {
+            "type": "string",
+            "nullable": true
+          },
+          "stage": {
+            "type": "string",
+            "enum": [
+              "PLANNED",
+              "PRIMARY",
+              "SECONDARY",
+              "BULK_AGE",
+              "STABILIZED",
+              "BACKSWEETENED",
+              "PACKAGED",
+              "COMPLETE"
+            ]
+          },
+          "batch_number": {
+            "type": "number",
+            "nullable": true
+          },
+          "current_volume_liters": {
+            "type": "number",
+            "nullable": true
+          },
+          "gravity_unit_preference": {
+            "type": "string",
+            "enum": [
+              "SG",
+              "BRIX"
+            ]
+          },
+          "latest_gravity": {
+            "type": "number",
+            "nullable": true
+          },
+          "public": {
+            "type": "boolean"
+          },
+          "recipe_id": {
+            "type": "number",
+            "nullable": true
+          },
+          "recipe_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "entry_count": {
+            "type": "number"
+          },
+          "owner": {
+            "type": "object",
+            "properties": {
+              "displayName": {
+                "type": "string"
+              }
+            },
+            "nullable": true
           }
         }
       },
@@ -15893,6 +17805,44 @@
         }
       }
     },
+    "/admin/brews": {
+      "get": {
+        "operationId": "get-admin-brews",
+        "summary": "",
+        "description": "",
+        "tags": [
+          "Admin"
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/admin/summary": {
+      "get": {
+        "operationId": "get-admin-summary",
+        "summary": "",
+        "description": "",
+        "tags": [
+          "Admin"
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
     "/users/{id}": {
       "get": {
         "operationId": "get-users-{id}",
@@ -16128,6 +18078,44 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/admin/brews/{brew_id}": {
+      "get": {
+        "operationId": "get-admin-brews-{brew_id}",
+        "summary": "",
+        "description": "",
+        "tags": [
+          "Admin"
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
+    "/admin/users/{id}/password-reset": {
+      "post": {
+        "operationId": "post-admin-users-{id}-password-reset",
+        "summary": "",
+        "description": "",
+        "tags": [
+          "Admin"
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
           }
         }
       }
@@ -17218,6 +19206,59 @@
         }
       }
     },
+    "/recipes/{id}/brews": {
+      "get": {
+        "operationId": "get-recipes-{id}-brews",
+        "summary": "List public brews for recipe",
+        "description": "Returns brews whose owners explicitly made them public for the given public recipe. Private recipes and private brews return an empty list.",
+        "tags": [
+          "Brews"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "example": "123"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicRecipeBrewsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicBrewValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicBrewFetchErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/brews/{brew_id}/entries/{entry_id}": {
       "patch": {
         "operationId": "patch-brews-{brew_id}-entries-{entry_id}",
@@ -17392,6 +19433,78 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BrewEntryDeleteErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/recipes/{id}/brews/{brew_id}": {
+      "get": {
+        "operationId": "get-recipes-{id}-brews-{brew_id}",
+        "summary": "Get public brew for recipe",
+        "description": "Returns the read-only tracker data for a brew whose owner explicitly made it public and whose linked recipe is public.",
+        "tags": [
+          "Brews"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "example": "123"
+          },
+          {
+            "in": "path",
+            "name": "brew_id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "example": "123"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicRecipeBrewResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicBrewValidationErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicBrewNotFoundErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicBrewFetchErrorResponse"
                 }
               }
             }

--- a/types/brewView.ts
+++ b/types/brewView.ts
@@ -1,0 +1,70 @@
+import type { Prisma } from "@prisma/client";
+
+import type { BrewEntryType, BrewStage, GravityUnit } from "@/lib/brewEnums";
+import type { BrewRecipeSnapshot } from "@/lib/utils/buildBrewRecipeStageData";
+
+export type BrewViewEntry = {
+  id: string;
+  datetime: string;
+  type: BrewEntryType;
+  title: string | null;
+  note: string | null;
+  gravity: number | null;
+  temperature: number | null;
+  temp_units: string | null;
+  data: Prisma.JsonValue | null;
+};
+
+export type BrewViewLog = {
+  datetime: string;
+  temperature: number;
+  temp_units: "C" | "F" | "K";
+  battery: number | null;
+  gravity: number;
+  calculated_gravity: number | null;
+};
+
+export type BrewViewOwner = {
+  displayName: string;
+};
+
+export type BrewViewListItem = {
+  id: string;
+  name: string | null;
+  start_date: string;
+  end_date: string | null;
+  stage: BrewStage;
+  batch_number: number | null;
+  current_volume_liters: number | null;
+  gravity_unit_preference: GravityUnit;
+  latest_gravity: number | null;
+  public: boolean;
+  recipe_id: number | null;
+  recipe_name: string | null;
+  entry_count: number;
+  owner: BrewViewOwner | null;
+};
+
+export type BrewViewDetail = BrewViewListItem & {
+  recipe_snapshot: BrewRecipeSnapshot | null;
+  entries: BrewViewEntry[];
+  entries_by_stage: Array<{
+    stage: BrewStage;
+    entries: BrewViewEntry[];
+  }>;
+  logs: BrewViewLog[];
+};
+
+export type BrewViewCapabilities = {
+  canEditMetadata: boolean;
+  canManageEntries: boolean;
+  canMoveStage: boolean;
+  canManageHydrometer: boolean;
+};
+
+export const READ_ONLY_BREW_CAPABILITIES: BrewViewCapabilities = {
+  canEditMetadata: false,
+  canManageEntries: false,
+  canMoveStage: false,
+  canManageHydrometer: false
+};


### PR DESCRIPTION
## Summary

- refresh the admin shell, overview, lists, forms, brew viewer, and recipe viewer to match the account surfaces
- add reusable read-only brew projections and capability-driven tracker UI for admin and public recipe views
- add private-by-default brew publishing, public recipe brew links, and an account-page share action
- add admin password-reset delivery and fix ingredient/yeast creation when database ID sequences are stale
- document the new admin and public brew API routes and update the MeadTools 4.0 release notes

## Impact

Admins can review users, recipes, and complete brew trackers without mutation controls. Brewers can selectively publish a brew attached to a public recipe and share its recipe-scoped URL while private brews remain inaccessible. Public tracker entries, notes, metrics, packaging recap, and charts use the same presentation model without carrying authorization, alert, device identity, or mutation fields.

## Fixes

Ingredient and yeast creation could fail with an `id` unique constraint when imported or seeded rows left PostgreSQL sequences behind the current maximum ID. Creation now detects that specific conflict, resynchronizes the sequence, and retries once.

The public packaging panel inherited owner controls even though the route had no mutation capabilities. Read-only stage panels now omit those controls entirely.

## Validation

- `npx tsc --noEmit`
- `npx tsx --test lib/brews/projectBrewView.test.ts lib/utils/brewTrackingScaling.test.ts lib/utils/unitConverter.test.ts`
- `npm run build`
- regenerated `public/openapi.json` with `npx next-openapi-gen generate`
- browser-verified public brew summary cards, read-only packaged stage, full public entries, and filter clearing without console errors
