### PR TITLE
Fix Mark Complete stage transitions

### DIFF
--- a/components/brews/BrewStagePath.tsx
+++ b/components/brews/BrewStagePath.tsx
@@ -206,8 +206,6 @@ export function BrewStagePath({
             };
             const helpers = {
               moveToStage: async (to: BrewStage, datetime?: string) => {
-                const decision = getStageMoveDecision(to, stage, ctx);
-                if (!decision.allowed) return;
                 await onMoveToStage(to, datetime);
                 setActiveId(to);
               },


### PR DESCRIPTION
## Summary

- allow explicit Mark Complete actions to transition a brew directly to Complete
- fix the behavior from both Bulk Age and Packaged stages
- retain prerequisite checks for generic stage navigation

## Root cause

The shared panel action helper repeated the generic stage-navigation prerequisite guard. That caused the explicit completion action to return silently when packaging details were absent.

## Validation

- npx tsc --noEmit
- npx eslint components/brews/BrewStagePath.tsx
- git diff --check

Closes #299