### PR TITLE
Promote brew tracking volume guidance to main

### DIFF
--- a/apps/web/app/[locale]/account/brews/[brew_id]/page.tsx
+++ b/apps/web/app/[locale]/account/brews/[brew_id]/page.tsx
@@ -1448,7 +1448,12 @@ export default function BrewPageClient() {
         </TabsContent>
 
         <TabsContent value="charts" className="mt-0">
-          <BrewTimelineCharts brewId={brew.id} entries={brew.entries ?? []} linkedDevices={brew.linked_devices ?? []} />
+          <BrewTimelineCharts
+            brewId={brew.id}
+            entries={brew.entries ?? []}
+            linkedDevices={brew.linked_devices ?? []}
+            volumeUnit={recipeVolumeUnit}
+          />
         </TabsContent>
       </Tabs>
       <EditBrewEntryDialog

--- a/apps/web/app/[locale]/admin/maintenance/page.tsx
+++ b/apps/web/app/[locale]/admin/maintenance/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+import { EstimatedAbvRebuild } from "@/components/admin/EstimatedAbvRebuild";
+import { AdminPageHeader } from "@/components/admin/AdminPageHeader";
+
+export default function AdminMaintenancePage() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-6">
+      <AdminPageHeader
+        title={t("admin.maintenance.title", "Maintenance")}
+        description={t(
+          "admin.maintenance.description",
+          "Run safe administrative maintenance tasks in small batches."
+        )}
+      />
+      <EstimatedAbvRebuild />
+    </div>
+  );
+}

--- a/apps/web/app/api/admin/maintenance/rebuild-estimated-abv/route.ts
+++ b/apps/web/app/api/admin/maintenance/rebuild-estimated-abv/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { rebuildEstimatedAbvEntriesForBrew } from "@/lib/db/brews";
+import prisma from "@/lib/prisma";
+import { verifyAdmin } from "@/lib/userAccessFunctions";
+
+const BATCH_SIZE = 10;
+
+type RebuildRequest = {
+  scope?: unknown;
+  brewId?: unknown;
+  dryRun?: unknown;
+  cursor?: unknown;
+};
+
+export async function POST(req: NextRequest) {
+  const adminOrResponse = await verifyAdmin(req);
+  if (adminOrResponse instanceof NextResponse) return adminOrResponse;
+
+  let body: RebuildRequest;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body." }, { status: 400 });
+  }
+
+  const scope = body.scope === "all" ? "all" : "brew";
+  const dryRun = body.dryRun === true;
+  const brewId = typeof body.brewId === "string" ? body.brewId.trim() : "";
+  const cursor = typeof body.cursor === "string" ? body.cursor : undefined;
+
+  if (scope === "brew") {
+    if (!brewId) {
+      return NextResponse.json({ error: "A brew ID is required." }, { status: 400 });
+    }
+
+    const brew = await prisma.brews.findFirst({
+      where: { id: brewId, user_id: { not: null } },
+      select: { id: true }
+    });
+    if (!brew) {
+      return NextResponse.json({ error: "Brew not found." }, { status: 404 });
+    }
+
+    if (!dryRun) await rebuildEstimatedAbvEntriesForBrew(brew.id);
+
+    return NextResponse.json({
+      scope,
+      dryRun,
+      total: 1,
+      processed: dryRun ? 0 : 1,
+      remaining: dryRun ? 1 : 0,
+      nextCursor: null
+    });
+  }
+
+  const where = { user_id: { not: null } };
+  const total = await prisma.brews.count({ where });
+  if (dryRun) {
+    return NextResponse.json({
+      scope,
+      dryRun: true,
+      total,
+      processed: 0,
+      remaining: total,
+      nextCursor: null
+    });
+  }
+
+  const rows = await prisma.brews.findMany({
+    where,
+    cursor: cursor ? { id: cursor } : undefined,
+    skip: cursor ? 1 : 0,
+    take: BATCH_SIZE + 1,
+    orderBy: { id: "asc" },
+    select: { id: true }
+  });
+  const batch = rows.slice(0, BATCH_SIZE);
+
+  for (const brew of batch) {
+    await rebuildEstimatedAbvEntriesForBrew(brew.id);
+  }
+
+  return NextResponse.json({
+    scope,
+    dryRun: false,
+    total,
+    processed: batch.length,
+    remaining: Math.max(total - batch.length, 0),
+    nextCursor: rows.length > BATCH_SIZE ? batch.at(-1)?.id ?? null : null
+  });
+}

--- a/apps/web/components/admin/EstimatedAbvRebuild.tsx
+++ b/apps/web/components/admin/EstimatedAbvRebuild.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useState } from "react";
+import { LoaderCircle, RefreshCw } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useFetchWithAuth } from "@/hooks/auth/useFetchWithAuth";
+
+type Scope = "brew" | "all";
+
+type RebuildResult = {
+  total: number;
+  processed: number;
+  nextCursor: string | null;
+};
+
+export function EstimatedAbvRebuild() {
+  const { t } = useTranslation();
+  const fetchWithAuth = useFetchWithAuth();
+  const [scope, setScope] = useState<Scope>("brew");
+  const [brewId, setBrewId] = useState("");
+  const [preview, setPreview] = useState<RebuildResult | null>(null);
+  const [progress, setProgress] = useState<{ processed: number; total: number } | null>(null);
+  const [isPreviewing, setIsPreviewing] = useState(false);
+  const [isRunning, setIsRunning] = useState(false);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [isComplete, setIsComplete] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const request = (body: Record<string, unknown>) =>
+    fetchWithAuth<RebuildResult>("/api/admin/maintenance/rebuild-estimated-abv", {
+      method: "POST",
+      body: JSON.stringify(body)
+    });
+
+  async function previewRebuild() {
+    setIsPreviewing(true);
+    setError(null);
+    setProgress(null);
+    setIsComplete(false);
+    try {
+      const result = await request({ scope, brewId, dryRun: true });
+      setPreview(result);
+    } catch (err) {
+      setPreview(null);
+      setError(err instanceof Error ? err.message : t("error.generic", "Something went wrong."));
+    } finally {
+      setIsPreviewing(false);
+    }
+  }
+
+  async function rebuild() {
+    if (!preview) return;
+
+    setIsConfirmOpen(false);
+    setIsRunning(true);
+    setError(null);
+    setIsComplete(false);
+
+    let processed = 0;
+    let cursor: string | null = null;
+    try {
+      do {
+        const result = await request({ scope, brewId, cursor });
+        processed += result.processed;
+        cursor = result.nextCursor;
+        setProgress({ processed, total: result.total });
+      } while (cursor);
+      setPreview(null);
+      setIsComplete(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("admin.maintenance.estimatedAbv.failed", "Could not rebuild estimated ABV entries."));
+    } finally {
+      setIsRunning(false);
+    }
+  }
+
+  function changeScope(nextScope: Scope) {
+    setScope(nextScope);
+    setPreview(null);
+    setProgress(null);
+    setIsComplete(false);
+    setError(null);
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t("admin.maintenance.estimatedAbv.title", "Rebuild estimated ABV")}</CardTitle>
+        <CardDescription>
+          {t(
+            "admin.maintenance.estimatedAbv.description",
+            "Recreates derived estimated-ABV timeline entries from each brew's current history. It does not modify logged brew data."
+          )}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <div className="flex flex-wrap gap-2" aria-label={t("admin.maintenance.estimatedAbv.title", "Rebuild estimated ABV")}>
+          <Button type="button" variant={scope === "brew" ? "default" : "outline"} onClick={() => changeScope("brew")} disabled={isPreviewing || isRunning}>
+            {t("admin.maintenance.estimatedAbv.scopeBrew", "One brew")}
+          </Button>
+          <Button type="button" variant={scope === "all" ? "default" : "outline"} onClick={() => changeScope("all")} disabled={isPreviewing || isRunning}>
+            {t("admin.maintenance.estimatedAbv.scopeAll", "All brews")}
+          </Button>
+        </div>
+
+        {scope === "brew" ? (
+          <div className="grid gap-2">
+            <Label htmlFor="estimated-abv-brew-id">
+              {t("admin.maintenance.estimatedAbv.brewId", "Brew ID")}
+            </Label>
+            <Input id="estimated-abv-brew-id" value={brewId} onChange={(event) => { setBrewId(event.target.value); setPreview(null); }} placeholder="00000000-0000-0000-0000-000000000000" disabled={isPreviewing || isRunning} />
+            <p className="text-sm text-muted-foreground">
+              {t("admin.maintenance.estimatedAbv.brewIdHelp", "Paste the brew ID to rebuild only that brew.")}
+            </p>
+          </div>
+        ) : null}
+
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        {preview ? (
+          <p className="text-sm text-muted-foreground">
+            {t("admin.maintenance.estimatedAbv.ready", "Ready to rebuild {{count}} brew estimate entries.", { count: preview.total })}
+          </p>
+        ) : null}
+        {progress ? (
+          <p className="text-sm text-muted-foreground">
+            {t("admin.maintenance.estimatedAbv.progress", "Rebuilt {{processed}} of {{total}} brews.", progress)}
+          </p>
+        ) : null}
+        {isComplete ? (
+          <p className="text-sm text-green-700 dark:text-green-400">
+            {t(
+              "admin.maintenance.estimatedAbv.complete",
+              "Estimated ABV entries rebuilt."
+            )}
+          </p>
+        ) : null}
+
+        <div className="flex flex-wrap gap-3">
+          <Button type="button" variant="outline" onClick={previewRebuild} disabled={isPreviewing || isRunning || (scope === "brew" && !brewId.trim())}>
+            {isPreviewing ? <LoaderCircle className="animate-spin" /> : null}
+            {t("admin.maintenance.estimatedAbv.preview", "Preview")}
+          </Button>
+          <Button type="button" onClick={() => setIsConfirmOpen(true)} disabled={!preview || preview.total === 0 || isPreviewing || isRunning}>
+            {isRunning ? <LoaderCircle className="animate-spin" /> : <RefreshCw />}
+            {t("admin.maintenance.estimatedAbv.rebuild", "Rebuild estimates")}
+          </Button>
+        </div>
+      </CardContent>
+
+      <AlertDialog open={isConfirmOpen} onOpenChange={setIsConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("admin.maintenance.estimatedAbv.confirmTitle", "Rebuild estimated ABV entries?")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t(
+                "admin.maintenance.estimatedAbv.confirmDescription",
+                "This will replace derived estimated-ABV entries for {{count}} brews. Logged volumes, additions, and measurements will remain unchanged.",
+                { count: preview?.total ?? 0 }
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isRunning}>{t("cancel", "Cancel")}</AlertDialogCancel>
+            <AlertDialogAction onClick={rebuild} disabled={isRunning}>
+              {t("admin.maintenance.estimatedAbv.rebuild", "Rebuild estimates")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}

--- a/apps/web/components/admin/Nav.tsx
+++ b/apps/web/components/admin/Nav.tsx
@@ -4,6 +4,7 @@ import {
   Beer,
   FlaskConical,
   LayoutDashboard,
+  Wrench,
   Menu,
   NotebookText,
   TestTube2,
@@ -27,7 +28,8 @@ const navLinks = [
   { key: "users", fallback: "Users", to: `${baseRoute}/users`, icon: Users },
   { key: "yeasts", fallback: "Yeasts", to: `${baseRoute}/yeasts`, icon: FlaskConical },
   { key: "ingredients", fallback: "Ingredients", to: `${baseRoute}/ingredients`, icon: Wheat },
-  { key: "additives", fallback: "Additives", to: `${baseRoute}/additives`, icon: TestTube2 }
+  { key: "additives", fallback: "Additives", to: `${baseRoute}/additives`, icon: TestTube2 },
+  { key: "maintenance", fallback: "Maintenance", to: `${baseRoute}/maintenance`, icon: Wrench }
 ];
 
 export default function AdminNav() {

--- a/apps/web/components/brews/BrewTimelineCharts.tsx
+++ b/apps/web/components/brews/BrewTimelineCharts.tsx
@@ -43,6 +43,8 @@ import {
 import { toast } from "@/hooks/use-toast";
 import { BREW_ENTRY_TYPE } from "@/lib/brewEnums";
 import { calcABV } from "@meadtools/core/gravity";
+import { L_TO_VOLUME } from "@meadtools/core/recipe";
+import type { VolumeUnit } from "@/types/recipeData";
 import type { BrewViewEntry, BrewViewLog } from "@/types/brewView";
 
 type WirelessLog = {
@@ -224,11 +226,13 @@ export function buildWirelessHydrometerChartData(
 export function BrewTimelineCharts({
   brewId,
   entries,
-  linkedDevices
+  linkedDevices,
+  volumeUnit = "L"
 }: {
   brewId: string;
   entries: BrewChartEntry[];
   linkedDevices: AccountBrewLinkedDevice[];
+  volumeUnit?: VolumeUnit;
 }) {
   const { data: logs = [], isLoading: logsLoading } = useBrewLogs(brewId);
 
@@ -245,6 +249,7 @@ export function BrewTimelineCharts({
         entries={entries}
         logs={logs}
         logsLoading={logsLoading}
+        volumeUnit={volumeUnit}
       />
     </div>
   );
@@ -253,16 +258,25 @@ export function BrewTimelineCharts({
 export function BrewTimelineChartsView({
   entries,
   logs,
-  logsLoading = false
+  logsLoading = false,
+  volumeUnit = "L"
 }: {
   entries: BrewChartEntry[];
   logs: WirelessLog[];
   logsLoading?: boolean;
+  volumeUnit?: VolumeUnit;
 }) {
   const { t } = useTranslation();
   const manualChartData = useMemo(
-    () => buildManualBrewChartData(entries),
-    [entries]
+    () =>
+      buildManualBrewChartData(entries).map((point) => ({
+        ...point,
+        volume:
+          typeof point.volume === "number"
+            ? point.volume * L_TO_VOLUME[volumeUnit]
+            : point.volume
+      })),
+    [entries, volumeUnit]
   );
   const wirelessChartData = useMemo(
     () => buildWirelessHydrometerChartData(logs),
@@ -290,6 +304,7 @@ export function BrewTimelineChartsView({
             chartData={wirelessChartData}
             tempUnits={wirelessTempUnits}
             loading={logsLoading}
+            volumeUnit={volumeUnit}
             name={t(
               "brews.charts.wirelessTitle",
               "Wireless hydrometer readings"
@@ -313,6 +328,7 @@ export function BrewTimelineChartsView({
             chartData={manualChartData}
             tempUnits={manualTempUnits}
             name={t("brews.charts.manualTitle", "Manual timeline readings")}
+            volumeUnit={volumeUnit}
           />
         </ChartSection>
       ) : (

--- a/apps/web/components/brews/BrewViewer.tsx
+++ b/apps/web/components/brews/BrewViewer.tsx
@@ -424,7 +424,11 @@ export function BrewViewer({
         </TabsContent>
 
         <TabsContent value="charts" className="mt-0">
-          <BrewTimelineChartsView entries={brew.entries} logs={brew.logs} />
+          <BrewTimelineChartsView
+            entries={brew.entries}
+            logs={brew.logs}
+            volumeUnit={recipeUnit}
+          />
         </TabsContent>
       </Tabs>
     </div>

--- a/apps/web/components/brews/stages/SecondaryStagePanel.tsx
+++ b/apps/web/components/brews/stages/SecondaryStagePanel.tsx
@@ -49,6 +49,13 @@ import {
   type ScaledIngredientSuggestion
 } from "@meadtools/brew-domain/scaling";
 import { calcABV } from "@meadtools/core/gravity";
+import {
+  getEntryTimestamp,
+  getLatestTimestamp,
+  getMeasuredSecondaryVolumeState,
+  hasVolumeRecordOnOrAfter,
+  needsSupplementalStabilizers
+} from "@/lib/brews/stabilizerVolume";
 import { isValidNumber, parseNumber } from "@/lib/utils/validateInput";
 import type {
   IngredientLine,
@@ -141,8 +148,7 @@ function fmtVolumeWithZero(
 function getEntryTime(
   entry: StagePanelProps["ctx"]["brew"]["entries"][number]
 ) {
-  const value = (entry as any).datetime ?? entry.createdAt;
-  return typeof value === "string" ? new Date(value).getTime() : 0;
+  return getEntryTimestamp(entry) ?? 0;
 }
 
 function latestLoggedPh(ctx: StagePanelProps["ctx"]) {
@@ -338,9 +344,35 @@ function getStabilizerPlan(
   if (abv == null) return null;
 
   const secondaryVolume = getSecondaryVolumeBreakdown(ctx);
-  const adjustedTotalVolumeL = baseVolumeL + secondaryVolume.totalVolumeL;
+  const initialStabilizer = getLoggedStabilizerAdditions(ctx).find(
+    (addition) => addition.meta?.supplemental !== true
+  );
+  const initialBaseVolumeL =
+    typeof initialStabilizer?.meta?.baseVolumeLiters === "number" &&
+    Number.isFinite(initialStabilizer.meta.baseVolumeLiters)
+      ? initialStabilizer.meta.baseVolumeLiters
+      : baseVolumeL;
+  const initialBaseAbv =
+    typeof initialStabilizer?.meta?.baseAbv === "number" &&
+    Number.isFinite(initialStabilizer.meta.baseAbv)
+      ? initialStabilizer.meta.baseAbv
+      : abv;
+  const secondaryIngredientIds = ctx.recipe.secondaryIngredients
+    .filter((line) => (line.name ?? "").trim())
+    .map((line) => String(line.lineId));
+  const measuredSecondaryVolume = getMeasuredSecondaryVolumeState({
+    entries: ctx.brew.entries,
+    secondaryIngredientIds,
+    allSecondaryIngredientsLogged:
+      secondaryVolume.source === "logged" && secondaryIngredientIds.length > 0
+  });
+  const adjustedTotalVolumeL = measuredSecondaryVolume.hasMeasuredVolume
+    ? baseVolumeL
+    : baseVolumeL + secondaryVolume.totalVolumeL;
   const dilutedAbv =
-    adjustedTotalVolumeL > 0 ? (abv * baseVolumeL) / adjustedTotalVolumeL : abv;
+    adjustedTotalVolumeL > 0
+      ? (initialBaseAbv * initialBaseVolumeL) / adjustedTotalVolumeL
+      : initialBaseAbv;
 
   const latestPh = latestLoggedPh(ctx);
   const recipePh = ctx.recipe.stabilizerPlan?.phReading?.trim();
@@ -361,7 +393,7 @@ function getStabilizerPlan(
     secondaryVolumePartiallyPlanned: secondaryVolume.partiallyPlanned,
     abv: dilutedAbv,
     abvSource: hasLoggedOgFg && loggedAbv != null ? "logged_og_fg" : "recipe",
-    baseAbv: abv,
+    baseAbv: initialBaseAbv,
     dilutedAbv,
     defaultPh,
     phSource:
@@ -387,6 +419,23 @@ function getLatestLoggedStabilizer(
   return latestLoggedItem(additions);
 }
 
+function needsVolumeReadingAfterStabilizers(
+  ctx: StagePanelProps["ctx"],
+  additions: ReturnType<typeof getLoggedStabilizerAdditions>
+) {
+  const initialStabilizerAdditions = additions.filter(
+    (addition) => addition.meta?.supplemental !== true
+  );
+
+  if (initialStabilizerAdditions.length === 0) return false;
+
+  const latestStabilizerTime = getLatestTimestamp(initialStabilizerAdditions);
+
+  if (latestStabilizerTime == null) return true;
+
+  return !hasVolumeRecordOnOrAfter(ctx.brew.entries, latestStabilizerTime);
+}
+
 function getSupplementalStabilizerPlan(
   ctx: StagePanelProps["ctx"],
   plan: StabilizerPlan | null
@@ -407,24 +456,16 @@ function getSupplementalStabilizerPlan(
     Number.isFinite(latest.meta.adjustedTotalVolumeLiters)
       ? latest.meta.adjustedTotalVolumeLiters
       : null;
-  const currentVolumeL =
-    typeof ctx.brew.current_volume_liters === "number" &&
-    Number.isFinite(ctx.brew.current_volume_liters) &&
-    ctx.brew.current_volume_liters > 0
-      ? ctx.brew.current_volume_liters
-      : null;
-  const secondaryDilutionIncreased =
-    latestSecondaryVolumeL != null &&
-    plan.secondaryVolumeL >
-      latestSecondaryVolumeL + SUPPLEMENTAL_VOLUME_THRESHOLD_L;
-  const measuredVolumeOverEstimate =
-    latestAdjustedTotalVolumeL != null &&
-    currentVolumeL != null &&
-    currentVolumeL >
-      latestAdjustedTotalVolumeL + SUPPLEMENTAL_VOLUME_THRESHOLD_L;
-
-  if (latestSecondaryVolumeL != null || latestAdjustedTotalVolumeL != null) {
-    if (!secondaryDilutionIncreased && !measuredVolumeOverEstimate) return null;
+  if (
+    !needsSupplementalStabilizers({
+      currentSecondaryVolumeL: plan.secondaryVolumeL,
+      currentAdjustedVolumeL: plan.adjustedTotalVolumeL,
+      latestSecondaryVolumeL,
+      latestAdjustedVolumeL: latestAdjustedTotalVolumeL,
+      thresholdL: SUPPLEMENTAL_VOLUME_THRESHOLD_L
+    })
+  ) {
+    return null;
   }
 
   const stabilizerType =
@@ -438,36 +479,13 @@ function getSupplementalStabilizerPlan(
     typeof latest?.meta?.ph === "number" && Number.isFinite(latest.meta.ph)
       ? String(latest.meta.ph)
       : plan.defaultPh;
-  const latestBaseVolumeL =
-    typeof latest?.meta?.baseVolumeLiters === "number" &&
-    Number.isFinite(latest.meta.baseVolumeLiters)
-      ? latest.meta.baseVolumeLiters
-      : null;
-  const latestBaseAbv =
-    typeof latest?.meta?.baseAbv === "number" &&
-    Number.isFinite(latest.meta.baseAbv)
-      ? latest.meta.baseAbv
-      : null;
-  const requiredVolumeL =
-    measuredVolumeOverEstimate &&
-    !secondaryDilutionIncreased &&
-    currentVolumeL != null
-      ? currentVolumeL
-      : plan.volumeL;
-  const requiredAbv =
-    measuredVolumeOverEstimate &&
-    !secondaryDilutionIncreased &&
-    currentVolumeL != null &&
-    latestBaseVolumeL != null &&
-    latestBaseAbv != null
-      ? (latestBaseAbv * latestBaseVolumeL) / currentVolumeL
-      : plan.abv;
+  const requiredVolumeL = plan.volumeL;
   const required = calculateRecipeStabilizerResults({
     addingStabilizers: true,
     phReading: ph,
     stabilizerType,
     totalVolumeL: requiredVolumeL,
-    abv: requiredAbv
+    abv: plan.abv
   });
 
   const logged = additions.reduce(
@@ -617,6 +635,9 @@ export function SecondaryStagePanel({
   const usesRecipeStabilizers = Boolean(ctx.recipe.stabilizerPlan?.enabled);
   const loggedStabilizerAdditions = getLoggedStabilizerAdditions(ctx);
   const hasLoggedStabilizers = loggedStabilizerAdditions.length > 0;
+  const needsVolumeReading =
+    hasLoggedStabilizers &&
+    needsVolumeReadingAfterStabilizers(ctx, loggedStabilizerAdditions);
   const supplementalStabilizerPlan =
     usesRecipeStabilizers && hasLoggedStabilizers
       ? getSupplementalStabilizerPlan(ctx, stabilizerPlan)
@@ -1007,6 +1028,45 @@ export function SecondaryStagePanel({
           </div>
         </div>
       </div>
+
+      {needsVolumeReading && stabilizerPlan ? (
+        <div className="rounded-lg border border-yellow-500/40 bg-yellow-500/10 px-3 py-3 text-sm">
+          <div className="font-medium text-yellow-700 dark:text-yellow-300">
+            {t(
+              "brews.secondary.recordVolumeAfterStabilizersTitle",
+              "Record the updated volume"
+            )}
+          </div>
+          <div className="mt-1 text-muted-foreground">
+            {t(
+              "brews.secondary.recordVolumeAfterStabilizersHelp",
+              "You logged stabilizers. Record the actual volume now—secondary additions can increase batch volume and may require additional stabilizers."
+            )}
+          </div>
+          <div className="mt-3 max-w-sm">
+            <InfoRow
+              label={t(
+                "brews.secondary.estimatedVolumeAfterStabilizers",
+                "Estimated volume after secondary additions"
+              )}
+              value={fmtVolume(
+                stabilizerPlan.adjustedTotalVolumeL,
+                stabilizerPlan.volumeUnit
+              )}
+            />
+          </div>
+          <div className="mt-3">
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={!canEdit}
+              onClick={() => helpers.openRecordVolume?.()}
+            >
+              {t("brews.actions.logVolume", "Record volume")}
+            </Button>
+          </div>
+        </div>
+      ) : null}
 
       {supplementalStabilizerPlan ? (
         <div className="rounded-lg border border-destructive/50 bg-destructive/10 px-3 py-3 text-sm">

--- a/apps/web/components/ispindel/HydrometerData.tsx
+++ b/apps/web/components/ispindel/HydrometerData.tsx
@@ -37,6 +37,8 @@ import { useTranslation } from "react-i18next";
 import { toBrix } from "@meadtools/core/gravity";
 import { toCelsius, toFahrenheit } from "@meadtools/core/temperature";
 import { formatBrixDisplay, formatSgDisplay } from "@/lib/utils/gravityFormatting";
+import { normalizeNumberString } from "@/lib/utils/validateInput";
+import type { VolumeUnit } from "@/types/recipeData";
 
 import {
   Dialog,
@@ -65,12 +67,14 @@ export function HydrometerData({
   chartData,
   name,
   tempUnits,
-  loading
+  loading,
+  volumeUnit = "L"
 }: {
   chartData: HydrometerChartData[];
   name?: string;
   tempUnits: TempUnits;
   loading?: boolean;
+  volumeUnit?: VolumeUnit;
 }) {
   const { i18n, t } = useTranslation();
   const lang = i18n.resolvedLanguage || "en-US";
@@ -111,11 +115,11 @@ export function HydrometerData({
           color: "hsl(var(--chart-3))"
         },
         volume: {
-          label: t("brews.charts.volumeLabel", "Volume (L)"),
+          label: `${t("volume", "Volume")} (${volumeUnit})`,
           color: "hsl(var(--chart-4))"
         }
       } satisfies ChartConfig),
-    [t, gravityUnits]
+    [t, gravityUnits, volumeUnit]
   );
 
   const initialChecked = useMemo(() => {
@@ -266,6 +270,11 @@ export function HydrometerData({
     [gravityUnits, lang, t]
   );
 
+  const formatVolume = useCallback(
+    (value: number) => normalizeNumberString(value, 3, lang),
+    [lang]
+  );
+
   const tooltipFormatter = useCallback(
     (value: any, name: any, item: any) => {
       const key = String(item?.dataKey ?? name ?? "");
@@ -276,6 +285,8 @@ export function HydrometerData({
           gravityUnits === "Brix"
             ? formatBrixDisplay(value, t("BRIX"), lang)
             : formatSgDisplay(value, lang);
+      } else if (key === "volume" && typeof value === "number") {
+        displayValue = formatVolume(value);
       }
 
       return (
@@ -294,7 +305,7 @@ export function HydrometerData({
         </>
       );
     },
-    [chartConfig, gravityUnits, lang, t]
+    [chartConfig, formatVolume, gravityUnits, lang, t]
   );
 
   // ---------- handlers ----------
@@ -474,7 +485,7 @@ export function HydrometerData({
               tick={false}
               axisLine={false}
               tickLine={false}
-              unit=" L"
+              unit={` ${volumeUnit}`}
             />
           ) : null}
 
@@ -553,7 +564,7 @@ export function HydrometerData({
               dot={getLineDot("volume")}
               activeDot={sparseDot}
               yAxisId={"volume"}
-              unit=" L"
+              unit={` ${volumeUnit}`}
               connectNulls
             />
           ) : null}
@@ -754,9 +765,9 @@ export function HydrometerData({
                   dataKey={"volume"}
                   yAxisId={"volume"}
                   tickCount={8}
-                  tickFormatter={(val) => Number(val).toFixed(1)}
+                  tickFormatter={formatVolume}
                   padding={yPadding}
-                  unit=" L"
+                  unit={` ${volumeUnit}`}
                   hide={!checkObj.volume}
                 />
               ) : null}
@@ -824,11 +835,11 @@ export function HydrometerData({
                   type="monotone"
                   stroke="var(--color-volume)"
                   strokeWidth={2}
-                  dot={getLineDot("volume")}
-                  activeDot={sparseDot}
-                  yAxisId={"volume"}
-                  unit=" L"
-                  hide={!checkObj.volume}
+              dot={getLineDot("volume")}
+              activeDot={sparseDot}
+              yAxisId={"volume"}
+              unit={` ${volumeUnit}`}
+              hide={!checkObj.volume}
                   connectNulls
                 />
               ) : null}

--- a/apps/web/lib/brews/stabilizerVolume.test.ts
+++ b/apps/web/lib/brews/stabilizerVolume.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getMeasuredSecondaryVolumeState,
+  needsSupplementalStabilizers
+} from "@/lib/brews/stabilizerVolume";
+
+test("a measured secondary volume remains the baseline after supplemental stabilizers", () => {
+  const timeline = [
+    {
+      id: "primary-volume",
+      datetime: "2026-01-01T00:00:00.000Z",
+      type: "VOLUME",
+      data: { liters: 12 }
+    },
+    {
+      id: "secondary-addition",
+      datetime: "2026-01-02T00:00:00.000Z",
+      type: "ADDITION",
+      data: {
+        kind: "INGREDIENT",
+        recipeIngredientId: "secondary-juice",
+        meta: { stage: "SECONDARY" }
+      }
+    },
+    {
+      id: "measured-volume",
+      datetime: "2026-01-03T00:00:00.000Z",
+      type: "VOLUME",
+      data: { liters: 16 }
+    }
+  ];
+
+  const measuredVolume = getMeasuredSecondaryVolumeState({
+    entries: timeline,
+    secondaryIngredientIds: ["secondary-juice"],
+    allSecondaryIngredientsLogged: true
+  });
+
+  assert.deepEqual(measuredVolume, {
+    hasMeasuredVolume: true,
+    baseVolumeL: 12
+  });
+
+  assert.equal(
+    needsSupplementalStabilizers({
+      currentSecondaryVolumeL: 4,
+      currentAdjustedVolumeL: 16,
+      latestSecondaryVolumeL: 4,
+      latestAdjustedVolumeL: 15,
+      thresholdL: 0.04
+    }),
+    true
+  );
+  assert.equal(
+    needsSupplementalStabilizers({
+      currentSecondaryVolumeL: 4,
+      currentAdjustedVolumeL: 16,
+      latestSecondaryVolumeL: 4,
+      latestAdjustedVolumeL: 16,
+      thresholdL: 0.04
+    }),
+    false
+  );
+  assert.equal(
+    needsSupplementalStabilizers({
+      currentSecondaryVolumeL: 4,
+      currentAdjustedVolumeL: 17,
+      latestSecondaryVolumeL: 4,
+      latestAdjustedVolumeL: 16,
+      thresholdL: 0.04
+    }),
+    true
+  );
+});

--- a/apps/web/lib/brews/stabilizerVolume.ts
+++ b/apps/web/lib/brews/stabilizerVolume.ts
@@ -1,0 +1,136 @@
+export type BrewTimelineEntry = {
+  id?: string;
+  datetime?: string | null;
+  type: string;
+  data?: unknown;
+};
+
+type VolumeEntry = BrewTimelineEntry & {
+  time: number;
+  liters: number;
+};
+
+export function getEntryTimestamp(entry: {
+  datetime?: string | null;
+  createdAt?: string | null;
+}) {
+  const value = entry.datetime ?? entry.createdAt;
+  const timestamp = value ? new Date(value).getTime() : NaN;
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+export function getLatestTimestamp(
+  entries: Array<{ datetime?: string | null; createdAt?: string | null }>
+) {
+  return entries.reduce<number | null>((latest, entry) => {
+    const timestamp = getEntryTimestamp(entry);
+    if (timestamp == null) return latest;
+    return latest == null ? timestamp : Math.max(latest, timestamp);
+  }, null);
+}
+
+export function hasVolumeRecordOnOrAfter(
+  entries: BrewTimelineEntry[],
+  timestamp: number | null
+) {
+  return (
+    timestamp != null &&
+    entries.some(
+      (entry) =>
+        entry.type === "VOLUME" &&
+        (getEntryTimestamp(entry) ?? -Infinity) >= timestamp
+    )
+  );
+}
+
+function getVolumeEntries(entries: BrewTimelineEntry[]): VolumeEntry[] {
+  return entries
+    .filter((entry) => entry.type === "VOLUME")
+    .map((entry) => {
+      const liters = (entry.data as { liters?: unknown } | null)?.liters;
+      return {
+        ...entry,
+        time: getEntryTimestamp(entry),
+        liters
+      };
+    })
+    .filter(
+      (entry): entry is VolumeEntry =>
+        entry.time != null &&
+        typeof entry.liters === "number" &&
+        Number.isFinite(entry.liters) &&
+        entry.liters > 0
+    );
+}
+
+export function getMeasuredSecondaryVolumeState(args: {
+  entries: BrewTimelineEntry[];
+  secondaryIngredientIds: string[];
+  allSecondaryIngredientsLogged: boolean;
+}) {
+  if (!args.allSecondaryIngredientsLogged || !args.secondaryIngredientIds.length) {
+    return { hasMeasuredVolume: false, baseVolumeL: null };
+  }
+
+  const secondaryAdditions = args.entries.filter((entry) => {
+    const data = entry.data as {
+      kind?: unknown;
+      meta?: { stage?: unknown } | null;
+      recipeIngredientId?: unknown;
+    } | null;
+    return (
+      entry.type === "ADDITION" &&
+      data?.kind === "INGREDIENT" &&
+      data.meta?.stage === "SECONDARY" &&
+      typeof data.recipeIngredientId === "string" &&
+      args.secondaryIngredientIds.includes(data.recipeIngredientId)
+    );
+  });
+  const secondaryTimes = secondaryAdditions
+    .map(getEntryTimestamp)
+    .filter((time): time is number => time != null);
+  if (!secondaryTimes.length) {
+    return { hasMeasuredVolume: false, baseVolumeL: null };
+  }
+
+  const firstSecondaryTime = Math.min(...secondaryTimes);
+  const latestSecondaryTime = Math.max(...secondaryTimes);
+  const volumeEntries = getVolumeEntries(args.entries);
+  const latestVolume = [...volumeEntries]
+    .filter((entry) => entry.time >= latestSecondaryTime)
+    .sort((a, b) => b.time - a.time)[0];
+  const baseVolume = [...volumeEntries]
+    .filter((entry) => entry.time < firstSecondaryTime)
+    .sort((a, b) => b.time - a.time)[0];
+
+  return {
+    hasMeasuredVolume: Boolean(latestVolume && baseVolume),
+    baseVolumeL: baseVolume?.liters ?? null
+  };
+}
+
+export function needsSupplementalStabilizers(args: {
+  currentSecondaryVolumeL: number;
+  currentAdjustedVolumeL: number;
+  latestSecondaryVolumeL: number | null;
+  latestAdjustedVolumeL: number | null;
+  thresholdL: number;
+}) {
+  const secondaryVolumeIncreased =
+    args.latestSecondaryVolumeL != null &&
+    args.currentSecondaryVolumeL >
+      args.latestSecondaryVolumeL + args.thresholdL;
+  const adjustedVolumeIncreased =
+    args.latestAdjustedVolumeL != null &&
+    args.currentAdjustedVolumeL >
+      args.latestAdjustedVolumeL + args.thresholdL;
+
+  if (
+    args.latestSecondaryVolumeL != null ||
+    args.latestAdjustedVolumeL != null
+  ) {
+    return secondaryVolumeIncreased || adjustedVolumeIncreased;
+  }
+
+  return true;
+}

--- a/apps/web/lib/db/brews.ts
+++ b/apps/web/lib/db/brews.ts
@@ -1055,7 +1055,6 @@ async function syncEstimatedAbvEntry(
     });
     const originalGravityEntry = stageData.actual.originalGravity;
     const finalGravityEntry = stageData.actual.finalGravity;
-    const volumeData = event.data as any;
     const fallbackAbv =
       typeof originalGravityEntry?.gravity === "number" &&
       Number.isFinite(originalGravityEntry.gravity) &&
@@ -1063,26 +1062,11 @@ async function syncEstimatedAbvEntry(
       Number.isFinite(finalGravityEntry.gravity)
         ? calcABV(originalGravityEntry.gravity, finalGravityEntry.gravity)
         : null;
-    const volumeAdjustedAbv =
-      event.type === brew_entry_type.VOLUME &&
-      typeof volumeData?.startingLiters === "number" &&
-      Number.isFinite(volumeData.startingLiters) &&
-      volumeData.startingLiters > 0 &&
-      typeof volumeData?.liters === "number" &&
-      Number.isFinite(volumeData.liters) &&
-      volumeData.liters > 0 &&
-      typeof fallbackAbv === "number" &&
-      Number.isFinite(fallbackAbv)
-        ? (fallbackAbv * volumeData.startingLiters) / volumeData.liters
-        : null;
     const abv =
-      typeof volumeAdjustedAbv === "number" &&
-      Number.isFinite(volumeAdjustedAbv)
-        ? volumeAdjustedAbv
-        : typeof stageData.actual.currentAbv === "number" &&
-            Number.isFinite(stageData.actual.currentAbv)
-          ? stageData.actual.currentAbv
-          : fallbackAbv;
+      typeof stageData.actual.currentAbv === "number" &&
+      Number.isFinite(stageData.actual.currentAbv)
+        ? stageData.actual.currentAbv
+        : fallbackAbv;
 
     if (
       !originalGravityEntry ||
@@ -1124,6 +1108,18 @@ async function syncEstimatedAbvEntry(
       }
     });
   }
+}
+
+export async function rebuildEstimatedAbvEntriesForBrew(brewId: string) {
+  const brew = await prisma.brews.findUnique({
+    where: { id: brewId },
+    select: { id: true, user_id: true }
+  });
+  if (!brew || brew.user_id == null) throw new Error("Brew not found");
+
+  await prisma.$transaction((tx) =>
+    syncEstimatedAbvEntry(tx, brew.id, brew.user_id!)
+  );
 }
 
 function shouldSyncEstimatedAbvForEntry(entry: {

--- a/apps/web/lib/utils/buildBrewRecipeStageData.test.ts
+++ b/apps/web/lib/utils/buildBrewRecipeStageData.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { recipeDataV2Schema } from "@meadtools/schemas/recipe";
-import { traditionalRecipeFixture } from "@/lib/utils/__fixtures__/recipeDerivedFixtures";
+import { calcABV } from "@meadtools/core/gravity";
+import {
+  backsweetenedMetricRecipeFixture,
+  traditionalRecipeFixture
+} from "@/lib/utils/__fixtures__/recipeDerivedFixtures";
 import { buildBrewRecipeStageData } from "@/lib/utils/buildBrewRecipeStageData";
 import type { RecipeData } from "@/types/recipeData";
 
@@ -33,4 +37,77 @@ test("renders an existing V2 snapshot that predates newly required nested fields
   assert.equal(stageData.planned.ingredients[1]?.name, "Wildflower Honey");
   assert.ok(stageData.derived);
   assert.ok(stageData.derived.gravity.ogPrimary > 1);
+});
+
+test("uses a recorded post-secondary volume as the measured total for ABV", () => {
+  const stageData = buildBrewRecipeStageData({
+    recipeSnapshot: {
+      id: 2,
+      name: "Backsweetened mead",
+      version: 2,
+      dataV2: backsweetenedMetricRecipeFixture,
+      snapshottedAt: "2026-01-01T00:00:00.000Z"
+    },
+    currentVolumeLiters: 5,
+    latestGravity: 1.01,
+    entries: [
+      {
+        id: "og",
+        datetime: "2026-01-01T00:00:00.000Z",
+        type: "GRAVITY",
+        title: "Original gravity",
+        note: null,
+        gravity: 1.1,
+        data: { readingRole: "OG", source: "measured" }
+      },
+      {
+        id: "fg",
+        datetime: "2026-01-02T00:00:00.000Z",
+        type: "GRAVITY",
+        title: "Final gravity",
+        note: null,
+        gravity: 1.01,
+        data: { readingRole: "FG", source: "measured" }
+      },
+      {
+        id: "primary-volume",
+        datetime: "2026-01-03T00:00:00.000Z",
+        type: "VOLUME",
+        title: "Volume recorded",
+        note: null,
+        gravity: null,
+        data: { liters: 4 }
+      },
+      {
+        id: "cherry",
+        datetime: "2026-01-04T00:00:00.000Z",
+        type: "ADDITION",
+        title: "Cherry Juice",
+        note: null,
+        gravity: null,
+        data: {
+          kind: "INGREDIENT",
+          source: "recipe_ingredient",
+          name: "Cherry Juice",
+          amount: 0.75,
+          unit: "L",
+          recipeIngredientId: "metric-cherry",
+          meta: { stage: "SECONDARY" }
+        }
+      },
+      {
+        id: "measured-secondary-volume",
+        datetime: "2026-01-05T00:00:00.000Z",
+        type: "VOLUME",
+        title: "Volume recorded",
+        note: null,
+        gravity: null,
+        data: { liters: 5 }
+      }
+    ]
+  });
+
+  const expectedAbv = (calcABV(1.1, 1.01) * 4) / 5;
+  assert.ok(stageData.actual.currentAbv != null);
+  assert.ok(Math.abs(stageData.actual.currentAbv - expectedAbv) < 0.000001);
 });

--- a/apps/web/lib/utils/buildBrewRecipeStageData.ts
+++ b/apps/web/lib/utils/buildBrewRecipeStageData.ts
@@ -29,6 +29,7 @@ import {
 } from "@meadtools/core/recipe";
 import { calcABV, toSG } from "@meadtools/core/gravity";
 import { parseNumber } from "@/lib/utils/validateInput";
+import { getMeasuredSecondaryVolumeState } from "@/lib/brews/stabilizerVolume";
 
 type RecipeDerivedApiResponse = CoreRecipeDerivedApiResponse<RecipeData>;
 
@@ -753,6 +754,18 @@ export function buildBrewRecipeStageData(args: {
     secondaryIngredients,
     additionsByRecipeIngredientId
   });
+  const secondaryIngredientIds = secondaryIngredients
+    .filter((line) => (line.name ?? "").trim())
+    .map((line) => String(line.lineId));
+  const measuredSecondaryVolume = getMeasuredSecondaryVolumeState({
+    entries,
+    secondaryIngredientIds,
+    allSecondaryIngredientsLogged:
+      secondaryIngredientIds.length > 0 &&
+      secondaryIngredientIds.every((lineId) =>
+        Boolean(latestAddition(additionsByRecipeIngredientId[lineId]))
+      )
+  });
   const recipeFg = parseNumber(derivedResponse.recipeData.fg ?? "");
   const baseOg =
     typeof originalGravity?.gravity === "number" && Number.isFinite(originalGravity.gravity)
@@ -771,7 +784,10 @@ export function buildBrewRecipeStageData(args: {
       : null;
   const currentAbv =
     actualCurrentVolume && typeof baseAbv === "number" && Number.isFinite(baseAbv)
-      ? (baseAbv * actualCurrentVolume) / (actualCurrentVolume + secondaryVolumeL)
+      ? measuredSecondaryVolume.hasMeasuredVolume &&
+          measuredSecondaryVolume.baseVolumeL != null
+        ? (baseAbv * measuredSecondaryVolume.baseVolumeL) / actualCurrentVolume
+        : (baseAbv * actualCurrentVolume) / (actualCurrentVolume + secondaryVolumeL)
       : null;
 
   return {

--- a/apps/web/next.openapi.json
+++ b/apps/web/next.openapi.json
@@ -113,7 +113,8 @@
     "/cron/*",
     "/auth/oauth-callback",
     "/auth/start-oauth-flow",
-    "/auth/{nextauth}"
+    "/auth/{nextauth}",
+    "/admin/maintenance/rebuild-estimated-abv"
   ],
   "debug": false
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "start": "next start",
     "start:i18n": "npm --prefix ../.. run i18n:pull && next start",
     "test": "node --import tsx --test lib/brews/*.test.ts lib/utils/*.test.ts",
+    "brew:rebuild-abv": "tsx scripts/rebuildEstimatedAbv.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "openapi:generate": "next-openapi-gen generate && node ../../scripts/normalize-zod-openapi.mjs",
     "lint": "next lint",

--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -6571,6 +6571,25 @@
         }
       }
     },
+    "/admin/maintenance/rebuild-estimated-abv": {
+      "post": {
+        "operationId": "post-admin-maintenance-rebuild-estimated-abv",
+        "summary": "",
+        "description": "",
+        "tags": [
+          "Admin"
+        ],
+        "parameters": [],
+        "responses": {
+          "400": {
+            "$ref": "#/components/responses/400"
+          },
+          "500": {
+            "$ref": "#/components/responses/500"
+          }
+        }
+      }
+    },
     "/admin/users/{id}/password-reset": {
       "post": {
         "operationId": "post-admin-users-{id}-password-reset",

--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -6571,25 +6571,6 @@
         }
       }
     },
-    "/admin/maintenance/rebuild-estimated-abv": {
-      "post": {
-        "operationId": "post-admin-maintenance-rebuild-estimated-abv",
-        "summary": "",
-        "description": "",
-        "tags": [
-          "Admin"
-        ],
-        "parameters": [],
-        "responses": {
-          "400": {
-            "$ref": "#/components/responses/400"
-          },
-          "500": {
-            "$ref": "#/components/responses/500"
-          }
-        }
-      }
-    },
     "/admin/users/{id}/password-reset": {
       "post": {
         "operationId": "post-admin-users-{id}-password-reset",

--- a/apps/web/scripts/rebuildEstimatedAbv.ts
+++ b/apps/web/scripts/rebuildEstimatedAbv.ts
@@ -1,0 +1,90 @@
+type BackfillOptions = {
+  all: boolean;
+  brewIds: string[];
+  execute: boolean;
+};
+
+export {};
+
+function usage() {
+  return [
+    "Usage:",
+    "  npm run brew:rebuild-abv --workspace @meadtools/web -- --brew-id <brew-id> [--execute]",
+    "  npm run brew:rebuild-abv --workspace @meadtools/web -- --all [--execute]",
+    "",
+    "The command defaults to a dry run. It uses DATABASE_URL from the current environment."
+  ].join("\n");
+}
+
+function parseOptions(args: string[]): BackfillOptions {
+  const options: BackfillOptions = { all: false, brewIds: [], execute: false };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--all") {
+      options.all = true;
+      continue;
+    }
+    if (arg === "--brew-id") {
+      const brewId = args[index + 1];
+      if (!brewId || brewId.startsWith("--")) throw new Error(usage());
+      options.brewIds.push(brewId);
+      index += 1;
+      continue;
+    }
+    if (arg === "--execute") {
+      options.execute = true;
+      continue;
+    }
+    if (arg === "--dry-run") continue;
+    if (arg === "--help" || arg === "-h") {
+      console.log(usage());
+      process.exit(0);
+    }
+    throw new Error(`Unknown option: ${arg}\n\n${usage()}`);
+  }
+
+  if (options.all === (options.brewIds.length > 0)) throw new Error(usage());
+  return options;
+}
+
+const options = parseOptions(process.argv.slice(2));
+
+if (!process.env.DATABASE_URL) {
+  throw new Error(
+    "DATABASE_URL must be set by the target environment before running this backfill."
+  );
+}
+
+const [{ default: prisma }, { rebuildEstimatedAbvEntriesForBrew }] =
+  await Promise.all([
+    import("../lib/prisma"),
+    import("../lib/db/brews")
+  ]);
+
+try {
+  const brewIds = options.all
+    ? (
+        await prisma.brews.findMany({
+          where: { user_id: { not: null } },
+          select: { id: true },
+          orderBy: { id: "asc" }
+        })
+      ).map((brew) => brew.id)
+    : options.brewIds;
+
+  if (!options.execute) {
+    console.log(
+      `Dry run: ${brewIds.length} brew${brewIds.length === 1 ? "" : "s"} would have estimated ABV entries rebuilt. Re-run with --execute to write changes.`
+    );
+  } else {
+    for (const brewId of brewIds) {
+      await rebuildEstimatedAbvEntriesForBrew(brewId);
+    }
+    console.log(
+      `Rebuilt estimated ABV entries for ${brewIds.length} brew${brewIds.length === 1 ? "" : "s"}.`
+    );
+  }
+} finally {
+  await prisma.$disconnect();
+}


### PR DESCRIPTION
## Summary

Promotes the preview-validated brew tracking improvements to `main`:

- prompts secondary brews to record the measured volume after stabilizers, including the estimated adjusted volume
- recalculates supplemental stabilizer prompts and dilution-aware estimated ABV from measured volumes
- uses the brew’s preferred volume unit and consistent three-decimal formatting in charts
- adds an Admin maintenance tool for safely rebuilding derived estimated-ABV entries in batches

## Safety

The maintenance rebuild only replaces hidden derived `abv_estimate` entries. Logged brew history remains unchanged. The internal maintenance endpoint is excluded from the external OpenAPI contract.

## Validation

- full workspace typecheck
- full workspace test suite
- OpenAPI generation and API-contract parity tests
- preview deployment
