### PR TITLE
Add nutrient presets and organic multiplier support

### DIFF
--- a/apps/web/app/api/nutrient-presets/route.ts
+++ b/apps/web/app/api/nutrient-presets/route.ts
@@ -1,0 +1,27 @@
+import prisma from "@/lib/prisma";
+import { NextResponse } from "next/server";
+
+/**
+ * List nutrient presets for the Other Nutrient autofill input.
+ * @description Returns curated nutrient presets ordered by product name. Selecting a preset populates the existing Other nutrient inputs.
+ * @response 200:NutrientPresetListResponse
+ * @responseSet none
+ * @add 500:NutrientPresetFetchErrorResponse
+ * @tag Nutrients
+ * @openapi
+ */
+export async function GET() {
+  try {
+    const presets = await prisma.nutrient_presets.findMany({
+      orderBy: { name: "asc" }
+    });
+
+    return NextResponse.json(presets);
+  } catch (error) {
+    console.error("Failed to fetch nutrient presets:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch nutrient presets" },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/components/nutrientCalc/NutrientSelector.tsx
+++ b/apps/web/components/nutrientCalc/NutrientSelector.tsx
@@ -36,10 +36,11 @@ import {
 
 import { useNutrients } from "@/components/providers/NutrientProvider";
 import type { NutrientKey } from "@/types/nutrientData";
+import SearchableInput from "../ui/SearchableInput";
 
 export default function NutrientSelector() {
   const { t } = useTranslation();
-  const { data, actions } = useNutrients();
+  const { data, actions, catalog } = useNutrients();
 
   const warnNumberOfAdditions =
     Number(data.inputs.sg) > 1.08 && data.inputs.numberOfAdditions === "1";
@@ -93,19 +94,18 @@ export default function NutrientSelector() {
 
             {/* Name */}
             <label className="grid gap-1 col-span-2">
-              <span className="text-sm font-medium">
+              <span className="flex items-center sm:gap-1 text-sm font-medium">
                 {t("sortLabels.name")}
+                <Tooltip body={t("other.nutrientPresetHelp")} />
               </span>
 
-              <InputGroup className="h-12">
-                <InputGroupInput
-                  value={data.settings.other.name}
-                  onChange={(e) => actions.setOtherNutrientName(e.target.value)}
-                  inputMode="text"
-                  onFocus={(e) => e.target.select()}
-                  className="text-lg"
-                />
-              </InputGroup>
+              <SearchableInput
+                items={catalog.nutrientPresetList}
+                query={data.settings.other.name}
+                setQuery={actions.setOtherNutrientName}
+                keyName="name"
+                onSelect={actions.selectOtherNutrientPreset}
+              />
             </label>
 
             {/* YAN Contribution */}
@@ -158,6 +158,17 @@ export default function NutrientSelector() {
                   {t("units.gpl")}
                 </InputGroupAddon>
               </InputGroup>
+            </label>
+
+            <label className="flex items-center gap-2 col-span-2">
+              <Switch
+                checked={data.settings.other.usesOrganicMultiplier}
+                onCheckedChange={actions.setOtherUsesOrganicMultiplier}
+              />
+              <span className="flex items-center gap-1 text-sm font-medium">
+                {t("other.organicMultiplier")}
+                <Tooltip body={t("other.organicMultiplierHelp")} />
+              </span>
             </label>
           </div>
         )}

--- a/apps/web/components/providers/NutrientProvider.tsx
+++ b/apps/web/components/providers/NutrientProvider.tsx
@@ -14,6 +14,8 @@ import {
   scheduleFromSelected
 } from "@/types/nutrientData";
 import { useYeastsQuery } from "@/hooks/reactQuery/useYeastsQuery";
+import { useNutrientPresetsQuery } from "@/hooks/reactQuery/useNutrientPresetsQuery";
+import type { NutrientPreset } from "@/types/nutrientTypes";
 import { toBrix } from "@meadtools/core/gravity";
 import { parseNumber } from "@/lib/utils/validateInput";
 import {
@@ -35,6 +37,7 @@ type NutrientUI = {
     }[]; // replace with your Yeast type
     loadingYeasts: boolean;
     brands: string[];
+    nutrientPresetList: NutrientPreset[];
   };
 
   // actions: add later
@@ -51,6 +54,8 @@ type NutrientUI = {
     ) => void;
     toggleNutrient: (key: NutrientKey) => void;
     setOtherNutrientName: (name: string) => void;
+    selectOtherNutrientPreset: (preset: NutrientPreset) => void;
+    setOtherUsesOrganicMultiplier: (value: boolean) => void;
     setOtherYanContribution: (v: string) => void; // settings.yanContribution.other
     setMaxGpl: (key: NutrientKey, v: string) => void; // settings.maxGpl[key]
     setYanContribution: (key: NutrientKey, v: string) => void; // settings.yanContribution[key]
@@ -86,8 +91,11 @@ type ControlledProps = Extract<Props, { mode: "controlled" }>;
 const isControlledProps = (p: Props): p is ControlledProps =>
   p.mode === "controlled";
 
+const defaultOtherNutrientMaxGpl = "3";
+
 export function NutrientProvider(props: Props) {
   const { data: yeastList = [], isPending: loadingYeasts } = useYeastsQuery();
+  const { data: nutrientPresetList = [] } = useNutrientPresetsQuery();
   const brands = useMemo(
     () => Array.from(new Set(yeastList.map((y) => y.brand))).sort(),
     [yeastList]
@@ -265,6 +273,45 @@ export function NutrientProvider(props: Props) {
         }));
       },
 
+      selectOtherNutrientPreset: (preset) => {
+        commit((prev) => ({
+          ...prev,
+          settings: {
+            ...prev.settings,
+            yanContribution: {
+              ...prev.settings.yanContribution,
+              other: String(preset.yan_ppm_per_gpl)
+            },
+            maxGpl: {
+              ...prev.settings.maxGpl,
+              other:
+                preset.max_gpl == null
+                  ? defaultOtherNutrientMaxGpl
+                  : String(preset.max_gpl)
+            },
+            maxGplTouched: true,
+            other: {
+              ...prev.settings.other,
+              name: preset.name,
+              usesOrganicMultiplier: preset.organic_multiplier
+            }
+          }
+        }));
+      },
+
+      setOtherUsesOrganicMultiplier: (value) => {
+        commit((prev) => ({
+          ...prev,
+          settings: {
+            ...prev.settings,
+            other: {
+              ...prev.settings.other,
+              usesOrganicMultiplier: value
+            }
+          }
+        }));
+      },
+
       setOtherYanContribution: (v) => {
         commit((prev) => ({
           ...prev,
@@ -375,7 +422,9 @@ export function NutrientProvider(props: Props) {
         parseNumber(data.settings.yanContribution.fermO) * organicMultiplier,
       fermK: parseNumber(data.settings.yanContribution.fermK),
       dap: parseNumber(data.settings.yanContribution.dap),
-      other: parseNumber(data.settings.yanContribution.other)
+      other:
+        parseNumber(data.settings.yanContribution.other) *
+        (data.settings.other.usesOrganicMultiplier ? organicMultiplier : 1)
     };
 
     const enabled = data.selected.selectedNutrients;
@@ -432,6 +481,7 @@ export function NutrientProvider(props: Props) {
     data.selected.schedule,
     data.selected.selectedNutrients,
     data.settings.yanContribution,
+    data.settings.other.usesOrganicMultiplier,
     data.adjustments.providedYanPpm,
     data.settings.maxGpl.fermO,
     data.settings.maxGpl.fermK,
@@ -517,7 +567,7 @@ export function NutrientProvider(props: Props) {
     () => ({
       data,
       derived,
-      catalog: { yeastList, loadingYeasts, brands },
+      catalog: { yeastList, loadingYeasts, brands, nutrientPresetList },
       actions,
       meta: { isDirty, markSaved, hydrate, reset }
     }),
@@ -531,7 +581,8 @@ export function NutrientProvider(props: Props) {
       reset,
       yeastList,
       loadingYeasts,
-      brands
+      brands,
+      nutrientPresetList
     ]
   );
 

--- a/apps/web/hooks/reactQuery/useNutrientPresetsQuery.ts
+++ b/apps/web/hooks/reactQuery/useNutrientPresetsQuery.ts
@@ -1,0 +1,23 @@
+import { qk } from "@/lib/db/queryKeys";
+import type { NutrientPreset } from "@/types/nutrientTypes";
+import { useQuery } from "@tanstack/react-query";
+
+export function useNutrientPresetsQuery() {
+  return useQuery<NutrientPreset[]>({
+    queryKey: qk.nutrientPresets,
+    queryFn: async () => {
+      const res = await fetch("/api/nutrient-presets");
+
+      if (!res.ok) {
+        const err: Error & { status?: number } = new Error(
+          `HTTP ${res.status}`
+        );
+        err.status = res.status;
+        throw err;
+      }
+
+      return (await res.json()) as NutrientPreset[];
+    },
+    staleTime: 5 * 60 * 1000
+  });
+}

--- a/apps/web/lib/db/queryKeys.ts
+++ b/apps/web/lib/db/queryKeys.ts
@@ -21,6 +21,7 @@ export const qk = {
 
   additives: ["additives"] as const,
   yeasts: ["yeasts"] as const,
+  nutrientPresets: ["nutrient-presets"] as const,
 
   // Hydrometer dashboard
   hydrometerInfo: ["hydrometer", "info"] as const,

--- a/apps/web/lib/utils/__fixtures__/recipeDerivedFixtures.ts
+++ b/apps/web/lib/utils/__fixtures__/recipeDerivedFixtures.ts
@@ -105,7 +105,7 @@ export const traditionalRecipeFixture: RecipeData = {
         other: "0"
       },
       maxGplTouched: false,
-      other: { name: "" }
+      other: { name: "", usesOrganicMultiplier: false }
     },
     adjustments: {
       adjustAllowed: false,
@@ -216,7 +216,7 @@ export const backsweetenedMetricRecipeFixture: RecipeData = {
         other: "0"
       },
       maxGplTouched: false,
-      other: { name: "" }
+      other: { name: "", usesOrganicMultiplier: false }
     },
     adjustments: {
       adjustAllowed: true,

--- a/apps/web/lib/utils/buildBrewRecipeStageData.test.ts
+++ b/apps/web/lib/utils/buildBrewRecipeStageData.test.ts
@@ -7,7 +7,7 @@ import {
   traditionalRecipeFixture
 } from "@/lib/utils/__fixtures__/recipeDerivedFixtures";
 import { buildBrewRecipeStageData } from "@/lib/utils/buildBrewRecipeStageData";
-import type { RecipeData } from "@/types/recipeData";
+import { isRecipeData, type RecipeData } from "@/types/recipeData";
 
 test("renders an existing V2 snapshot that predates newly required nested fields", () => {
   const existingSnapshotData = structuredClone(traditionalRecipeFixture) as RecipeData;
@@ -37,6 +37,34 @@ test("renders an existing V2 snapshot that predates newly required nested fields
   assert.equal(stageData.planned.ingredients[1]?.name, "Wildflower Honey");
   assert.ok(stageData.derived);
   assert.ok(stageData.derived.gravity.ogPrimary > 1);
+});
+
+test("accepts copied recipes and brew snapshots without the organic multiplier", () => {
+  const existingSnapshotData = structuredClone(traditionalRecipeFixture) as RecipeData;
+  const otherNutrient = existingSnapshotData.nutrients!.settings.other as {
+    name: string;
+    usesOrganicMultiplier?: boolean;
+  };
+  delete otherNutrient.usesOrganicMultiplier;
+
+  // Recipe creation validates this same shape when a user saves a copy.
+  assert.equal(isRecipeData(existingSnapshotData), true);
+
+  const stageData = buildBrewRecipeStageData({
+    recipeSnapshot: {
+      id: 3,
+      name: "Existing recipe copy",
+      version: 2,
+      dataV2: existingSnapshotData,
+      snapshottedAt: "2026-01-01T00:00:00.000Z"
+    },
+    currentVolumeLiters: null,
+    latestGravity: null,
+    entries: []
+  });
+
+  assert.ok(stageData.planned.nutrientPlan);
+  assert.ok(Number.isFinite(stageData.planned.nutrientPlan.derived.targetYanPpm));
 });
 
 test("uses a recorded post-secondary volume as the measured total for ABV", () => {

--- a/apps/web/lib/utils/migrateLegacyData.ts
+++ b/apps/web/lib/utils/migrateLegacyData.ts
@@ -193,7 +193,7 @@ export function migrateLegacyRecipeToV2(recipe: RecipeApiResponse): RecipeData {
         selected: nutrientsSelected
       }),
       maxGplTouched: false,
-      other: { name: "" }
+      other: { name: "", usesOrganicMultiplier: false }
     },
     adjustments: {
       adjustAllowed: false,

--- a/apps/web/prisma/migrations/20260719000000_add_nutrient_presets/migration.sql
+++ b/apps/web/prisma/migrations/20260719000000_add_nutrient_presets/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "nutrient_presets" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "name" TEXT NOT NULL,
+    "yan_ppm_per_gpl" DOUBLE PRECISION NOT NULL,
+    "max_gpl" DOUBLE PRECISION,
+    "organic_multiplier" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "nutrient_presets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "nutrient_presets_name_key" ON "nutrient_presets"("name");
+
+-- Seed curated Other Nutrient presets in every environment.
+INSERT INTO "nutrient_presets" ("id", "name", "yan_ppm_per_gpl", "max_gpl", "organic_multiplier")
+VALUES
+    (gen_random_uuid(), 'Wyeast Wine Nutrient Blend', 129, NULL, false),
+    (gen_random_uuid(), 'Boiled Bread Yeast (BBY)', 13.333333333333334, 7.5, true),
+    (gen_random_uuid(), 'Mangrove Jack''s Mead Yeast Nutrient', 40, NULL, true),
+    (gen_random_uuid(), 'Mangrove Jack''s Wine Yeast Nutrient', 140, NULL, false),
+    (gen_random_uuid(), 'Vinoferm Nutrivit', 144, 0.3, false)
+ON CONFLICT ("name") DO NOTHING;

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -188,6 +188,14 @@ model additives {
   unit       additive_unit
 }
 
+model nutrient_presets {
+  id                 String  @id @default(uuid()) @db.Uuid
+  name               String  @unique
+  yan_ppm_per_gpl    Float
+  max_gpl            Float?
+  organic_multiplier Boolean @default(false)
+}
+
 model Account {
   id                String  @id @default(cuid())
   userId            String

--- a/apps/web/prisma/seed-data/nutrient_presets.json
+++ b/apps/web/prisma/seed-data/nutrient_presets.json
@@ -1,0 +1,29 @@
+[
+  {
+    "name": "Wyeast Wine Nutrient Blend",
+    "yan_ppm_per_gpl": 129,
+    "organic_multiplier": false
+  },
+  {
+    "name": "Boiled Bread Yeast (BBY)",
+    "yan_ppm_per_gpl": 13.333333333333334,
+    "max_gpl": 7.5,
+    "organic_multiplier": true
+  },
+  {
+    "name": "Mangrove Jack's Mead Yeast Nutrient",
+    "yan_ppm_per_gpl": 40,
+    "organic_multiplier": true
+  },
+  {
+    "name": "Mangrove Jack's Wine Yeast Nutrient",
+    "yan_ppm_per_gpl": 140,
+    "organic_multiplier": false
+  },
+  {
+    "name": "Vinoferm Nutrivit",
+    "yan_ppm_per_gpl": 144,
+    "max_gpl": 0.3,
+    "organic_multiplier": false
+  }
+]

--- a/apps/web/prisma/seed.ts
+++ b/apps/web/prisma/seed.ts
@@ -1,6 +1,7 @@
 import INGREDIENTS from "./seed-data/ingredients_rows.json";
 import YEASTS from "./seed-data/yeasts_rows.json";
 import ADDITIVES from "./seed-data/additives.json";
+import NUTRIENT_PRESETS from "./seed-data/nutrient_presets.json";
 import RECIPES from "./seed-data/recipes_rows.json";
 import COMMENTS from "./seed-data/comments_rows.json";
 import RATINGS from "./seed-data/recipe_ratings_rows.json";
@@ -72,6 +73,9 @@ async function main() {
   // @ts-expect-error additives in correct type format, json pulled directly from DB
   await prisma.additives.createMany({ data: ADDITIVES });
   console.log("Additives seeded.");
+
+  await prisma.nutrient_presets.createMany({ data: NUTRIENT_PRESETS });
+  console.log("Nutrient presets seeded.");
 
   const hydrometerSeedUser =
     users.find((user) => user.role === "user") ?? users[0];
@@ -383,6 +387,7 @@ async function clearDb() {
   await prisma.ingredients.deleteMany();
   await prisma.yeasts.deleteMany();
   await prisma.additives.deleteMany();
+  await prisma.nutrient_presets.deleteMany();
 
   await prisma.users.deleteMany();
 

--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -2241,6 +2241,8 @@
       "CreateIngredientFailureErrorResponse": {
         "$ref": "#/components/schemas/ApiErrorResponse"
       },
+      "NutrientPresetListResponse": {},
+      "NutrientPresetFetchErrorResponse": {},
       "PublicRecipeBrewResponse": {
         "type": "object",
         "properties": {
@@ -9793,6 +9795,39 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/DeleteIngredientFailureErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nutrient-presets": {
+      "get": {
+        "operationId": "get-nutrient-presets",
+        "summary": "List nutrient presets for the Other Nutrient autofill input.",
+        "description": "Returns curated nutrient presets ordered by product name. Selecting a preset populates the existing Other nutrient inputs.",
+        "tags": [
+          "Nutrients"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NutrientPresetListResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NutrientPresetFetchErrorResponse"
                 }
               }
             }

--- a/apps/web/types/nutrientData.ts
+++ b/apps/web/types/nutrientData.ts
@@ -40,7 +40,7 @@ export type NutrientSettings = {
   yanContribution: Record<NutrientKey, NumericInputString>;
   maxGpl: Record<NutrientKey, NumericInputString>;
   maxGplTouched: boolean;
-  other: { name: string };
+  other: { name: string; usesOrganicMultiplier: boolean };
 };
 
 export type NutrientInputs = {
@@ -147,7 +147,7 @@ export const initialNutrientData = (
         other: "0"
       },
       maxGplTouched: false,
-      other: { name: "" }
+      other: { name: "", usesOrganicMultiplier: false }
     },
 
     adjustments: {

--- a/apps/web/types/nutrientTypes.ts
+++ b/apps/web/types/nutrientTypes.ts
@@ -33,6 +33,14 @@ export type Yeast = {
   high_temp: string;
 };
 
+export type NutrientPreset = {
+  id: string;
+  name: string;
+  yan_ppm_per_gpl: number;
+  max_gpl: number | null;
+  organic_multiplier: boolean;
+};
+
 export type FullNutrientData = {
   inputs: {
     volume: string;

--- a/docs/domain/api-contract.md
+++ b/docs/domain/api-contract.md
@@ -10,11 +10,11 @@ from them.
 Before the Zod migration, `apps/web/public/openapi.json` was regenerated with
 `next-openapi-gen` and captured as the endpoint compatibility baseline.
 
-- Paths: 52
+- Paths: 54
 - Canonical endpoint-path SHA-256:
-  `4610d8687942691b4d6a411907359deca3fb67c00a6f34dd7acc8ad3ee38076c`
+  `b04650619e96df83b3f5eba864c44cd4599039be01125b2b0b4966aaa068880a`
 - Reviewed Zod document SHA-256:
-  `1c0c6673a150cb99377bfe86772b604c4911aad4347a808c7688f7090b43a562`
+  `b5da53654bc24a9c2b5016f18f5fcbba85864e1b6f2590fe72cbabcc10a6d7af`
 
 The parity test preserves the complete pre-migration `paths` object: routes,
 methods, parameters, descriptions, response statuses, and component references.
@@ -25,9 +25,10 @@ significant.
 
 The native API readiness update intentionally adds `client_entry_id` to
 `CreateBrewEntryRequestBody` and HTTP 409 documentation to the create-entry
-operation. The endpoint parity test removes only that new response before
-comparing against the pre-migration paths hash, proving all earlier endpoint
-documentation remains unchanged.
+operation. The nutrient-preset update intentionally adds the
+`/nutrient-presets` endpoint. The endpoint parity test removes these approved
+additions before comparing against the pre-migration paths hash, proving all
+earlier endpoint documentation remains unchanged.
 
 Run:
 

--- a/packages/api-contract/test/openapi-parity.test.ts
+++ b/packages/api-contract/test/openapi-parity.test.ts
@@ -4,7 +4,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const baselineCanonicalSha256 =
-  "6c5d770338c9d2bf1bbf02bc7d52d50601493bb113b75505a3719c1f33b828fc";
+  "b5da53654bc24a9c2b5016f18f5fcbba85864e1b6f2590fe72cbabcc10a6d7af";
 const preZodPathsCanonicalSha256 =
   "5474c09299fc8dbcd5bb25a54559d9bd19cca3dec0b0ee22f05f302dab0a7aa3";
 
@@ -37,7 +37,7 @@ test("generated OpenAPI document matches the reviewed Zod baseline", async () =>
   );
 });
 
-test("idempotency contract preserves all pre-existing endpoint documentation", async () => {
+test("approved API additions preserve all pre-existing endpoint documentation", async () => {
   const documentUrl = new URL(
     "../../../apps/web/public/openapi.json",
     import.meta.url
@@ -48,11 +48,12 @@ test("idempotency contract preserves all pre-existing endpoint documentation", a
       { post?: { responses?: Record<string, unknown> } }
     >;
   };
-  const pathsWithoutIdempotencyConflict = structuredClone(document.paths);
-  delete pathsWithoutIdempotencyConflict["/brews/{brew_id}/entries"]?.post
+  const pathsWithoutApprovedAdditions = structuredClone(document.paths);
+  delete pathsWithoutApprovedAdditions["/brews/{brew_id}/entries"]?.post
     ?.responses?.["409"];
+  delete pathsWithoutApprovedAdditions["/nutrient-presets"];
   const canonicalPaths = JSON.stringify(
-    sortJson(pathsWithoutIdempotencyConflict)
+    sortJson(pathsWithoutApprovedAdditions)
   );
   const actualHash = createHash("sha256")
     .update(canonicalPaths)

--- a/packages/core/src/nutrients.ts
+++ b/packages/core/src/nutrients.ts
@@ -45,7 +45,7 @@ export type NutrientData = {
     yanContribution: Record<NutrientKey, string>;
     maxGpl: Record<NutrientKey, string>;
     maxGplTouched: boolean;
-    other: { name: string };
+    other: { name: string; usesOrganicMultiplier: boolean };
   };
   adjustments: {
     adjustAllowed: boolean;
@@ -138,7 +138,7 @@ export function initialNutrientData(
         other: "0"
       },
       maxGplTouched: false,
-      other: { name: "" }
+      other: { name: "", usesOrganicMultiplier: false }
     },
     adjustments: {
       adjustAllowed: false,
@@ -234,7 +234,9 @@ function calculateAutoProvidedYanPpm(data: NutrientData) {
     fermO: parseNumber(data.settings.yanContribution.fermO) * organicMultiplier,
     fermK: parseNumber(data.settings.yanContribution.fermK),
     dap: parseNumber(data.settings.yanContribution.dap),
-    other: parseNumber(data.settings.yanContribution.other)
+    other:
+      parseNumber(data.settings.yanContribution.other) *
+      (data.settings.other.usesOrganicMultiplier ? organicMultiplier : 1)
   };
   const provided: Record<NutrientKey, string> = {
     fermO: "0",
@@ -322,7 +324,10 @@ export function calculateNutrientDerivedState(
     nutrientKeys.map((key) => {
       const baseContribution = parseNumber(data.settings.yanContribution[key]);
       const contribution =
-        key === "fermO" ? baseContribution * organicMultiplier : baseContribution;
+        key === "fermO" ||
+        (key === "other" && data.settings.other.usesOrganicMultiplier)
+          ? baseContribution * organicMultiplier
+          : baseContribution;
       const ppm = Math.max(0, providedYanPpm[key] || 0);
       return [key, (contribution === 0 ? 0 : ppm / contribution) * volume * litersPerUnit];
     })

--- a/packages/core/test/nutrients.test.ts
+++ b/packages/core/test/nutrients.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  calculateEffectiveNutrientData,
+  calculateNutrientDerivedState,
+  initialNutrientData
+} from "../src/nutrients";
+
+function totalNutrientGrams(
+  goFermType: "Go-Ferm" | "none",
+  useBoiledBreadYeast: boolean
+) {
+  const data = initialNutrientData();
+  data.inputs.goFermType = goFermType;
+  data.inputs.sg = "1.1";
+  data.selected.selectedNutrients = {
+    fermO: !useBoiledBreadYeast,
+    fermK: false,
+    dap: false,
+    other: useBoiledBreadYeast
+  };
+  data.selected.schedule = useBoiledBreadYeast ? "other" : "tosna";
+
+  if (useBoiledBreadYeast) {
+    data.settings.maxGplTouched = true;
+    data.settings.maxGpl.other = "7.5";
+    data.settings.yanContribution.other = "13.333333333333334";
+    data.settings.other = {
+      name: "Boiled Bread Yeast (BBY)",
+      usesOrganicMultiplier: true
+    };
+  }
+
+  const effectiveData = calculateEffectiveNutrientData(data);
+  const key = useBoiledBreadYeast ? "other" : "fermO";
+  return calculateNutrientDerivedState(effectiveData).nutrientAdditions
+    .totalGrams[key];
+}
+
+test("organic Other nutrients use the Fermaid O effectiveness multiplier", () => {
+  for (const goFermType of ["Go-Ferm", "none"] as const) {
+    const fermaidOGrams = totalNutrientGrams(goFermType, false);
+    const boiledBreadYeastGrams = totalNutrientGrams(goFermType, true);
+
+    assert.ok(
+      Math.abs(boiledBreadYeastGrams - fermaidOGrams * 3) < 1e-10,
+      `${goFermType} should keep BBY at three times the Fermaid O dose`
+    );
+  }
+});

--- a/packages/i18n/locales/de/default.json
+++ b/packages/i18n/locales/de/default.json
@@ -153,10 +153,31 @@
     "ingredients": {
       "add": "Zutat hinzufügen"
     },
+    "maintenance": {
+      "description": "Sichere administrative Wartungsaufgaben in kleinen Batches ausführen.",
+      "estimatedAbv": {
+        "brewId": "Brauvorgangs-ID",
+        "brewIdHelp": "Füge die Brauvorgangs-ID ein, um nur diesen Brauvorgang neu zu berechnen.",
+        "complete": "Geschätzte ABV-Einträge neu berechnet.",
+        "confirmDescription": "Dadurch werden abgeleitete Einträge für den geschätzten ABV von {{count}} Brauvorgängen ersetzt. Erfasste Volumen, Zugaben und Messwerte bleiben unverändert.",
+        "confirmTitle": "Geschätzte ABV-Einträge neu berechnen?",
+        "description": "Erstellt abgeleitete Zeitachseneinträge für den geschätzten ABV anhand des aktuellen Brauverlaufs neu. Erfasste Braudaten werden nicht verändert.",
+        "failed": "Geschätzte ABV-Einträge konnten nicht neu berechnet werden.",
+        "preview": "Vorschau",
+        "progress": "{{processed}} von {{total}} Brauvorgängen neu berechnet.",
+        "ready": "Bereit, die Schätzwerte für {{count}} Brauvorgänge neu zu berechnen.",
+        "rebuild": "Schätzwerte neu berechnen",
+        "scopeAll": "Alle Brauvorgänge",
+        "scopeBrew": "Ein Brauvorgang",
+        "title": "Geschätzten ABV neu berechnen"
+      },
+      "title": "Wartung"
+    },
     "nav": {
       "additives": "Zusatzstoffe",
       "brews": "Ansätze",
       "ingredients": "Zutaten",
+      "maintenance": "Wartung",
       "overview": "Übersicht",
       "recipes": "Rezepte",
       "users": "Benutzer",
@@ -642,6 +663,7 @@
       "confirmPackageTitle": "In die Verpackung überführen?",
       "currentVolume": "Aktuelles Volumen",
       "dilutedAbv": "Verdünnte ABV",
+      "estimatedVolumeAfterStabilizers": "Geschätztes Volumen nach Zugaben in der Sekundärgärung",
       "focusReady": "Bereit für die Umstellung auf die Massenreifung",
       "focusTracking": "Sekundäre Zusätze und Volumen aktuell halten",
       "ingredients": "Sekundärzutaten",
@@ -664,6 +686,8 @@
       "recipeAdditives": "Rezeptzusätze",
       "recipeNotes": "Sekundäre Rezeptnotizen",
       "recipeNoteTitle": "Sekundäre Rezeptnotiz hinzufügen",
+      "recordVolumeAfterStabilizersHelp": "Du hast Stabilisatoren protokolliert. Erfasse jetzt das tatsächliche Volumen – Zugaben in der Sekundärgärung können das Chargenvolumen erhöhen und weitere Stabilisatoren erfordern.",
+      "recordVolumeAfterStabilizersTitle": "Aktualisiertes Volumen erfassen",
       "scaleAdditives": "Skalierungszusätze",
       "scaleSecondaryIngredients": "Skalierung sekundärer Zutaten",
       "secondaryBeforeStabilizersHelp": "Dieses Rezept verwendet Stabilisatoren. Sekundäre Zutaten werden normalerweise nach den Stabilisatoren protokolliert, damit die Dosierung auf aktuellem Volumen und ABV basiert.",
@@ -1360,6 +1384,9 @@
   "other": {
     "detailsHeading": "Weitere Nährwertangaben",
     "label": "Other",
+    "nutrientPresetHelp": "Wähle einen Nährstoff aus der Liste, um seine Werte auszufüllen, oder gib die Angaben für deinen eigenen Nährstoff ein.",
+    "organicMultiplier": "Multiplikator für organischen Stickstoff verwenden",
+    "organicMultiplierHelp": "Wähle dies nur für Nährstoffe, die vollständig aus organischem Stickstoff bestehen.",
     "settingsAdjustValue": "Umschalter für die YAN-Einstellung",
     "settingsProvidedYan": "Bereitgestellt von YAN",
     "settingsTitle": "Nährstoffeinstellungen anpassen",

--- a/packages/i18n/locales/en/default.json
+++ b/packages/i18n/locales/en/default.json
@@ -153,10 +153,31 @@
     "ingredients": {
       "add": "Add ingredient"
     },
+    "maintenance": {
+      "description": "Run safe administrative maintenance tasks in small batches.",
+      "estimatedAbv": {
+        "brewId": "Brew ID",
+        "brewIdHelp": "Paste the brew ID to rebuild only that brew.",
+        "complete": "Estimated ABV entries rebuilt.",
+        "confirmDescription": "This will replace derived estimated-ABV entries for {{count}} brews. Logged volumes, additions, and measurements will remain unchanged.",
+        "confirmTitle": "Rebuild estimated ABV entries?",
+        "description": "Recreates derived estimated-ABV timeline entries from each brew's current history. It does not modify logged brew data.",
+        "failed": "Could not rebuild estimated ABV entries.",
+        "preview": "Preview",
+        "progress": "Rebuilt {{processed}} of {{total}} brews.",
+        "ready": "Ready to rebuild {{count}} brew estimate entries.",
+        "rebuild": "Rebuild estimates",
+        "scopeAll": "All brews",
+        "scopeBrew": "One brew",
+        "title": "Rebuild estimated ABV"
+      },
+      "title": "Maintenance"
+    },
     "nav": {
       "additives": "Additives",
       "brews": "Brews",
       "ingredients": "Ingredients",
+      "maintenance": "Maintenance",
       "overview": "Overview",
       "recipes": "Recipes",
       "users": "Users",
@@ -642,6 +663,7 @@
       "confirmPackageTitle": "Move to packaging?",
       "currentVolume": "Current volume",
       "dilutedAbv": "Diluted ABV",
+      "estimatedVolumeAfterStabilizers": "Estimated volume after secondary additions",
       "focusReady": "Ready to move into bulk aging",
       "focusTracking": "Keep secondary additions and volume current",
       "ingredients": "Secondary ingredients",
@@ -664,6 +686,8 @@
       "recipeAdditives": "Recipe additives",
       "recipeNotes": "Recipe secondary notes",
       "recipeNoteTitle": "Add recipe secondary note",
+      "recordVolumeAfterStabilizersHelp": "You logged stabilizers. Record the actual volume now—secondary additions can increase batch volume and may require additional stabilizers.",
+      "recordVolumeAfterStabilizersTitle": "Record the updated volume",
       "scaleAdditives": "Scale additives",
       "scaleSecondaryIngredients": "Scale secondary ingredients",
       "secondaryBeforeStabilizersHelp": "This recipe uses stabilizers. Secondary ingredients are usually logged after stabilizers so the dosage is based on the current volume and ABV.",
@@ -1360,6 +1384,9 @@
   "other": {
     "detailsHeading": "Other Nutrient Details",
     "label": "Other",
+    "nutrientPresetHelp": "Select a nutrient from the list to fill in its values, or enter your own nutrient details.",
+    "organicMultiplier": "Use organic nitrogen multiplier",
+    "organicMultiplierHelp": "Only select this for nutrients made entirely from organic nitrogen.",
     "settingsAdjustValue": "Toggle adjusting provided YAN",
     "settingsProvidedYan": "Provided YAN",
     "settingsTitle": "Adjust Nutrient Settings",

--- a/packages/schemas/src/nutrient.ts
+++ b/packages/schemas/src/nutrient.ts
@@ -66,7 +66,8 @@ export const nutrientSettingsSchema = z.object({
   maxGpl: nutrientRecordSchema,
   maxGplTouched: z.boolean(),
   other: z.object({
-    name: z.string()
+    name: z.string(),
+    usesOrganicMultiplier: z.boolean().optional().default(false)
   })
 });
 export const nutrientAdjustmentsSchema = z.object({

--- a/packages/schemas/test/schemas.test.ts
+++ b/packages/schemas/test/schemas.test.ts
@@ -41,7 +41,7 @@ const nutrient = {
       other: "0"
     },
     maxGplTouched: false,
-    other: { name: "" }
+    other: { name: "", usesOrganicMultiplier: false }
   },
   adjustments: {
     adjustAllowed: false,
@@ -117,6 +117,25 @@ test("nutrient v2 schema validates nested schedules and inputs", () => {
     }).success,
     false
   );
+});
+
+test("nutrient v2 schema defaults the organic multiplier for saved recipes", () => {
+  const legacyNutrient = {
+    ...nutrient,
+    settings: {
+      ...nutrient.settings,
+      other: { name: nutrient.settings.other.name }
+    }
+  };
+
+  const parsed = nutrientDataV2Schema.parse(legacyNutrient);
+  assert.equal(parsed.settings.other.usesOrganicMultiplier, false);
+
+  const parsedRecipe = recipeDataV2Schema.parse({
+    ...recipe,
+    nutrients: legacyNutrient
+  });
+  assert.equal(parsedRecipe.nutrients?.settings.other.usesOrganicMultiplier, false);
 });
 
 test("recipe schema rejects version, unit, and nested shape mismatches", () => {


### PR DESCRIPTION
## What changed

Adds curated Other-nutrient presets with searchable autofill, including Wyeast, BBY, Mangrove Jack’s, and Vinoferm options. Adds an opt-in organic nitrogen multiplier that presets BBY and Mangrove Jack’s Mead Nutrient select automatically.

## Why

This makes known nutrient products easier to enter while preserving the existing nutrient calculation model and allowing custom nutrients.

## Impact

Existing recipes remain compatible: the new recipe flag is optional and defaults to `false`. The preset API is documented in OpenAPI.

## Validation

- `npx prisma validate --schema apps/web/prisma/schema.prisma`
- `npm run typecheck`
- schema, core, web, and API-contract test suites
- compatibility coverage for copied recipes and recipe-to-brew snapshots without the new flag