### PR TITLE
chore: migrate translations to Weblate

### DIFF
--- a/.github/workflows/approve-translator-pr.yml
+++ b/.github/workflows/approve-translator-pr.yml
@@ -1,0 +1,30 @@
+name: Approve trusted German translation PRs
+
+on:
+  pull_request:
+    branches: [preview]
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  approve-weblate-units:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out the merged commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 2
+
+      - name: Approve trusted German translation changes in Weblate
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          WEBLATE_URL: https://translations.meadtools.com
+          WEBLATE_APPROVAL_TOKEN: ${{ secrets.WEBLATE_APPROVAL_TOKEN }}
+        run: node scripts/approve-weblate-pr.mjs

--- a/ops/weblate/.env.example
+++ b/ops/weblate/.env.example
@@ -1,0 +1,36 @@
+# Copy this file to .env.local and choose unique passwords before starting.
+WEBLATE_SITE_TITLE=MeadTools Translations
+WEBLATE_ADMIN_NAME=MeadTools Admin
+WEBLATE_ADMIN_EMAIL=weblate-admin@meadtools.local
+WEBLATE_ADMIN_PASSWORD=replace-with-a-unique-local-password
+WEBLATE_SERVER_EMAIL=weblate@meadtools.local
+WEBLATE_DEFAULT_FROM_EMAIL=weblate@meadtools.local
+WEBLATE_SITE_DOMAIN=translations.meadtools.com
+WEBLATE_ALLOWED_HOSTS=translations.meadtools.com
+WEBLATE_ENABLE_HTTPS=1
+WEBLATE_IP_PROXY_HEADER=HTTP_X_FORWARDED_FOR
+WEBLATE_IP_PROXY_OFFSET=0
+WEBLATE_USE_X_FORWARDED_PORT=true
+WEBLATE_SECURE_PROXY_SSL_HEADER=HTTP_X_FORWARDED_PROTO,https
+WEBLATE_REGISTRATION_OPEN=0
+WEBLATE_REQUIRE_LOGIN=1
+
+POSTGRES_USER=weblate
+POSTGRES_PASSWORD=replace-with-a-unique-local-database-password
+POSTGRES_DB=weblate
+POSTGRES_DATABASE=weblate
+POSTGRES_HOST=database
+POSTGRES_PORT=
+
+REDIS_HOST=cache
+REDIS_PORT=6379
+
+# Outbound email is optional; configure it before enabling email notifications.
+WEBLATE_EMAIL_HOST=127.0.0.1
+WEBLATE_EMAIL_HOST_USER=
+WEBLATE_EMAIL_HOST_PASSWORD=
+
+# Required only when using the OpenAI automatic-translation engine.
+OPENAI_API_KEY=replace-with-an-api-key
+
+CLIENT_MAX_BODY_SIZE=1000M

--- a/ops/weblate/.env.example
+++ b/ops/weblate/.env.example
@@ -34,3 +34,6 @@ WEBLATE_EMAIL_HOST_PASSWORD=
 OPENAI_API_KEY=replace-with-an-api-key
 
 CLIENT_MAX_BODY_SIZE=1000M
+
+# Backup configuration belongs in the untracked /srv/meadtools-weblate/backup.env
+# file on the permanent host, alongside the restic password and SSH key.

--- a/ops/weblate/Caddyfile
+++ b/ops/weblate/Caddyfile
@@ -1,0 +1,14 @@
+# Caddy obtains and renews the TLS certificate after DNS for this hostname
+# points to the home network and TCP ports 80 and 443 are forwarded here.
+translations.meadtools.com {
+	encode zstd gzip
+
+	reverse_proxy weblate:8080
+
+	header {
+		-Server
+		X-Content-Type-Options "nosniff"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+	}
+}

--- a/ops/weblate/README.md
+++ b/ops/weblate/README.md
@@ -42,9 +42,31 @@ certificate automatically; Weblate itself stays bound to `127.0.0.1:8088` for
 SSH-tunnel troubleshooting.
 
 Production components use `git@github.com:ljreaux/MeadTools.git` on the
-translation-provider branch. Weblate's own Ed25519 public key is installed as
+`preview` branch. Weblate's own Ed25519 public key is installed as
 a write-enabled GitHub deploy key; do not copy a personal SSH key into the
 container.
+
+## Backups
+
+`backup.sh` creates a consistent PostgreSQL dump and backs it up together with
+the persistent Weblate and Caddy volumes. It uses a locally cached, encrypted
+restic repository which is mirrored to the offsite backup host over a dedicated
+SSH account. Caches are intentionally excluded because Weblate rebuilds them.
+
+The protected host-only `backup.env` file supplies the backup destination. It
+must never be committed. Install the supplied systemd unit and timer after a
+successful manual backup:
+
+```bash
+sudo install -m 0755 backup.sh /srv/meadtools-weblate/backup.sh
+sudo install -m 0644 systemd/meadtools-weblate-backup.service /etc/systemd/system/
+sudo install -m 0644 systemd/meadtools-weblate-backup.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now meadtools-weblate-backup.timer
+```
+
+The timer runs daily around 03:15 local time and retains 14 daily, 8 weekly,
+and 12 monthly restic snapshots. Test restoration before relying on backups.
 
 ## Pilot import
 

--- a/ops/weblate/README.md
+++ b/ops/weblate/README.md
@@ -1,0 +1,85 @@
+# MeadTools Weblate operations
+
+Weblate has two Compose configurations:
+
+- `compose.yml` is a local, disposable pilot. It listens only on
+  `http://localhost:8088` and mounts this checkout read-only for its initial
+  import.
+- `compose.production.yml` is the permanent Ubuntu-host deployment. Caddy is
+  its only public entry point and provides HTTPS for
+  `https://translations.meadtools.com`.
+
+The local pilot's `settings-override.py` enables the `file://` VCS scheme
+solely for its read-only checkout. Do not use that override in production.
+
+## Start
+
+```bash
+docker compose -f ops/weblate/compose.yml up -d
+```
+
+Open `http://localhost:8088` and sign in with the admin email and password in
+the untracked `ops/weblate/.env.local` file. The initial administrator username
+is `admin`.
+
+## Permanent deployment
+
+The permanent host uses the same ignored `.env.local` file shape as the pilot,
+but it must contain production-specific passwords, `WEBLATE_SITE_DOMAIN`, and
+the optional `OPENAI_API_KEY`. Keep that file mode `0600`; it is intentionally
+ignored by Git.
+
+On the Ubuntu host, store the deployment under `/srv/meadtools-weblate` and
+use the production configuration as its `compose.yml`:
+
+```bash
+docker compose up -d
+docker compose ps
+```
+
+The host must forward TCP ports 80 and 443 to Caddy. Caddy manages the TLS
+certificate automatically; Weblate itself stays bound to `127.0.0.1:8088` for
+SSH-tunnel troubleshooting.
+
+Production components use `git@github.com:ljreaux/MeadTools.git` on the
+translation-provider branch. Weblate's own Ed25519 public key is installed as
+a write-enabled GitHub deploy key; do not copy a personal SSH key into the
+container.
+
+## Pilot import
+
+The initialized local volumes include the `MeadTools pilot` project and the two
+components below. If you discard the volumes and recreate the pilot, use these
+settings to add them again:
+
+- Source repository: `file:///workspace/meadtools`
+- Branch: `362-update-translation-provider`
+- Source language: English
+- File format: `i18next JSON file v4`
+
+Use these component settings:
+
+| Component | File mask | Base language file |
+| --- | --- | --- |
+| Default | `packages/i18n/locales/*/default.json` | `packages/i18n/locales/en/default.json` |
+| Yeast table | `packages/i18n/locales/*/YeastTable.json` | `packages/i18n/locales/en/YeastTable.json` |
+
+Do not configure a push URL or machine translation provider during a fresh
+pilot import. Verify that the files are parsed and the expected English and
+German strings appear before enabling write access or adding an API key.
+
+## Operations
+
+```bash
+# Follow startup logs
+docker compose -f ops/weblate/compose.yml logs -f weblate
+
+# Stop without deleting pilot data
+docker compose -f ops/weblate/compose.yml stop
+
+# Start again
+docker compose -f ops/weblate/compose.yml start
+```
+
+To discard the pilot and all of its local Weblate data, first stop the stack,
+then run `docker compose -f ops/weblate/compose.yml down -v`.

--- a/ops/weblate/backup.sh
+++ b/ops/weblate/backup.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Encrypted Weblate backup. Run on the permanent Ubuntu host.
+set -euo pipefail
+
+COMPOSE_DIR=${COMPOSE_DIR:-/srv/meadtools-weblate}
+CONFIG_FILE=${BACKUP_CONFIG_FILE:-"$COMPOSE_DIR/backup.env"}
+
+if [[ ! -r "$CONFIG_FILE" ]]; then
+  echo "Missing protected backup configuration: $CONFIG_FILE" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$CONFIG_FILE"
+
+: "${BACKUP_SSH_HOST:?Set BACKUP_SSH_HOST in backup.env}"
+: "${BACKUP_SSH_USER:?Set BACKUP_SSH_USER in backup.env}"
+: "${BACKUP_REMOTE_PATH:?Set BACKUP_REMOTE_PATH in backup.env}"
+
+BACKUP_DIR=${BACKUP_DIR:-"$COMPOSE_DIR/backups"}
+STAGING_DIR="$BACKUP_DIR/staging"
+RESTIC_REPOSITORY="$BACKUP_DIR/restic-repository"
+SSH_DIR=${BACKUP_SSH_DIR:-"$COMPOSE_DIR/backup-ssh"}
+RESTIC_IMAGE=${RESTIC_IMAGE:-restic/restic:0.19.1}
+SSH_KEY="$SSH_DIR/id_ed25519"
+KNOWN_HOSTS="$SSH_DIR/known_hosts"
+PASSWORD_FILE="$SSH_DIR/restic-password"
+WEBLATE_VOLUME=${WEBLATE_VOLUME:-meadtools-weblate_weblate-data}
+CADDY_VOLUME=${CADDY_VOLUME:-meadtools-weblate_caddy-data}
+
+for required_file in "$SSH_KEY" "$KNOWN_HOSTS" "$PASSWORD_FILE"; do
+  [[ -r "$required_file" ]] || { echo "Missing backup secret: $required_file" >&2; exit 1; }
+done
+
+umask 077
+mkdir -p "$STAGING_DIR" "$RESTIC_REPOSITORY"
+rm -f "$STAGING_DIR/weblate.pg.dump"
+
+cd "$COMPOSE_DIR"
+docker compose exec -T database pg_dump --username weblate --format=custom weblate > "$STAGING_DIR/weblate.pg.dump"
+
+restic() {
+  docker run --rm --network none \
+    -e RESTIC_PASSWORD_FILE=/secrets/restic-password \
+    -v "$PASSWORD_FILE":/secrets/restic-password:ro \
+    -v "$RESTIC_REPOSITORY":/repository \
+    -v "$STAGING_DIR":/staging:ro \
+    -v "$WEBLATE_VOLUME":/weblate-data:ro \
+    -v "$CADDY_VOLUME":/caddy-data:ro \
+    "$RESTIC_IMAGE" -r /repository "$@"
+}
+
+if [[ ! -f "$RESTIC_REPOSITORY/config" ]]; then
+  restic init
+fi
+
+restic backup --host meadtools-weblate --tag weblate /staging /weblate-data /caddy-data
+restic forget --host meadtools-weblate --keep-daily 14 --keep-weekly 8 --keep-monthly 12 --prune
+
+# The backup container writes the local repository as root. Make it readable by
+# the unprivileged systemd service before rsync mirrors the encrypted files.
+docker run --rm -v "$RESTIC_REPOSITORY":/repository alpine:3.21 \
+  chown -R "$(id -u):$(id -g)" /repository
+
+ssh -i "$SSH_KEY" -o UserKnownHostsFile="$KNOWN_HOSTS" -o StrictHostKeyChecking=yes \
+  -o BatchMode=yes "$BACKUP_SSH_USER@$BACKUP_SSH_HOST" "mkdir -p '$BACKUP_REMOTE_PATH'"
+rsync -a --delete \
+  -e "ssh -i $SSH_KEY -o UserKnownHostsFile=$KNOWN_HOSTS -o StrictHostKeyChecking=yes -o BatchMode=yes" \
+  "$RESTIC_REPOSITORY/" "$BACKUP_SSH_USER@$BACKUP_SSH_HOST:$BACKUP_REMOTE_PATH/"

--- a/ops/weblate/compose.production.yml
+++ b/ops/weblate/compose.production.yml
@@ -1,0 +1,61 @@
+# Permanent host deployment. Weblate itself remains bound to the host loopback
+# interface; Caddy is the sole public HTTPS entry point.
+name: meadtools-weblate
+
+services:
+  cache:
+    image: valkey/valkey:9.1.0
+    command: [valkey-server, --save, "60", "1", --loglevel, warning]
+    restart: unless-stopped
+    read_only: true
+    volumes:
+      - redis-data:/data
+
+  database:
+    image: postgres:18-alpine
+    env_file:
+      - .env.local
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql
+
+  weblate:
+    # Pin the exact image validated by the local pilot. Update this digest only
+    # as part of an intentional Weblate upgrade.
+    image: weblate/weblate@sha256:2e6b11ba52c90824901ba2728540836295882f6cfa9df49ef22b69ce4b55a5bf
+    depends_on:
+      - cache
+      - database
+    env_file:
+      - .env.local
+    ports:
+      - "127.0.0.1:8088:8080"
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - weblate-data:/app/data
+      - weblate-cache:/app/cache
+
+  caddy:
+    image: caddy:2.10.2-alpine
+    depends_on:
+      - weblate
+    ports:
+      - "80:80"
+      - "443:443"
+    restart: unless-stopped
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+
+volumes:
+  caddy-data:
+  caddy-config:
+  postgres-data:
+  redis-data:
+  weblate-cache:
+  weblate-data:

--- a/ops/weblate/compose.yml
+++ b/ops/weblate/compose.yml
@@ -1,0 +1,46 @@
+name: meadtools-weblate-pilot
+
+services:
+  cache:
+    image: valkey/valkey:9.1.0
+    command: [valkey-server, --save, "60", "1", --loglevel, warning]
+    restart: unless-stopped
+    read_only: true
+    volumes:
+      - redis-data:/data
+
+  database:
+    image: postgres:18-alpine
+    env_file:
+      - .env.local
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql
+
+  weblate:
+    # Keep the pilot on the same image that was validated for production.
+    image: weblate/weblate@sha256:2e6b11ba52c90824901ba2728540836295882f6cfa9df49ef22b69ce4b55a5bf
+    depends_on:
+      - cache
+      - database
+    env_file:
+      - .env.local
+    ports:
+      - "127.0.0.1:8088:8080"
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - weblate-data:/app/data
+      - weblate-cache:/app/cache
+      - ./settings-override.py:/app/data/settings-override.py:ro
+      # The pilot may import this checkout, but cannot write to it.
+      - ../..:/workspace/meadtools:ro
+
+volumes:
+  postgres-data:
+  redis-data:
+  weblate-cache:
+  weblate-data:

--- a/ops/weblate/settings-override.py
+++ b/ops/weblate/settings-override.py
@@ -1,0 +1,4 @@
+# Local pilot only: permit the read-only file:// repository mounted by Compose.
+# Remove this override when moving Weblate to its permanent host, where the
+# repository should be accessed through GitHub using SSH or HTTPS.
+VCS_ALLOW_SCHEMES = {"https", "ssh", "file"}

--- a/ops/weblate/systemd/meadtools-weblate-backup.service
+++ b/ops/weblate/systemd/meadtools-weblate-backup.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Create encrypted MeadTools Weblate backup
+Wants=network-online.target
+After=network-online.target docker.service
+
+[Service]
+Type=oneshot
+User=larry-reaux
+Group=docker
+ExecStart=/srv/meadtools-weblate/backup.sh

--- a/ops/weblate/systemd/meadtools-weblate-backup.timer
+++ b/ops/weblate/systemd/meadtools-weblate-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run the MeadTools Weblate backup daily
+
+[Timer]
+OnCalendar=*-*-* 03:15:00
+Persistent=true
+RandomizedDelaySec=15m
+
+[Install]
+WantedBy=timers.target

--- a/scripts/app-impact.mjs
+++ b/scripts/app-impact.mjs
@@ -17,6 +17,11 @@ const SHARED_PATHS = [
   "tsconfig.base.json",
 ];
 
+// Weblate writes these generated runtime files in a follow-up commit. The
+// preceding source/app commit has already produced the useful preview, so a
+// translation-only update should not create another identical deployment.
+const GENERATED_TRANSLATION_PATH = "packages/i18n/locales/";
+
 const LOCKFILE = "package-lock.json";
 
 const TARGET_CONFIGURATION = {
@@ -44,8 +49,10 @@ export function isTargetAffected(target, changedPaths) {
     ...TARGET_CONFIGURATION[target],
   ];
 
-  return changedPaths.some((changedPath) =>
-    relevantPaths.some((candidate) => matchesPath(changedPath, candidate)),
+  return changedPaths.some(
+    (changedPath) =>
+      !changedPath.startsWith(GENERATED_TRANSLATION_PATH) &&
+      relevantPaths.some((candidate) => matchesPath(changedPath, candidate)),
   );
 }
 

--- a/scripts/app-impact.test.mjs
+++ b/scripts/app-impact.test.mjs
@@ -31,6 +31,34 @@ test("shared packages and root dependencies affect every app", () => {
   }
 });
 
+test("generated translation-only changes do not rebuild apps", () => {
+  assert.deepEqual(
+    classifyAppImpact([
+      "packages/i18n/locales/de/default.json",
+      "packages/i18n/locales/de/YeastTable.json",
+    ]),
+    {
+      web: false,
+      mobile: false,
+      desktop: false,
+    },
+  );
+});
+
+test("translation updates deploy when combined with an app change", () => {
+  assert.deepEqual(
+    classifyAppImpact([
+      "apps/web/app/page.tsx",
+      "packages/i18n/locales/de/default.json",
+    ]),
+    {
+      web: true,
+      mobile: false,
+      desktop: false,
+    },
+  );
+});
+
 test("an app manifest and lockfile change affect only that app", () => {
   assert.deepEqual(
     classifyAppImpact([

--- a/scripts/approve-weblate-pr.mjs
+++ b/scripts/approve-weblate-pr.mjs
@@ -1,0 +1,130 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const WEBLATE_URL = process.env.WEBLATE_URL?.replace(/\/$/, "");
+const WEBLATE_TOKEN = process.env.WEBLATE_APPROVAL_TOKEN;
+const event = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+const pullRequest = event.pull_request;
+const approvalLabel = "translations-approved";
+const trustedAuthor = "rizzek";
+const componentByFile = new Map([
+  ["packages/i18n/locales/de/default.json", "default"],
+  ["packages/i18n/locales/de/YeastTable.json", "yeast-table"],
+]);
+
+if (!WEBLATE_URL || !WEBLATE_TOKEN) {
+  throw new Error("WEBLATE_URL and WEBLATE_APPROVAL_TOKEN are required.");
+}
+
+const hasApprovalLabel = pullRequest.labels.some(
+  ({ name }) => name === approvalLabel,
+);
+const isTrustedAuthor = pullRequest.user.login === trustedAuthor;
+
+if (!pullRequest.merged || (!hasApprovalLabel && !isTrustedAuthor)) {
+  console.log("PR is not eligible for automatic Weblate approval.");
+  process.exit(0);
+}
+
+function git(...args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function flatten(value, prefix = "", entries = new Map()) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => flatten(item, `${prefix}[${index}]`, entries));
+    return entries;
+  }
+
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      flatten(child, prefix ? `${prefix}.${key}` : key, entries);
+    }
+    return entries;
+  }
+
+  entries.set(prefix, value);
+  return entries;
+}
+
+function readJson(revision, file) {
+  try {
+    return JSON.parse(git("show", `${revision}:${file}`));
+  } catch {
+    return {};
+  }
+}
+
+const after = git("rev-parse", "HEAD");
+const before = git("rev-parse", "HEAD^");
+const changedFiles = git("diff", "--name-only", before, after)
+  .split("\n")
+  .filter(Boolean);
+
+const localeFiles = changedFiles.filter((file) => componentByFile.has(file));
+const unexpectedFiles = changedFiles.filter((file) => !componentByFile.has(file));
+
+if (localeFiles.length === 0) {
+  console.log("Eligible PR has no German translation-file changes.");
+  process.exit(0);
+}
+
+if (unexpectedFiles.length > 0) {
+  throw new Error(
+    `Refusing automatic approval because this PR also changes: ${unexpectedFiles.join(", ")}`,
+  );
+}
+
+const changedUnits = [];
+for (const file of localeFiles) {
+  const previousEntries = flatten(readJson(before, file));
+  const currentEntries = flatten(readJson(after, file));
+
+  for (const [context, target] of currentEntries) {
+    if (previousEntries.get(context) !== target) {
+      changedUnits.push({ component: componentByFile.get(file), context, target });
+    }
+  }
+}
+
+if (changedUnits.length === 0) {
+  console.log("No German translation values changed.");
+  process.exit(0);
+}
+
+const headers = {
+  Accept: "application/json",
+  Authorization: `Token ${WEBLATE_TOKEN}`,
+};
+
+for (const { component, context, target } of changedUnits) {
+  const query = new URLSearchParams({
+    q: `component:${component} language:de context:${context}`,
+    page_size: "10",
+  });
+  const response = await fetch(`${WEBLATE_URL}/api/units/?${query}`, { headers });
+  if (!response.ok) {
+    throw new Error(`Unable to find Weblate unit for ${component}:${context}.`);
+  }
+
+  const { results } = await response.json();
+  const unit = results.find(
+    (candidate) => candidate.context === context && candidate.target?.[0] === target,
+  );
+  if (!unit) {
+    throw new Error(
+      `Weblate does not have the expected current value for ${component}:${context}.`,
+    );
+  }
+
+  const approval = await fetch(`${WEBLATE_URL}/api/units/${unit.id}/`, {
+    method: "PATCH",
+    headers: { ...headers, "Content-Type": "application/json" },
+    body: JSON.stringify({ state: 30 }),
+  });
+  if (!approval.ok) {
+    throw new Error(`Unable to approve Weblate unit ${unit.id}.`);
+  }
+}
+
+console.log(`Approved ${changedUnits.length} German Weblate unit(s).`);


### PR DESCRIPTION
## What changes
- Add the self-hosted Weblate deployment configuration and translator workflow.
- Add encrypted, retained off-site backups for the Weblate host.
- Skip Vercel app deployments for translation-only commits.
- Mark trusted German translation PRs as approved in Weblate after merge into `preview`.

## Why
This replaces the constrained i18nexus workflow with reviewable, prompt-guided translations while keeping application previews focused on actual app changes.

## Validation
- `npm run test:workflows`
- `git diff --check`
- Weblate deployment, public access, API access, backup, and restore test completed on the Ubuntu host.