### PR TITLE
[codex] Prepare MeadTools 4.0 release

### DIFF
--- a/content/release-notes.mdx
+++ b/content/release-notes.mdx
@@ -11,7 +11,7 @@ Brews now move through a clearer lifecycle, with dedicated workflows for each ma
 - Planned brews can be created and prepared before fermentation starts
 - Primary fermentation has a focused stage panel for recording key events
 - Secondary, bulk aging, packaged, and complete stages now have their own workflows
-- Stage completion logic is more consistent across the brew dashboard
+- Brews can be explicitly marked complete when the work is finished
 
 ---
 
@@ -22,6 +22,7 @@ Brew history is easier to review and maintain.
 - Timeline entries are clearer and more consistent
 - Nutrient additions and brew entries can be refined after they are created
 - Original gravity, yeast, volume, and other key brew events are better represented
+- Gravity readings can be recorded and displayed in either SG or Brix
 - Brew activity is easier to scan across the account brew pages
 
 ---
@@ -67,6 +68,18 @@ Brewers can now share selected brew trackers from their public recipes.
 
 ---
 
+## More Improvements
+
+- Brew lists can be filtered by stage and status
+- Brews can be deleted from the account brew list with confirmation
+- Brew-tracking dialogs fit and behave better on mobile screens
+- Dialogs now layer correctly over the navigation bar
+- ABV calculations now handle original gravity entered in Brix correctly
+- Brew data handling is more resilient across the new workflow
+- OpenAPI documentation now covers the expanded brew model, admin endpoints, and public recipe brew routes
+
+---
+
 ## Admin Updates
 
 The admin area has been refreshed to match the rest of MeadTools more closely.
@@ -87,8 +100,6 @@ This release includes a broad polish pass across the new brew tracking surfaces.
 - Brew dashboards and detail pages have cleaner layouts
 - Stage panels share more consistent patterns
 - Account navigation better reflects the available brew tools
-- Brew data handling is more resilient across the new workflow
-- OpenAPI documentation now covers the expanded brew model, admin endpoints, and public recipe brew routes
 - Seed data has been updated for the expanded brew model
 
 ---

--- a/lib/db/brews.ts
+++ b/lib/db/brews.ts
@@ -1443,19 +1443,27 @@ export async function removeDeviceFromBrew(
   user_id: number
 ) {
   try {
-    const brew = await prisma.brews.findFirst({
-      where: { user_id, id: brew_id }
-    });
+    return await prisma.$transaction(async (tx) => {
+      const brew = await tx.brews.findFirst({
+        where: { user_id, id: brew_id }
+      });
+      if (!brew) throw new Error("Brew not found");
 
-    const device = await prisma.devices.update({
-      where: { id },
-      data: { brew_id: null }
-    });
+      const device = await tx.devices.findFirst({
+        where: { id, user_id, brew_id }
+      });
+      if (!device) throw new Error("Device not found");
 
-    return [brew, device];
+      const detachedDevice = await tx.devices.update({
+        where: { id: device.id },
+        data: { brew_id: null }
+      });
+
+      return [brew, detachedDevice];
+    });
   } catch (error) {
     console.error(error);
-    throw new Error("Error ending brew.");
+    throw error;
   }
 }
 

--- a/lib/db/iSpindel.ts
+++ b/lib/db/iSpindel.ts
@@ -606,20 +606,33 @@ export async function startBrew(
 
 export async function endBrew(id: string, brew_id: string, user_id: number) {
   try {
-    const brew = await prisma.brews.update({
-      where: { user_id, id: brew_id },
-      data: { end_date: new Date() }
-    });
+    return await prisma.$transaction(async (tx) => {
+      const brew = await tx.brews.findFirst({
+        where: { user_id, id: brew_id },
+        select: { id: true }
+      });
+      if (!brew) throw new Error("Brew not found");
 
-    const device = await prisma.devices.update({
-      where: { id },
-      data: { brew_id: null }
-    });
+      const device = await tx.devices.findFirst({
+        where: { id, user_id, brew_id }
+      });
+      if (!device) throw new Error("Device not found");
 
-    return [brew, device];
+      const completedBrew = await tx.brews.update({
+        where: { id: brew_id, user_id },
+        data: { end_date: new Date() }
+      });
+
+      const detachedDevice = await tx.devices.update({
+        where: { id: device.id },
+        data: { brew_id: null }
+      });
+
+      return [completedBrew, detachedDevice];
+    });
   } catch (error) {
     console.error(error);
-    throw new Error("Error ending brew.");
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary

- expand the MeadTools 4.0 release notes with Brix readings, mobile improvements, brew filters and deletion, explicit completion, dialog layering, and the corrected Brix OG calculation
- require hydrometer devices to belong to the authenticated user and be attached to the specified brew before unlinking
- preserve the existing `[brew, device]` API response contract used by the UI
- perform brew completion and device unlinking atomically

## Why

The 4.0 notes were written before several user-facing fixes landed. The unlink paths also trusted a device UUID without checking its owner and brew relationship. An initial hardening pass changed the response shape and broke the UI; this version keeps the original response contract while applying the server-side ownership constraint.

## Validation

- `npx tsx --test lib/brews/projectBrewView.test.ts lib/utils/brewTrackingScaling.test.ts lib/utils/unitConverter.test.ts`
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
