### PR TITLE
Implement native sign-in and session persistence

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,9 +2,6 @@ name: Quality
 
 on:
   pull_request:
-    branches:
-      - main
-      - preview
   push:
     branches:
       - main

--- a/apps/mobile/FEATURES.md
+++ b/apps/mobile/FEATURES.md
@@ -15,6 +15,7 @@ batch easier to monitor and update, especially when connectivity is poor.
 - EAS production workflow gated by mobile typechecking
 - Access to the shared MeadTools domain, schema, contract, and API packages
 - Environment-aware API client and TanStack Query providers
+- Native password sign-in, protected routes, and SecureStore session restore
 
 The foundation does not yet claim to provide authentication, synchronization,
 offline persistence, or production-ready branding.

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -56,6 +56,8 @@ GitHub settings before branch pushes can start workflows automatically.
 - `src/app/(auth)` and `src/app/(app)` keep unauthenticated and authenticated
   routes separate.
 - `src/providers` owns app-wide API and query state.
+- Native sessions are persisted with Expo SecureStore; access tokens are
+  supplied to the shared API client at request time.
 - Shared recipe and brew behavior comes from `packages/*`.
 - Network access goes through the app-level `@meadtools/api-client` instance.
 - Prisma, database code, Next.js modules, and web UI must not be imported.

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,6 +19,7 @@
     "expo-linking": "~57.0.1",
     "expo-localization": "~57.0.0",
     "expo-router": "~57.0.3",
+    "expo-secure-store": "~57.0.0",
     "expo-splash-screen": "~57.0.2",
     "expo-status-bar": "~57.0.0",
     "expo-symbols": "~57.0.0",

--- a/apps/mobile/src/api/client.ts
+++ b/apps/mobile/src/api/client.ts
@@ -16,9 +16,12 @@ const nativeFetch: FetchTransport = async (url, init) => {
   };
 };
 
-export function createMobileApiClient() {
+export function createMobileApiClient(
+  getAccessToken?: () => string | null | undefined
+) {
   return createMeadToolsApiClient({
     baseUrl: apiBaseUrl,
-    fetch: nativeFetch
+    fetch: nativeFetch,
+    getAccessToken
   });
 }

--- a/apps/mobile/src/app/(app)/brews.tsx
+++ b/apps/mobile/src/app/(app)/brews.tsx
@@ -1,8 +1,11 @@
-import { ScrollView, StyleSheet, Text } from "react-native";
+import { Pressable, ScrollView, StyleSheet, Text } from "react-native";
 import { useTranslation } from "react-i18next";
+
+import { useSession } from "@/providers/app-providers";
 
 export default function BrewsScreen() {
   const { t } = useTranslation();
+  const { signOut } = useSession();
 
   return (
     <ScrollView
@@ -12,16 +15,35 @@ export default function BrewsScreen() {
       <Text accessibilityRole="header" selectable style={styles.heading}>
         {t("brews.label")}
       </Text>
+      <Pressable
+        accessibilityRole="button"
+        onPress={() => void signOut()}
+        style={styles.button}
+      >
+        <Text style={styles.buttonText}>{t("account.logout")}</Text>
+      </Pressable>
     </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
   content: {
+    gap: 24,
     padding: 24
   },
   heading: {
     fontSize: 28,
+    fontWeight: "700"
+  },
+  button: {
+    alignSelf: "flex-start",
+    borderRadius: 10,
+    backgroundColor: "#F5A623",
+    paddingHorizontal: 18,
+    paddingVertical: 12
+  },
+  buttonText: {
+    color: "#171717",
     fontWeight: "700"
   }
 });

--- a/apps/mobile/src/app/(auth)/index.tsx
+++ b/apps/mobile/src/app/(auth)/index.tsx
@@ -1,26 +1,114 @@
+import { useMutation } from "@tanstack/react-query";
 import { Image } from "expo-image";
-import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View
+} from "react-native";
 import { useTranslation } from "react-i18next";
 
-export default function WelcomeScreen() {
+import { MeadToolsApiError } from "@meadtools/api-client";
+
+import { useSession } from "@/providers/app-providers";
+
+export default function SignInScreen() {
   const { t } = useTranslation();
+  const { signIn } = useSession();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const signInMutation = useMutation({
+    mutationFn: signIn
+  });
+  const canSubmit =
+    email.trim().length > 0 &&
+    password.length > 0 &&
+    !signInMutation.isPending;
+  const errorMessage =
+    signInMutation.error instanceof MeadToolsApiError &&
+    signInMutation.error.status === 401
+      ? t("auth.login.error")
+      : t("error");
+
+  function handleSignIn() {
+    if (!canSubmit) {
+      return;
+    }
+
+    signInMutation.mutate({
+      email: email.trim(),
+      password
+    });
+  }
 
   return (
     <ScrollView
+      automaticallyAdjustKeyboardInsets
       contentContainerStyle={styles.content}
       contentInsetAdjustmentBehavior="automatic"
+      keyboardShouldPersistTaps="handled"
       style={styles.screen}
     >
       <View style={styles.glow} />
-      <View style={styles.brandContainer}>
+      <View style={styles.form}>
         <Image
           accessibilityLabel="MeadTools"
           source={require("@/assets/images/meadtools-logo.png")}
           style={styles.mark}
         />
-        <Text accessibilityRole="header" selectable style={styles.brand}>
-          {t("greeting")}
+        <Text accessibilityRole="header" selectable style={styles.heading}>
+          {t("accountPage.login")}
         </Text>
+        <TextInput
+          accessibilityLabel={t("accountPage.email")}
+          autoCapitalize="none"
+          autoComplete="email"
+          inputMode="email"
+          onChangeText={setEmail}
+          placeholder={t("accountPage.email")}
+          placeholderTextColor="#A3A3A3"
+          style={styles.input}
+          textContentType="emailAddress"
+          value={email}
+        />
+        <TextInput
+          accessibilityLabel={t("accountPage.password")}
+          autoCapitalize="none"
+          autoComplete="current-password"
+          onChangeText={setPassword}
+          onSubmitEditing={handleSignIn}
+          placeholder={t("accountPage.password")}
+          placeholderTextColor="#A3A3A3"
+          secureTextEntry
+          style={styles.input}
+          textContentType="password"
+          value={password}
+        />
+        {signInMutation.isError ? (
+          <Text accessibilityRole="alert" selectable style={styles.error}>
+            {errorMessage}
+          </Text>
+        ) : null}
+        <Pressable
+          accessibilityRole="button"
+          disabled={!canSubmit}
+          onPress={handleSignIn}
+          style={({ pressed }) => [
+            styles.button,
+            !canSubmit && styles.buttonDisabled,
+            pressed && canSubmit && styles.buttonPressed
+          ]}
+        >
+          {signInMutation.isPending ? (
+            <ActivityIndicator color="#171717" />
+          ) : (
+            <Text style={styles.buttonText}>{t("accountPage.login")}</Text>
+          )}
+        </Pressable>
       </View>
     </ScrollView>
   );
@@ -44,20 +132,55 @@ const styles = StyleSheet.create({
     height: 360,
     borderRadius: 180,
     backgroundColor: "#F5A623",
-    opacity: 0.12
+    opacity: 0.1
   },
-  brandContainer: {
-    alignItems: "center",
-    gap: 18
+  form: {
+    width: "100%",
+    maxWidth: 420,
+    gap: 16
   },
   mark: {
-    width: 196,
-    height: 168
+    width: 140,
+    height: 120,
+    alignSelf: "center"
   },
-  brand: {
+  heading: {
     color: "#FAFAFA",
-    fontSize: 22,
+    fontSize: 28,
     fontWeight: "700",
-    letterSpacing: 7
+    textAlign: "center"
+  },
+  input: {
+    minHeight: 52,
+    borderWidth: 1,
+    borderColor: "#525252",
+    borderRadius: 12,
+    backgroundColor: "#262626",
+    color: "#FAFAFA",
+    fontSize: 16,
+    paddingHorizontal: 16
+  },
+  error: {
+    color: "#FCA5A5",
+    fontSize: 14
+  },
+  button: {
+    minHeight: 52,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 12,
+    backgroundColor: "#F5A623",
+    paddingHorizontal: 20
+  },
+  buttonDisabled: {
+    opacity: 0.45
+  },
+  buttonPressed: {
+    opacity: 0.8
+  },
+  buttonText: {
+    color: "#171717",
+    fontSize: 17,
+    fontWeight: "700"
   }
 });

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -4,7 +4,29 @@ import { StatusBar } from "expo-status-bar";
 import { I18nextProvider } from "react-i18next";
 
 import i18n, { initI18n } from "@/i18n";
-import { AppProviders } from "@/providers/app-providers";
+import { AppProviders, useSession } from "@/providers/app-providers";
+
+function RootNavigator() {
+  const { status } = useSession();
+
+  if (status === "loading") {
+    return null;
+  }
+
+  return (
+    <>
+      <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Protected guard={status === "unauthenticated"}>
+          <Stack.Screen name="(auth)" />
+        </Stack.Protected>
+        <Stack.Protected guard={status === "authenticated"}>
+          <Stack.Screen name="(app)" />
+        </Stack.Protected>
+      </Stack>
+      <StatusBar style="light" />
+    </>
+  );
+}
 
 export default function RootLayout() {
   const [i18nReady, setI18nReady] = useState(false);
@@ -22,11 +44,7 @@ export default function RootLayout() {
   return (
     <I18nextProvider i18n={i18n}>
       <AppProviders>
-        <Stack screenOptions={{ headerShown: false }}>
-          <Stack.Screen name="(auth)" />
-          <Stack.Screen name="(app)" />
-        </Stack>
-        <StatusBar style="light" />
+        <RootNavigator />
       </AppProviders>
     </I18nextProvider>
   );

--- a/apps/mobile/src/auth/session-storage.ts
+++ b/apps/mobile/src/auth/session-storage.ts
@@ -1,0 +1,49 @@
+import * as SecureStore from "expo-secure-store";
+
+const SESSION_KEY = "meadtools.mobile.session.v1";
+
+export type MobileSession = {
+  accessToken: string;
+  email: string;
+  id: number;
+  refreshToken: string;
+  role: string | null;
+};
+
+function isMobileSession(value: unknown): value is MobileSession {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const session = value as Record<string, unknown>;
+  return (
+    typeof session.accessToken === "string" &&
+    typeof session.email === "string" &&
+    typeof session.id === "number" &&
+    typeof session.refreshToken === "string" &&
+    (typeof session.role === "string" || session.role === null)
+  );
+}
+
+export async function loadSession() {
+  const storedSession = await SecureStore.getItemAsync(SESSION_KEY);
+
+  if (!storedSession) {
+    return null;
+  }
+
+  try {
+    const session: unknown = JSON.parse(storedSession);
+    return isMobileSession(session) ? session : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveSession(session: MobileSession) {
+  await SecureStore.setItemAsync(SESSION_KEY, JSON.stringify(session));
+}
+
+export async function clearSession() {
+  await SecureStore.deleteItemAsync(SESSION_KEY);
+}

--- a/apps/mobile/src/auth/token.ts
+++ b/apps/mobile/src/auth/token.ts
@@ -1,0 +1,30 @@
+export function isAccessTokenExpired(
+  accessToken: string,
+  now = Date.now()
+) {
+  try {
+    const encodedPayload = accessToken.split(".")[1];
+
+    if (!encodedPayload) {
+      return true;
+    }
+
+    const normalizedPayload = encodedPayload
+      .replace(/-/g, "+")
+      .replace(/_/g, "/");
+    const paddedPayload = normalizedPayload.padEnd(
+      Math.ceil(normalizedPayload.length / 4) * 4,
+      "="
+    );
+    const payload = JSON.parse(
+      atob(paddedPayload)
+    ) as { exp?: unknown };
+
+    return (
+      typeof payload.exp !== "number" ||
+      payload.exp * 1000 <= now + 60_000
+    );
+  } catch {
+    return true;
+  }
+}

--- a/apps/mobile/src/providers/app-providers.tsx
+++ b/apps/mobile/src/providers/app-providers.tsx
@@ -4,15 +4,37 @@ import {
   createContext,
   type PropsWithChildren,
   type ReactNode,
+  use,
+  useCallback,
+  useEffect,
+  useRef,
   useState
 } from "react";
-import { use } from "react";
 
-import type { MeadToolsApiClient } from "@meadtools/api-client";
+import {
+  MeadToolsApiError,
+  type MeadToolsApiClient
+} from "@meadtools/api-client";
 
 import { createMobileApiClient } from "@/api/client";
+import {
+  clearSession as clearStoredSession,
+  loadSession,
+  type MobileSession,
+  saveSession
+} from "@/auth/session-storage";
+import { isAccessTokenExpired } from "@/auth/token";
+
+type SessionContextValue = {
+  session: MobileSession | null;
+  status: "authenticated" | "loading" | "unauthenticated";
+  signIn(input: { email: string; password: string }): Promise<void>;
+  signOut(): Promise<void>;
+};
 
 const ApiClientContext = createContext<MeadToolsApiClient | null>(null);
+const SessionContext = createContext<SessionContextValue | null>(null);
+
 // The web workspace retains React 18 type packages while Expo uses React 19.
 // Keep that type-only monorepo boundary isolated at the shared provider.
 const MobileQueryClientProvider = QueryClientProvider as unknown as ComponentType<{
@@ -20,8 +42,122 @@ const MobileQueryClientProvider = QueryClientProvider as unknown as ComponentTyp
   client: QueryClient;
 }>;
 
+function SessionProvider({
+  children,
+  queryClient
+}: PropsWithChildren<{ queryClient: QueryClient }>) {
+  const sessionRef = useRef<MobileSession | null>(null);
+  const [session, setSession] = useState<MobileSession | null>(null);
+  const [status, setStatus] =
+    useState<SessionContextValue["status"]>("loading");
+  const [apiClient] = useState(() =>
+    createMobileApiClient(() => sessionRef.current?.accessToken)
+  );
+
+  const updateSession = useCallback((nextSession: MobileSession | null) => {
+    sessionRef.current = nextSession;
+    setSession(nextSession);
+    setStatus(nextSession ? "authenticated" : "unauthenticated");
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    async function restoreSession() {
+      let storedSession: MobileSession | null;
+
+      try {
+        storedSession = await loadSession();
+      } catch {
+        if (active) {
+          updateSession(null);
+        }
+        return;
+      }
+
+      if (!active) {
+        return;
+      }
+
+      if (!storedSession) {
+        updateSession(null);
+        return;
+      }
+
+      if (!isAccessTokenExpired(storedSession.accessToken)) {
+        updateSession(storedSession);
+        return;
+      }
+
+      try {
+        const refreshed = await apiClient.refreshAccessToken({
+          email: storedSession.email,
+          refreshToken: storedSession.refreshToken
+        });
+        const nextSession = {
+          ...storedSession,
+          accessToken: refreshed.accessToken
+        };
+
+        await saveSession(nextSession);
+        if (active) {
+          updateSession(nextSession);
+        }
+      } catch (error) {
+        if (error instanceof MeadToolsApiError) {
+          await clearStoredSession();
+        }
+        if (active) {
+          updateSession(null);
+        }
+      }
+    }
+
+    void restoreSession();
+
+    return () => {
+      active = false;
+    };
+  }, [apiClient, updateSession]);
+
+  const signIn = useCallback(
+    async (input: { email: string; password: string }) => {
+      const response = await apiClient.login(input);
+      const nextSession: MobileSession = {
+        accessToken: response.accessToken,
+        email: response.email,
+        id: response.id,
+        refreshToken: response.refreshToken,
+        role: response.role
+      };
+
+      await saveSession(nextSession);
+      updateSession(nextSession);
+    },
+    [apiClient, updateSession]
+  );
+
+  const signOut = useCallback(async () => {
+    await clearStoredSession();
+    queryClient.clear();
+    updateSession(null);
+  }, [queryClient, updateSession]);
+
+  return (
+    <SessionContext
+      value={{
+        session,
+        status,
+        signIn,
+        signOut
+      }}
+    >
+      <ApiClientContext value={apiClient}>{children}</ApiClientContext>
+    </SessionContext>
+  );
+}
+
 export function AppProviders({ children }: PropsWithChildren) {
-  const [apiClient] = useState(createMobileApiClient);
   const [queryClient] = useState(
     () =>
       new QueryClient({
@@ -38,11 +174,9 @@ export function AppProviders({ children }: PropsWithChildren) {
   );
 
   return (
-    <ApiClientContext value={apiClient}>
-      <MobileQueryClientProvider client={queryClient}>
-        {children}
-      </MobileQueryClientProvider>
-    </ApiClientContext>
+    <MobileQueryClientProvider client={queryClient}>
+      <SessionProvider queryClient={queryClient}>{children}</SessionProvider>
+    </MobileQueryClientProvider>
   );
 }
 
@@ -54,4 +188,14 @@ export function useApiClient() {
   }
 
   return apiClient;
+}
+
+export function useSession() {
+  const session = use(SessionContext);
+
+  if (!session) {
+    throw new Error("useSession must be used within AppProviders");
+  }
+
+  return session;
 }

--- a/apps/mobile/test/token.test.ts
+++ b/apps/mobile/test/token.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isAccessTokenExpired } from "../src/auth/token";
+
+function tokenWithExpiration(exp: number) {
+  const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+  return `header.${payload}.signature`;
+}
+
+test("recognizes an access token that remains valid", () => {
+  assert.equal(
+    isAccessTokenExpired(tokenWithExpiration(3_000), 1_000_000),
+    false
+  );
+});
+
+test("recognizes expired and malformed access tokens", () => {
+  assert.equal(
+    isAccessTokenExpired(tokenWithExpiration(1_000), 1_000_000),
+    true
+  );
+  assert.equal(isAccessTokenExpired("not-a-jwt", 1_000_000), true);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "expo-linking": "~57.0.1",
         "expo-localization": "~57.0.0",
         "expo-router": "~57.0.3",
+        "expo-secure-store": "~57.0.0",
         "expo-splash-screen": "~57.0.2",
         "expo-status-bar": "~57.0.0",
         "expo-symbols": "~57.0.0",
@@ -16794,6 +16795,15 @@
       },
       "bin": {
         "expo-modules-autolinking": "bin/expo-modules-autolinking.js"
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "57.0.0",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-57.0.0.tgz",
+      "integrity": "sha512-vkP16rhW7b4bljW5BC4kKXBpNxQ0O1E9SpI5NIfh2biZnszLTpI/gUF4oBsvOY2nvkh7oXS2ERuUoA8cuS8FWQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-server": {

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -4,14 +4,22 @@ import {
   brewsResponseSchema,
   createBrewEntryRequestBodySchema,
   createBrewEntryResponseSchema,
+  loginRequestBodySchema,
+  loginSuccessResponseSchema,
   recipeDataV2Schema,
   recipeDerivedStateResponseBodySchema,
+  refreshTokenRequestBodySchema,
+  refreshTokenSuccessResponseSchema,
   type AccountRecipeResponse,
   type BrewListItemResponse,
   type BrewResponse,
   type CreateBrewEntryRequestBody,
+  type LoginRequestBody,
+  type LoginSuccessResponse,
   type RecipeDataV2Input,
-  type RecipeDerivedStateResponseBody
+  type RecipeDerivedStateResponseBody,
+  type RefreshTokenRequestBody,
+  type RefreshTokenSuccessResponse
 } from "@meadtools/api-contract";
 
 export type ApiRequestInit = {
@@ -120,6 +128,54 @@ export function createMeadToolsApiClient(options: MeadToolsApiClientOptions) {
   }
 
   return {
+    async login(input: LoginRequestBody): Promise<LoginSuccessResponse> {
+      if (!loginRequestBodySchema.safeParse(input).success) {
+        throw new MeadToolsContractError(
+          "Login request does not match the MeadTools API contract",
+          input
+        );
+      }
+
+      const body = await request("/api/auth/login", {
+        method: "POST",
+        body: JSON.stringify(input)
+      });
+      const parsed = loginSuccessResponseSchema.safeParse(body);
+      if (!parsed.success) {
+        throw new MeadToolsContractError(
+          "Login response does not match the MeadTools API contract",
+          body
+        );
+      }
+
+      return parsed.data;
+    },
+
+    async refreshAccessToken(
+      input: RefreshTokenRequestBody
+    ): Promise<RefreshTokenSuccessResponse> {
+      if (!refreshTokenRequestBodySchema.safeParse(input).success) {
+        throw new MeadToolsContractError(
+          "Refresh request does not match the MeadTools API contract",
+          input
+        );
+      }
+
+      const body = await request("/api/auth/refresh", {
+        method: "POST",
+        body: JSON.stringify(input)
+      });
+      const parsed = refreshTokenSuccessResponseSchema.safeParse(body);
+      if (!parsed.success) {
+        throw new MeadToolsContractError(
+          "Refresh response does not match the MeadTools API contract",
+          body
+        );
+      }
+
+      return parsed.data;
+    },
+
     async calculateRecipeDerived(
       recipeData: RecipeDataV2Input
     ): Promise<RecipeDerivedStateResponseBody> {

--- a/packages/api-client/test/client.test.ts
+++ b/packages/api-client/test/client.test.ts
@@ -9,6 +9,51 @@ import {
   type ApiRequestInit
 } from "../src/index";
 
+test("logs in and validates refresh responses through the shared contract", async () => {
+  const requests: Array<{ url: string; init: ApiRequestInit }> = [];
+  const responses = [
+    {
+      message: "Successfully logged in!",
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      role: "user",
+      email: "brewer@example.com",
+      id: 42
+    },
+    { accessToken: "refreshed-access-token" }
+  ];
+  const client = createMeadToolsApiClient({
+    baseUrl: "https://meadtools.test/",
+    fetch: async (url, init) => {
+      requests.push({ url, init });
+      return {
+        ok: true,
+        status: 200,
+        json: async () => responses.shift()
+      };
+    }
+  });
+
+  const session = await client.login({
+    email: "brewer@example.com",
+    password: "secret"
+  });
+  const refreshed = await client.refreshAccessToken({
+    email: session.email,
+    refreshToken: session.refreshToken
+  });
+
+  assert.equal(session.id, 42);
+  assert.equal(refreshed.accessToken, "refreshed-access-token");
+  assert.deepEqual(
+    requests.map(({ url, init }) => [url, init.method]),
+    [
+      ["https://meadtools.test/api/auth/login", "POST"],
+      ["https://meadtools.test/api/auth/refresh", "POST"]
+    ]
+  );
+});
+
 const recipe: RecipeDataV2Input = {
   version: 2,
   unitDefaults: { weight: "lb", volume: "gal" },


### PR DESCRIPTION
Closes #342

## What changed
- promotes password login and refresh operations into `@meadtools/api-client` with runtime contract validation
- adds a localized native sign-in form with pending, invalid-credential, and general failure states
- persists MeadTools access and refresh credentials with Expo SecureStore
- restores valid sessions, refreshes expired access tokens, and clears rejected sessions
- supplies the current bearer token to the shared API client at request time
- protects authenticated and unauthenticated Expo Router groups and adds logout
- reuses existing i18n keys without changing generated translation resources

Google OAuth remains isolated in follow-up child issue #348.

## Validation
- `npm test --workspace @meadtools/api-client`
- `npm test --workspace @meadtools/mobile`
- `npm run typecheck`
- `npm run check:package-boundaries`
- `npx expo-doctor@latest apps/mobile` (20/20)
- `npm exec --workspace @meadtools/mobile -- expo export --platform android`

## Manual verification needed
- sign in with an existing password account on Android or the iOS Simulator
- restart the app and confirm the session restores
- log out and confirm the sign-in route returns
- try an invalid password and a disconnected network
