### PR TITLE
Refine lockfile app impact

### DIFF
--- a/scripts/app-impact.mjs
+++ b/scripts/app-impact.mjs
@@ -14,9 +14,10 @@ const SHARED_PATHS = [
   "packages/",
   "scripts/",
   "package.json",
-  "package-lock.json",
   "tsconfig.base.json",
 ];
+
+const LOCKFILE = "package-lock.json";
 
 const TARGET_CONFIGURATION = {
   web: ["vercel.json"],
@@ -49,12 +50,26 @@ export function isTargetAffected(target, changedPaths) {
 }
 
 export function classifyAppImpact(changedPaths) {
-  return Object.fromEntries(
+  const impact = Object.fromEntries(
     TARGETS.map((target) => [
       target,
       isTargetAffected(target, changedPaths),
     ]),
   );
+
+  if (changedPaths.includes(LOCKFILE)) {
+    const lockfileHasManifestContext = changedPaths.some(
+      (changedPath) =>
+        changedPath === "package.json" ||
+        /^(?:apps|packages)\/[^/]+\/package\.json$/.test(changedPath),
+    );
+
+    if (!lockfileHasManifestContext) {
+      return Object.fromEntries(TARGETS.map((target) => [target, true]));
+    }
+  }
+
+  return impact;
 }
 
 function readChangedPaths(base, head) {

--- a/scripts/app-impact.test.mjs
+++ b/scripts/app-impact.test.mjs
@@ -21,10 +21,61 @@ test("shared packages and root dependencies affect every app", () => {
   for (const changedPath of [
     "packages/core/src/index.ts",
     "package.json",
-    "package-lock.json",
     "tsconfig.base.json",
   ]) {
     assert.deepEqual(classifyAppImpact([changedPath]), {
+      web: true,
+      mobile: true,
+      desktop: true,
+    });
+  }
+});
+
+test("an app manifest and lockfile change affect only that app", () => {
+  assert.deepEqual(
+    classifyAppImpact([
+      "apps/mobile/package.json",
+      "package-lock.json",
+    ]),
+    {
+      web: false,
+      mobile: true,
+      desktop: false,
+    },
+  );
+
+  assert.deepEqual(
+    classifyAppImpact(["apps/web/package.json", "package-lock.json"]),
+    {
+      web: true,
+      mobile: false,
+      desktop: false,
+    },
+  );
+});
+
+test("multiple app manifests and a lockfile affect each changed app", () => {
+  assert.deepEqual(
+    classifyAppImpact([
+      "apps/mobile/package.json",
+      "apps/web/package.json",
+      "package-lock.json",
+    ]),
+    {
+      web: true,
+      mobile: true,
+      desktop: false,
+    },
+  );
+});
+
+test("unexplained lockfile changes safely affect every app", () => {
+  for (const changedPaths of [
+    ["package-lock.json"],
+    ["README.md", "package-lock.json"],
+    ["apps/mobile/src/app/index.tsx", "package-lock.json"],
+  ]) {
+    assert.deepEqual(classifyAppImpact(changedPaths), {
       web: true,
       mobile: true,
       desktop: true,


### PR DESCRIPTION
## Summary

- stop treating every root lockfile change as automatically affecting every app
- use changed workspace manifests to attribute lockfile changes to web, mobile, or desktop
- retain the safe all-app fallback for lockfile changes without an explanatory manifest
- add coverage for single-app, multi-app, shared, and unexplained lockfile changes

## Why

Workspace dependencies are recorded in the root `package-lock.json`. A mobile-only dependency addition therefore changes that lockfile, but should not trigger a web build when no web or shared manifest changed.

## Functional impact

No application runtime behavior changes. This only refines CI and Vercel build selection.

## Verification

- `npm run test:workflows`
- eight impact-classifier tests pass
- `git diff --check`
