### PR TITLE
Use native mobile CI export

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -103,5 +103,5 @@ jobs:
       - name: Typecheck mobile app
         run: npm run mobile:typecheck
 
-      - name: Verify Expo can export the app
-        run: npm exec --workspace @meadtools/mobile -- expo export --platform web
+      - name: Verify Expo can export an Android bundle
+        run: npm exec --workspace @meadtools/mobile -- expo export --platform android

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -34,6 +34,17 @@ npm run mobile:typecheck
 Expo CLI commands that affect EAS configuration or credentials should be run
 from `apps/mobile`, where `app.json`, `eas.json`, and `.eas/workflows` live.
 
+## EAS builds
+
+The EAS project must be connected to the `ljreaux/MeadTools` repository in its
+GitHub settings before branch pushes can start workflows automatically.
+
+- Merges into `preview` create an Android internal build and an unsigned iOS
+  Simulator build.
+- Merges into `main` create Android and iOS production builds.
+- Production iOS builds require Apple Developer Program membership and signing
+  credentials; preview Simulator builds do not.
+
 ## Project shape
 
 - `src/app` owns Expo Router routes and layouts.


### PR DESCRIPTION
## Summary

- replace the unused Expo web export CI check with an Android native bundle export
- document the EAS preview and production branch behavior
- document that the Expo project must be connected to GitHub for automatic triggers

## Why

Mobile web is not currently a MeadTools product target. A native Android export
is a more relevant bundling smoke test for the Expo companion app.

This PR also creates a new `apps/mobile/**` push when merged into `preview`, which
can verify the EAS preview trigger after `ljreaux/MeadTools` is connected in the
Expo project's GitHub settings.

## Verification

- `npm run mobile:typecheck`
- `npm exec --workspace @meadtools/mobile -- expo export --platform android`
- `git diff --check`
