### PR TITLE
Stabilize native-facing recipe and brew APIs

### DIFF
--- a/app/api/brews/[brew_id]/entries/route.ts
+++ b/app/api/brews/[brew_id]/entries/route.ts
@@ -1,5 +1,7 @@
 import { createBrewEntryForApp } from "@/lib/db/brews";
+import { BrewEntryIdConflictError } from "@/lib/brews/createBrewEntryIdempotently";
 import { verifyUser } from "@/lib/userAccessFunctions";
+import { createBrewEntryRequestBodySchema } from "@meadtools/api-contract/brews";
 import { NextRequest, NextResponse } from "next/server";
 
 /**
@@ -12,6 +14,7 @@ import { NextRequest, NextResponse } from "next/server";
  * @add 400:BrewValidationErrorResponse
  * @add 401:AuthenticatedRouteErrorResponse
  * @add 404:AuthenticatedRouteErrorResponse
+ * @add 409:BrewEntryIdConflictErrorResponse
  * @add 500:BrewEntryCreateErrorResponse
  * @auth BearerAuth
  * @tag Brews
@@ -34,11 +37,28 @@ export async function POST(
   if (!body) {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
+  if (
+    body.client_entry_id !== undefined &&
+    !createBrewEntryRequestBodySchema.shape.client_entry_id.safeParse(
+      body.client_entry_id
+    ).success
+  ) {
+    return NextResponse.json(
+      { error: "Invalid client_entry_id" },
+      { status: 400 }
+    );
+  }
 
   try {
     const brew = await createBrewEntryForApp(userId, brew_id, body);
     return NextResponse.json({ brew }, { status: 201 });
   } catch (err) {
+    if (err instanceof BrewEntryIdConflictError) {
+      return NextResponse.json(
+        { error: "Entry ID is already in use" },
+        { status: 409 }
+      );
+    }
     console.error("Error creating entry:", err);
     return NextResponse.json(
       { error: "Failed to create entry." },

--- a/docs/domain/api-client.md
+++ b/docs/domain/api-client.md
@@ -12,9 +12,22 @@ The package:
 - exposes typed API and contract errors; and
 - contains no React, Next.js, Prisma, storage, or authentication state.
 
-The first supported operation is `calculateRecipeDerived`, which calls the
-existing `POST /api/recipes/derived` endpoint. The package does not change that
-endpoint or the generated OpenAPI document.
+Supported operations are:
+
+- `calculateRecipeDerived`
+- `listRecipes`, through the authenticated account-info endpoint
+- `listBrews`
+- `getBrew`
+- `createBrewEntry`
+
+Every successful response is checked against the same Zod schema used by the
+OpenAPI contract. Invalid request payloads are rejected before the transport is
+called.
+
+`createBrewEntry` accepts an optional `client_entry_id` UUID. Offline-capable
+clients should generate one UUID when an entry is first queued and reuse it for
+every retry. The server uses it as the entry resource ID, so repeated uploads
+resolve to the original entry instead of creating duplicates.
 
 The optional `getAccessToken` callback only attaches the current bearer token.
 Credential persistence, login, and refresh behavior remain the responsibility

--- a/docs/domain/api-contract.md
+++ b/docs/domain/api-contract.md
@@ -14,7 +14,7 @@ Before the Zod migration, `public/openapi.json` was regenerated with
 - Canonical endpoint-path SHA-256:
   `4610d8687942691b4d6a411907359deca3fb67c00a6f34dd7acc8ad3ee38076c`
 - Reviewed Zod document SHA-256:
-  `49844af6db83344c1ec241652d1251f4c3e361b01cb7caff56e7d9de030a06ce`
+  `1c0c6673a150cb99377bfe86772b604c4911aad4347a808c7688f7090b43a562`
 
 The parity test preserves the complete pre-migration `paths` object: routes,
 methods, parameters, descriptions, response statuses, and component references.
@@ -22,6 +22,12 @@ Zod now generates the component schemas, including explicit required and
 nullable semantics, so the full document has a separately reviewed baseline.
 The canonical hashes sort object keys; array order and all values remain
 significant.
+
+The native API readiness update intentionally adds `client_entry_id` to
+`CreateBrewEntryRequestBody` and HTTP 409 documentation to the create-entry
+operation. The endpoint parity test removes only that new response before
+comparing against the pre-migration paths hash, proving all earlier endpoint
+documentation remains unchanged.
 
 Run:
 

--- a/docs/domain/brew-entry-idempotency.md
+++ b/docs/domain/brew-entry-idempotency.md
@@ -1,0 +1,23 @@
+# Brew-entry idempotency
+
+Companion clients may create a brew entry while offline and retry delivery
+after reconnecting. `POST /api/brews/{brew_id}/entries` therefore accepts an
+optional `client_entry_id` UUID.
+
+## Semantics
+
+1. The client generates one UUID when it creates the local outbox item.
+2. Every upload attempt for that item sends the same `client_entry_id`.
+3. The server stores that UUID as `brew_entries.id`.
+4. Concurrent inserts use PostgreSQL conflict handling, so only one row can be
+   created.
+5. A retry for the same brew and owner returns the refreshed brew normally.
+6. Reusing an existing entry ID for another brew or owner returns HTTP 409 with
+   `Entry ID is already in use`.
+
+Existing callers may omit `client_entry_id`; PostgreSQL continues generating
+the entry UUID exactly as before.
+
+This design reuses the existing UUID primary key and requires no database
+migration. It does not provide offline update/delete conflict resolution; those
+operations need explicit revision semantics if they are added later.

--- a/lib/brews/createBrewEntryIdempotently.test.ts
+++ b/lib/brews/createBrewEntryIdempotently.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  BrewEntryIdConflictError,
+  createBrewEntryIdempotently,
+  type BrewEntryIdentity
+} from "@/lib/brews/createBrewEntryIdempotently";
+
+test("retries with the same client entry ID resolve to one stored entry", async () => {
+  const entries = new Map<string, BrewEntryIdentity>();
+  let createCount = 0;
+  const create = async (clientEntryId?: string) => {
+    const id = clientEntryId ?? "server-generated";
+    const existing = entries.get(id);
+    if (existing) return existing;
+
+    createCount += 1;
+    const entry = { id, brew_id: "brew-1", user_id: 7 };
+    entries.set(id, entry);
+    return entry;
+  };
+
+  const first = await createBrewEntryIdempotently({
+    brewId: "brew-1",
+    userId: 7,
+    clientEntryId: "client-entry-id",
+    create
+  });
+  const retry = await createBrewEntryIdempotently({
+    brewId: "brew-1",
+    userId: 7,
+    clientEntryId: "client-entry-id",
+    create
+  });
+
+  assert.equal(createCount, 1);
+  assert.equal(entries.size, 1);
+  assert.equal(first, retry);
+});
+
+test("a client entry ID cannot be reused for another brew or owner", async () => {
+  const existing = {
+    id: "client-entry-id",
+    brew_id: "another-brew",
+    user_id: 99
+  };
+
+  await assert.rejects(
+    createBrewEntryIdempotently({
+      brewId: "brew-1",
+      userId: 7,
+      clientEntryId: "client-entry-id",
+      create: async () => existing
+    }),
+    BrewEntryIdConflictError
+  );
+});
+
+test("omitting a client entry ID preserves server-generated creation", async () => {
+  let receivedClientId: string | undefined = "not-called";
+
+  const entry = await createBrewEntryIdempotently({
+    brewId: "brew-1",
+    userId: 7,
+    create: async (clientEntryId) => {
+      receivedClientId = clientEntryId;
+      return {
+        id: "server-generated-id",
+        brew_id: "brew-1",
+        user_id: 7
+      };
+    }
+  });
+
+  assert.equal(receivedClientId, undefined);
+  assert.equal(entry.id, "server-generated-id");
+});

--- a/lib/brews/createBrewEntryIdempotently.ts
+++ b/lib/brews/createBrewEntryIdempotently.ts
@@ -1,0 +1,37 @@
+export type BrewEntryIdentity = {
+  id: string;
+  brew_id: string;
+  user_id: number | null;
+};
+
+export class BrewEntryIdConflictError extends Error {
+  constructor() {
+    super("Entry ID is already in use");
+    this.name = "BrewEntryIdConflictError";
+  }
+}
+
+export async function createBrewEntryIdempotently({
+  brewId,
+  userId,
+  clientEntryId,
+  create
+}: {
+  brewId: string;
+  userId: number;
+  clientEntryId?: string;
+  create: (clientEntryId?: string) => Promise<BrewEntryIdentity>;
+}) {
+  const entry = await create(clientEntryId);
+
+  if (
+    clientEntryId &&
+    (entry.id !== clientEntryId ||
+      entry.brew_id !== brewId ||
+      entry.user_id !== userId)
+  ) {
+    throw new BrewEntryIdConflictError();
+  }
+
+  return entry;
+}

--- a/lib/db/brews.ts
+++ b/lib/db/brews.ts
@@ -7,6 +7,7 @@ import {
   gravity_unit
 } from "@prisma/client";
 import { calcABV } from "@meadtools/core/gravity";
+import { createBrewEntryIdempotently } from "@/lib/brews/createBrewEntryIdempotently";
 import { buildBrewRecipeStageData } from "@/lib/utils/buildBrewRecipeStageData";
 import type { BrewRecipeSnapshot } from "@/lib/utils/buildBrewRecipeStageData";
 import {
@@ -102,6 +103,7 @@ export type PatchBrewMetadataInput = {
 
 export type CreateBrewEntryInput = {
   type: brew_entry_type;
+  client_entry_id?: string;
 
   datetime?: string | Date;
   title?: string | null;
@@ -1201,18 +1203,45 @@ export async function createBrewEntryForApp(
   if (Number.isNaN(datetime.getTime())) throw new Error("Invalid datetime");
 
   await prisma.$transaction(async (tx) => {
-    await tx.brew_entries.create({
-      data: {
-        brew_id: brewId,
-        user_id: userId,
-        type: input.type,
-        datetime,
-        title: input.title ?? null,
-        note: input.note ?? null,
-        gravity: input.gravity ?? null,
-        temperature: input.temperature ?? null,
-        temp_units: input.temp_units ?? null,
-        data: (input.data as any) ?? null
+    const entryData = {
+      brew_id: brewId,
+      user_id: userId,
+      type: input.type,
+      datetime,
+      title: input.title ?? null,
+      note: input.note ?? null,
+      gravity: input.gravity ?? null,
+      temperature: input.temperature ?? null,
+      temp_units: input.temp_units ?? null,
+      data: (input.data as any) ?? null
+    };
+
+    await createBrewEntryIdempotently({
+      brewId,
+      userId,
+      clientEntryId: input.client_entry_id,
+      create: async (clientEntryId) => {
+        const select = {
+          id: true,
+          brew_id: true,
+          user_id: true
+        } as const;
+
+        if (clientEntryId) {
+          await tx.brew_entries.createMany({
+            data: [{ id: clientEntryId, ...entryData }],
+            skipDuplicates: true
+          });
+          return tx.brew_entries.findUniqueOrThrow({
+            where: { id: clientEntryId },
+            select
+          });
+        }
+
+        return tx.brew_entries.create({
+          data: entryData,
+          select
+        });
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:i18n": "npx i18nexus pull && npx prisma generate && next build --webpack",
     "start": "next start",
     "start:i18n": "npx i18nexus pull && next start",
-    "test": "npm run test:core && npm run test:schemas && npm run test:api-contract && npm run test:api-client && npm run test:brew-domain && node --import tsx --test lib/utils/*.test.ts",
+    "test": "npm run test:core && npm run test:schemas && npm run test:api-contract && npm run test:api-client && npm run test:brew-domain && node --import tsx --test lib/brews/*.test.ts lib/utils/*.test.ts",
     "openapi:generate": "next-openapi-gen generate && node scripts/normalize-zod-openapi.mjs",
     "contracts:generate": "node scripts/generate-api-contract-types.mjs",
     "test:api-contract": "npm test --workspace @meadtools/api-contract",

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,6 +1,15 @@
 import {
+  accountInfoResponseSchema,
+  brewResponseSchema,
+  brewsResponseSchema,
+  createBrewEntryRequestBodySchema,
+  createBrewEntryResponseSchema,
   recipeDataV2Schema,
   recipeDerivedStateResponseBodySchema,
+  type AccountRecipeResponse,
+  type BrewListItemResponse,
+  type BrewResponse,
+  type CreateBrewEntryRequestBody,
   type RecipeDataV2Input,
   type RecipeDerivedStateResponseBody
 } from "@meadtools/api-contract";
@@ -96,6 +105,20 @@ async function requestHeaders(options: MeadToolsApiClientOptions) {
 export function createMeadToolsApiClient(options: MeadToolsApiClientOptions) {
   const baseUrl = normalizeBaseUrl(options.baseUrl);
 
+  async function request(path: string, init: Omit<ApiRequestInit, "headers">) {
+    const response = await options.fetch(`${baseUrl}${path}`, {
+      ...init,
+      headers: await requestHeaders(options)
+    });
+    const body = await readJson(response);
+
+    if (!response.ok) {
+      throw new MeadToolsApiError(response.status, body);
+    }
+
+    return body;
+  }
+
   return {
     async calculateRecipeDerived(
       recipeData: RecipeDataV2Input
@@ -107,25 +130,92 @@ export function createMeadToolsApiClient(options: MeadToolsApiClientOptions) {
         );
       }
 
-      const response = await options.fetch(`${baseUrl}/api/recipes/derived`, {
+      const body = await request("/api/recipes/derived", {
         method: "POST",
-        headers: await requestHeaders(options),
         body: JSON.stringify(recipeData)
       });
-      const body = await readJson(response);
-
-      if (!response.ok) {
-        throw new MeadToolsApiError(response.status, body);
-      }
-
-      if (!recipeDerivedStateResponseBodySchema.safeParse(body).success) {
+      const parsed = recipeDerivedStateResponseBodySchema.safeParse(body);
+      if (!parsed.success) {
         throw new MeadToolsContractError(
           "Response does not match the MeadTools API contract",
           body
         );
       }
 
-      return body as RecipeDerivedStateResponseBody;
+      return parsed.data;
+    },
+
+    async listRecipes(): Promise<AccountRecipeResponse[]> {
+      const body = await request("/api/auth/account-info", {
+        method: "GET"
+      });
+      const parsed = accountInfoResponseSchema.safeParse(body);
+      if (!parsed.success) {
+        throw new MeadToolsContractError(
+          "Recipe list response does not match the MeadTools API contract",
+          body
+        );
+      }
+
+      return parsed.data.recipes;
+    },
+
+    async listBrews(): Promise<BrewListItemResponse[]> {
+      const body = await request("/api/brews", { method: "GET" });
+      const parsed = brewsResponseSchema.safeParse(body);
+      if (!parsed.success) {
+        throw new MeadToolsContractError(
+          "Brew list response does not match the MeadTools API contract",
+          body
+        );
+      }
+
+      return parsed.data.brews;
+    },
+
+    async getBrew(brewId: string): Promise<BrewResponse> {
+      const body = await request(
+        `/api/brews/${encodeURIComponent(brewId)}`,
+        { method: "GET" }
+      );
+      const parsed = brewResponseSchema.safeParse(body);
+      if (!parsed.success) {
+        throw new MeadToolsContractError(
+          "Brew response does not match the MeadTools API contract",
+          body
+        );
+      }
+
+      return parsed.data;
+    },
+
+    async createBrewEntry(
+      brewId: string,
+      input: CreateBrewEntryRequestBody
+    ): Promise<BrewResponse> {
+      if (!createBrewEntryRequestBodySchema.safeParse(input).success) {
+        throw new MeadToolsContractError(
+          "Brew entry does not match the MeadTools API contract",
+          input
+        );
+      }
+
+      const body = await request(
+        `/api/brews/${encodeURIComponent(brewId)}/entries`,
+        {
+          method: "POST",
+          body: JSON.stringify(input)
+        }
+      );
+      const parsed = createBrewEntryResponseSchema.safeParse(body);
+      if (!parsed.success) {
+        throw new MeadToolsContractError(
+          "Brew entry response does not match the MeadTools API contract",
+          body
+        );
+      }
+
+      return parsed.data.brew;
     }
   };
 }

--- a/packages/api-client/test/native-consumer.test.ts
+++ b/packages/api-client/test/native-consumer.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createMeadToolsApiClient,
+  MeadToolsContractError,
+  type ApiRequestInit
+} from "../src/index";
+
+const clientEntryId = "00000000-0000-4000-8000-000000000001";
+
+const accountRecipe = {
+  id: 12,
+  user_id: 7,
+  name: "Traditional",
+  recipeData: "",
+  yanFromSource: null,
+  yanContribution: "",
+  nutrientData: "",
+  advanced: false,
+  nuteInfo: null,
+  primaryNotes: [],
+  secondaryNotes: [],
+  dataV2: null,
+  version: 2,
+  private: true,
+  lastActivityEmailAt: null,
+  activityEmailsEnabled: false,
+  users: { public_username: "maker" },
+  public_username: "maker"
+};
+
+const brewListItem = {
+  id: "brew-1",
+  name: "Traditional batch",
+  start_date: "2026-07-03T12:00:00.000Z",
+  end_date: null,
+  stage: "PRIMARY",
+  batch_number: 1,
+  current_volume_liters: 18.9,
+  requested_email_alerts: false,
+  gravity_unit_preference: "SG",
+  public: false,
+  recipe_id: 12,
+  recipe_name: "Traditional",
+  recipe_private: true,
+  entry_count: 0,
+  latest_gravity: null
+};
+
+function brewDetail(entries: unknown[] = []) {
+  return {
+    ...brewListItem,
+    entry_count: entries.length,
+    recipe_snapshot: null,
+    entries,
+    entries_by_stage: [
+      {
+        stage: "PRIMARY",
+        entries
+      }
+    ]
+  };
+}
+
+test("standalone consumer reads recipes/brews and retries one entry safely", async () => {
+  const storedEntries = new Map<string, Record<string, unknown>>();
+  const requests: Array<{ url: string; init: ApiRequestInit }> = [];
+  const client = createMeadToolsApiClient({
+    baseUrl: "https://meadtools.example",
+    getAccessToken: () => "access-token",
+    fetch: async (url, init) => {
+      requests.push({ url, init });
+
+      if (url.endsWith("/api/auth/account-info")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            user: {
+              id: 7,
+              email: "maker@example.com",
+              google_id: null,
+              role: "user",
+              hydro_token: null,
+              public_username: "maker",
+              google_avatar_url: null,
+              show_google_avatar: false,
+              active: true,
+              isGoogleUser: false
+            },
+            recipes: [accountRecipe]
+          })
+        };
+      }
+
+      if (url.endsWith("/api/brews") && init.method === "GET") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ brews: [brewListItem] })
+        };
+      }
+
+      if (url.endsWith("/api/brews/brew-1") && init.method === "GET") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => brewDetail()
+        };
+      }
+
+      if (url.endsWith("/api/brews/brew-1/entries")) {
+        const input = JSON.parse(init.body ?? "{}") as {
+          client_entry_id: string;
+          type: string;
+          note: string;
+        };
+        if (!storedEntries.has(input.client_entry_id)) {
+          storedEntries.set(input.client_entry_id, {
+            id: input.client_entry_id,
+            datetime: "2026-07-03T12:30:00.000Z",
+            type: input.type,
+            title: null,
+            note: input.note,
+            gravity: null,
+            temperature: null,
+            temp_units: null,
+            data: null,
+            user_id: 7
+          });
+        }
+
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({
+            brew: brewDetail(Array.from(storedEntries.values()))
+          })
+        };
+      }
+
+      throw new Error(`Unexpected request: ${init.method} ${url}`);
+    }
+  });
+
+  const recipes = await client.listRecipes();
+  const brews = await client.listBrews();
+  const brew = await client.getBrew("brew-1");
+  const input = {
+    client_entry_id: clientEntryId,
+    type: "NOTE" as const,
+    note: "Queued offline"
+  };
+  const created = await client.createBrewEntry("brew-1", input);
+  const retried = await client.createBrewEntry("brew-1", input);
+
+  assert.equal(recipes[0].id, 12);
+  assert.equal(brews[0].id, "brew-1");
+  assert.equal(brew.id, "brew-1");
+  assert.equal(created.entries.length, 1);
+  assert.equal(retried.entries.length, 1);
+  assert.equal(retried.entries[0].id, clientEntryId);
+  assert.equal(storedEntries.size, 1);
+  assert.equal(
+    requests.every(
+      ({ init }) => init.headers.authorization === "Bearer access-token"
+    ),
+    true
+  );
+});
+
+test("client rejects an invalid client entry UUID before transport", async () => {
+  let called = false;
+  const client = createMeadToolsApiClient({
+    baseUrl: "https://meadtools.example",
+    fetch: async () => {
+      called = true;
+      throw new Error("transport should not be called");
+    }
+  });
+
+  await assert.rejects(
+    client.createBrewEntry("brew-1", {
+      client_entry_id: "not-a-uuid",
+      type: "NOTE",
+      note: "Invalid"
+    }),
+    MeadToolsContractError
+  );
+  assert.equal(called, false);
+});

--- a/packages/api-contract/src/contracts.ts
+++ b/packages/api-contract/src/contracts.ts
@@ -49,6 +49,7 @@ import {
   brewEntriesByStageResponseSchema,
   brewEntryCreateErrorResponseSchema,
   brewEntryDeleteErrorResponseSchema,
+  brewEntryIdConflictErrorResponseSchema,
   brewEntryPathParamsSchema,
   brewEntryResponseSchema,
   brewEntryTypeResponseSchema,
@@ -344,6 +345,7 @@ export type BrewDeviceActionErrorResponse = z.infer<typeof brewDeviceActionError
 export type BrewEntriesByStageResponse = z.infer<typeof brewEntriesByStageResponseSchema>;
 export type BrewEntryCreateErrorResponse = z.infer<typeof brewEntryCreateErrorResponseSchema>;
 export type BrewEntryDeleteErrorResponse = z.infer<typeof brewEntryDeleteErrorResponseSchema>;
+export type BrewEntryIdConflictErrorResponse = z.infer<typeof brewEntryIdConflictErrorResponseSchema>;
 export type BrewEntryPathParams = z.infer<typeof brewEntryPathParamsSchema>;
 export type BrewEntryResponse = z.infer<typeof brewEntryResponseSchema>;
 export type BrewEntryTypeResponse = z.infer<typeof brewEntryTypeResponseSchema>;

--- a/packages/api-contract/src/zod/brews.ts
+++ b/packages/api-contract/src/zod/brews.ts
@@ -138,10 +138,14 @@ const brewEntryMutationObjectSchema = z.object({
 });
 export const createBrewEntryRequestBodySchema =
   brewEntryMutationObjectSchema.extend({
-    type: brewEntryTypeResponseSchema, stage_to: brewStageResponseSchema.optional()
+    type: brewEntryTypeResponseSchema,
+    stage_to: brewStageResponseSchema.optional(),
+    client_entry_id: z.string().uuid().optional()
   });
 export const createBrewEntryResponseSchema =
   z.object({ brew: brewResponseSchema });
+export const brewEntryIdConflictErrorResponseSchema =
+  z.object({ error: z.literal("Entry ID is already in use") });
 export const updateBrewEntryRequestBodySchema =
   brewEntryMutationObjectSchema;
 export const updateBrewEntryResponseSchema =
@@ -173,7 +177,10 @@ const errorEnum = <T extends string>(values: [T, ...T[]]) =>
 export const authenticatedRouteErrorResponseSchema =
   errorEnum(["Authorization header missing", "Token missing", "Invalid token or unauthorized access", "Invalid or expired token", "User not found", "Server misconfiguration"]);
 export const brewValidationErrorResponseSchema =
-  errorEnum(["Invalid JSON body", "Missing recipe_id", "Missing brew_id", "Missing entry_id"]);
+  errorEnum([
+    "Invalid JSON body", "Missing recipe_id", "Missing brew_id",
+    "Missing entry_id", "Invalid client_entry_id"
+  ]);
 export const brewFetchErrorResponseSchema =
   errorEnum(["Failed to fetch brews.", "Failed to fetch brew.", "Server misconfiguration"]);
 export const brewCreateErrorResponseSchema =

--- a/packages/api-contract/src/zod/openapi-aliases.ts
+++ b/packages/api-contract/src/zod/openapi-aliases.ts
@@ -48,6 +48,7 @@ import {
   brewEntriesByStageResponseSchema,
   brewEntryCreateErrorResponseSchema,
   brewEntryDeleteErrorResponseSchema,
+  brewEntryIdConflictErrorResponseSchema,
   brewEntryPathParamsSchema,
   brewEntryResponseSchema,
   brewEntryTypeResponseSchema,
@@ -343,6 +344,7 @@ export const BrewDeviceActionErrorResponse = brewDeviceActionErrorResponseSchema
 export const BrewEntriesByStageResponse = brewEntriesByStageResponseSchema;
 export const BrewEntryCreateErrorResponse = brewEntryCreateErrorResponseSchema;
 export const BrewEntryDeleteErrorResponse = brewEntryDeleteErrorResponseSchema;
+export const BrewEntryIdConflictErrorResponse = brewEntryIdConflictErrorResponseSchema;
 export const BrewEntryPathParams = brewEntryPathParamsSchema;
 export const BrewEntryResponse = brewEntryResponseSchema;
 export const BrewEntryTypeResponse = brewEntryTypeResponseSchema;

--- a/packages/api-contract/test/brew-schemas.test.ts
+++ b/packages/api-contract/test/brew-schemas.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  brewEntryIdConflictErrorResponseSchema,
   brewEntryResponseSchema,
   createBrewEntryRequestBodySchema,
   publicBrewFetchErrorResponseSchema,
@@ -27,6 +28,7 @@ test("brew entry schemas preserve nullable readings and arbitrary JSON data", ()
     createBrewEntryRequestBodySchema.safeParse({
       type: "STAGE_CHANGE",
       stage_to: "SECONDARY",
+      client_entry_id: "00000000-0000-4000-8000-000000000001",
       data: null
     }).success,
     true
@@ -48,6 +50,19 @@ test("brew schemas reject invalid enums while preserving literal errors", () => 
   assert.equal(
     createBrewEntryRequestBodySchema.safeParse({ type: "UNKNOWN" }).success,
     false
+  );
+  assert.equal(
+    createBrewEntryRequestBodySchema.safeParse({
+      type: "NOTE",
+      client_entry_id: "not-a-uuid"
+    }).success,
+    false
+  );
+  assert.equal(
+    brewEntryIdConflictErrorResponseSchema.safeParse({
+      error: "Entry ID is already in use"
+    }).success,
+    true
   );
   assert.equal(
     publicBrewFetchErrorResponseSchema.safeParse({

--- a/packages/api-contract/test/openapi-parity.test.ts
+++ b/packages/api-contract/test/openapi-parity.test.ts
@@ -4,7 +4,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const baselineCanonicalSha256 =
-  "49844af6db83344c1ec241652d1251f4c3e361b01cb7caff56e7d9de030a06ce";
+  "1c0c6673a150cb99377bfe86772b604c4911aad4347a808c7688f7090b43a562";
 const preZodPathsCanonicalSha256 =
   "4610d8687942691b4d6a411907359deca3fb67c00a6f34dd7acc8ad3ee38076c";
 
@@ -34,12 +34,20 @@ test("generated OpenAPI document matches the reviewed Zod baseline", async () =>
   );
 });
 
-test("Zod migration preserves the pre-migration endpoint documentation", async () => {
+test("idempotency contract preserves all pre-existing endpoint documentation", async () => {
   const documentUrl = new URL("../../../public/openapi.json", import.meta.url);
   const document = JSON.parse(await readFile(documentUrl, "utf8")) as {
-    paths: unknown;
+    paths: Record<
+      string,
+      { post?: { responses?: Record<string, unknown> } }
+    >;
   };
-  const canonicalPaths = JSON.stringify(sortJson(document.paths));
+  const pathsWithoutIdempotencyConflict = structuredClone(document.paths);
+  delete pathsWithoutIdempotencyConflict["/brews/{brew_id}/entries"]?.post
+    ?.responses?.["409"];
+  const canonicalPaths = JSON.stringify(
+    sortJson(pathsWithoutIdempotencyConflict)
+  );
   const actualHash = createHash("sha256")
     .update(canonicalPaths)
     .digest("hex");

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -979,7 +979,8 @@
               "Invalid JSON body",
               "Missing recipe_id",
               "Missing brew_id",
-              "Missing entry_id"
+              "Missing entry_id",
+              "Invalid client_entry_id"
             ]
           }
         },
@@ -1076,6 +1077,10 @@
                 "$ref": "#/components/schemas/BrewStageResponse"
               }
             ]
+          },
+          "client_entry_id": {
+            "type": "string",
+            "format": "uuid"
           }
         },
         "required": [
@@ -1091,6 +1096,20 @@
         },
         "required": [
           "brew"
+        ]
+      },
+      "BrewEntryIdConflictErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "enum": [
+              "Entry ID is already in use"
+            ]
+          }
+        },
+        "required": [
+          "error"
         ]
       },
       "BrewEntryCreateErrorResponse": {
@@ -7519,6 +7538,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AuthenticatedRouteErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BrewEntryIdConflictErrorResponse"
                 }
               }
             }


### PR DESCRIPTION
## Summary

- add optional `client_entry_id` UUID support to brew-entry creation
- reuse the existing entry UUID primary key for retry-safe, no-migration idempotency
- atomically ignore duplicate inserts and reject cross-brew/cross-owner ID reuse with HTTP 409
- preserve server-generated entry IDs for every existing caller
- add `listRecipes`, `listBrews`, `getBrew`, and `createBrewEntry` to `@meadtools/api-client`
- validate every new client request and response through the shared Zod contracts
- add a standalone non-Next.js consumer test covering reads and a repeated offline-style upload
- document API-client support, retry semantics, and the reviewed OpenAPI additions

## Why

Future companion clients need to queue brew entries while offline and retry them
without duplicating timeline records. The existing UUID primary key can serve
as the client operation identity, providing exact retry behavior without a
database migration or authentication redesign.

## Compatibility

- callers that omit `client_entry_id` behave exactly as before
- no Prisma schema or migration changes
- authentication and credential ownership are unchanged
- OpenAPI adds only the optional UUID field, a documented 409 response, and its
  error schema; the parity test proves all earlier endpoint documentation is
  unchanged

## Validation

- 73 tests pass
- workspace and application TypeScript checks pass
- contract and OpenAPI generation is deterministic
- package request/response validation and standalone consumer tests pass
- Next.js production build passes

Closes #320
