### PR TITLE
Add public brew unavailable page

### DIFF
--- a/app/[locale]/recipes/[id]/brews/[brew_id]/not-found.tsx
+++ b/app/[locale]/recipes/[id]/brews/[brew_id]/not-found.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { CircleSlash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { CardWrapper } from "@/components/CardWrapper";
+import { Button } from "@/components/ui/button";
+
+export default function PublicBrewNotFound() {
+  const pathname = usePathname();
+  const { t } = useTranslation();
+  const segments = pathname.split("/").filter(Boolean);
+  const recipesIndex = segments.lastIndexOf("recipes");
+  const recipeId = segments[recipesIndex + 1];
+  const recipeHref = /^\d+$/.test(recipeId ?? "")
+    ? `/recipes/${recipeId}`
+    : null;
+
+  return (
+    <main className="flex w-full justify-center py-[6rem]">
+      <CardWrapper>
+        <div className="flex min-h-72 flex-col items-center justify-center gap-4 text-center">
+          <CircleSlash2 className="size-10 text-muted-foreground" />
+          <div className="max-w-lg space-y-2">
+            <h1 className="text-2xl font-semibold sm:text-3xl">
+              {t("publicBrews.unavailableTitle", "Brew unavailable")}
+            </h1>
+            <p className="text-sm text-muted-foreground sm:text-base">
+              {t(
+                "publicBrews.unavailableDescription",
+                "This brew is private, was removed, or the link is no longer valid."
+              )}
+            </p>
+          </div>
+          <div className="flex flex-wrap justify-center gap-3">
+            {recipeHref ? (
+              <Button asChild>
+                <Link href={recipeHref}>
+                  {t("publicBrews.backToRecipe", "Back to recipe")}
+                </Link>
+              </Button>
+            ) : null}
+            <Button asChild variant={recipeHref ? "secondary" : "default"}>
+              <Link href="/public-recipes">
+                {t("publicRecipes.title", "Public Recipes")}
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </CardWrapper>
+    </main>
+  );
+}

--- a/locales/de/default.json
+++ b/locales/de/default.json
@@ -1430,6 +1430,8 @@
     "description": "Brauer haben diese Chargen aus diesem Rezept geteilt.",
     "empty": "Für dieses Rezept wurden noch keine öffentlichen Ansätze geteilt.",
     "title": "Öffentliche Ansätze",
+    "unavailableDescription": "Dieser Ansatz ist privat, wurde entfernt oder der Link ist nicht mehr gültig.",
+    "unavailableTitle": "Ansatz nicht verfügbar",
     "viewBrew": "Ansatz ansehen"
   },
   "publicRecipes": {

--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -1430,6 +1430,8 @@
     "description": "Brewers have shared these batches from this recipe.",
     "empty": "No public brews have been shared for this recipe yet.",
     "title": "Public brews",
+    "unavailableDescription": "This brew is private, was removed, or the link is no longer valid.",
+    "unavailableTitle": "Brew unavailable",
     "viewBrew": "View brew"
   },
   "publicRecipes": {


### PR DESCRIPTION
## Summary

- add a route-specific unavailable page for invalid, removed, or private public brew links
- keep the normal MeadTools navigation and card styling instead of showing the generic Next.js 404
- provide links back to the associated recipe and the public recipe directory
- add English and German copy through i18nexus

## Privacy

The message intentionally does not distinguish between a private brew, a removed brew, and an invalid link, so the page does not disclose whether a private brew exists.

## Validation

- `npx tsc --noEmit`
- `git diff --check`
