### PR TITLE
Preserve existing V2 recipe snapshot compatibility

### DIFF
--- a/apps/web/lib/utils/buildBrewRecipeStageData.test.ts
+++ b/apps/web/lib/utils/buildBrewRecipeStageData.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { recipeDataV2Schema } from "@meadtools/schemas/recipe";
+import { traditionalRecipeFixture } from "@/lib/utils/__fixtures__/recipeDerivedFixtures";
+import { buildBrewRecipeStageData } from "@/lib/utils/buildBrewRecipeStageData";
+import type { RecipeData } from "@/types/recipeData";
+
+test("renders an existing V2 snapshot that predates newly required nested fields", () => {
+  const existingSnapshotData = structuredClone(traditionalRecipeFixture) as RecipeData;
+
+  // Recipe snapshots created before IngredientRef was introduced do not have
+  // this field. New API input should reject that shape, but brew history must
+  // continue to render it.
+  delete (existingSnapshotData.ingredients[0] as Partial<RecipeData["ingredients"][number]>).ref;
+
+  assert.equal(recipeDataV2Schema.safeParse(existingSnapshotData).success, false);
+
+  const stageData = buildBrewRecipeStageData({
+    recipeSnapshot: {
+      id: 1,
+      name: "Existing traditional mead",
+      version: 2,
+      dataV2: existingSnapshotData,
+      snapshottedAt: "2026-01-01T00:00:00.000Z"
+    },
+    currentVolumeLiters: null,
+    latestGravity: null,
+    entries: []
+  });
+
+  assert.equal(stageData.snapshot?.id, 1);
+  assert.equal(stageData.planned.ingredients.length, 2);
+  assert.equal(stageData.planned.ingredients[1]?.name, "Wildflower Honey");
+  assert.ok(stageData.derived);
+  assert.ok(stageData.derived.gravity.ogPrimary > 1);
+});

--- a/apps/web/lib/utils/buildBrewRecipeStageData.ts
+++ b/apps/web/lib/utils/buildBrewRecipeStageData.ts
@@ -10,7 +10,7 @@ import type {
   GravityPayloadOptions
 } from "@/lib/utils/entryPayload";
 import type { RecipeData, IngredientLine, AdditiveLine, Notes, VolumeUnit, WeightUnit } from "@/types/recipeData";
-import { isRecipeData } from "@/types/recipeData";
+import { isCompatibleRecipeDataSnapshot } from "@/types/recipeData";
 import {
   calculateNutrientDerivedState,
   calculateEffectiveNutrientData,
@@ -653,7 +653,7 @@ export function buildBrewRecipeStageData(args: {
   const snapshot = args.recipeSnapshot ?? null;
   const snapshotData = snapshot?.dataV2;
 
-  if (!snapshot || !isRecipeData(snapshotData)) {
+  if (!snapshot || !isCompatibleRecipeDataSnapshot(snapshotData)) {
     return {
       ...EMPTY_STAGE_DATA,
       actual: {

--- a/apps/web/types/recipeData.ts
+++ b/apps/web/types/recipeData.ts
@@ -271,6 +271,41 @@ export const isRecipeData = (x: unknown): x is RecipeData => {
   return isRecipeDataV2(x);
 };
 
+/**
+ * Compatibility guard for persisted V2 recipe snapshots.
+ *
+ * Older snapshots may predate fields that are now required when accepting new
+ * recipe data at an API boundary. Brew history still needs to render those
+ * snapshots, so keep this intentionally narrower, tolerant top-level check
+ * separate from the strict Zod-backed `isRecipeData` guard.
+ */
+export const isCompatibleRecipeDataSnapshot = (x: unknown): x is RecipeData => {
+  if (!x || typeof x !== "object") return false;
+
+  const obj = x as Record<string, unknown>;
+  const unitDefaults = obj.unitDefaults as Record<string, unknown> | undefined;
+  const stabilizers = obj.stabilizers as Record<string, unknown> | undefined;
+  const notes = obj.notes as Record<string, unknown> | undefined;
+
+  return (
+    obj.version === 2 &&
+    !!unitDefaults &&
+    typeof unitDefaults.weight === "string" &&
+    typeof unitDefaults.volume === "string" &&
+    Array.isArray(obj.ingredients) &&
+    typeof obj.fg === "string" &&
+    Array.isArray(obj.additives) &&
+    !!stabilizers &&
+    typeof stabilizers.adding === "boolean" &&
+    typeof stabilizers.takingPh === "boolean" &&
+    typeof stabilizers.phReading === "string" &&
+    typeof stabilizers.type === "string" &&
+    !!notes &&
+    Array.isArray(notes.primary) &&
+    Array.isArray(notes.secondary)
+  );
+};
+
 export type BlendInput = {
   sg: number;
   volumeL: number;


### PR DESCRIPTION
Closes #324

## What changed
- restore a tolerant read guard for persisted V2 recipe snapshots
- keep the strict Zod-backed recipe guard for API request validation
- add a regression test for snapshots that predate newly required nested fields

## Why
The schema extraction made brew detail rendering use the strict current recipe schema. Existing snapshots without newer nested fields were discarded wholesale, leaving a linked recipe name but no planned recipe details.

## Validation
- `npm run typecheck`
- `npm test`

After Vercel deploys this PR, verify brew `a9405c1a-7193-4625-89d9-9c07342087d1` shows its recipe details.