### PR TITLE
ci: queue German translation reviews

### DIFF
--- a/.github/workflows/approve-weblate-batch.yml
+++ b/.github/workflows/approve-weblate-batch.yml
@@ -1,0 +1,32 @@
+name: Approve trusted Weblate translation batch
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  approve-batch:
+    if: >-
+      github.event.issue.pull_request == null &&
+      github.event.comment.user.login == 'rizzek' &&
+      startsWith(github.event.comment.body, '/approve-translations ')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Approve the exact Weblate batch
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_TOKEN: ${{ github.token }}
+          WEBLATE_URL: https://translations.meadtools.com
+          WEBLATE_APPROVAL_TOKEN: ${{ secrets.WEBLATE_APPROVAL_TOKEN }}
+        run: node scripts/approve-weblate-batch.mjs

--- a/.github/workflows/queue-weblate-review.yml
+++ b/.github/workflows/queue-weblate-review.yml
@@ -1,0 +1,25 @@
+name: Queue Weblate German translation review
+
+on:
+  push:
+    branches: [preview]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  queue-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out the pushed revision
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Add isolated Weblate German commits to the review queue
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/queue-weblate-review.mjs

--- a/docs/translation-workflow.md
+++ b/docs/translation-workflow.md
@@ -1,0 +1,182 @@
+# Translation workflow
+
+> **Status: rollout plan.** The Weblate service is running as a pilot with a
+> provisional German glossary and style baseline. Generated translations stay
+> unapproved until a human reviews them. Do not treat this document as
+> authorization to remove i18nexus yet.
+
+## Goals
+
+- Keep the app releasable when German review happens after a feature ships.
+- Generate initial German suggestions with the approved style rules and
+  glossary, but leave them unapproved.
+- Give the German translator a Git-first review flow, with Weblate as the
+  accurate review queue and UI fallback.
+- Avoid web, mobile, and Vercel work for German-only follow-up commits.
+
+## Roles
+
+| Role | Purpose |
+| --- | --- |
+| Project owner | Manages Weblate, glossary rules, service configuration, and cutover. |
+| `rizzek` | German translator and trusted GitHub/Weblate reviewer. |
+| `github-translation-approver` | Weblate service account used only by GitHub Actions; not a human login. |
+| Translation bot | Creates unapproved German suggestions. |
+
+Use real name/email accounts for the owner and translator. Keep public
+registration closed except for a short, supervised account-creation window;
+verify the new owner login before disabling or removing any pilot account.
+
+### Initial translator setup
+
+The initial German reviewer account is `rizzek`. The account has the **Users**
+and **Reviewers** roles and is registered to the translator's approved email
+address.
+
+To set or replace its password, open
+`https://translations.meadtools.com/accounts/reset/`, enter that email address,
+and use the reset email to choose a password. Do not share a temporary password
+in chat, GitHub, or a repository file. Public registration should remain
+closed; an owner provisions any additional accounts.
+
+## Current source of truth
+
+Until the explicit cutover, i18nexus remains the source of truth for English
+strings and existing translations. Do not edit locale JSON files directly for
+ordinary product copy changes. The Weblate pilot is isolated from the
+production translation workflow during this period.
+
+The same-PR translation bot writes German locale JSON. It therefore cannot be
+enabled while i18nexus is still the source of truth. The cutover must occur
+before enabling that bot; it will replace these instructions after one
+successful feature cycle and translation-review cycle.
+
+## Target feature flow
+
+This is the intended **post-cutover** production workflow. The same-PR
+translation bot and review-issue automation are not enabled until i18nexus is
+formally retired and their implementation has been reviewed. The glossary can
+evolve over time; a bot must never auto-approve its own output.
+
+1. A feature PR adds, changes, or removes English strings.
+2. The translation bot detects the English locale change and updates the
+   German JSON in **that same PR**.
+3. Bot-created German values are marked unapproved in Weblate after the PR is
+   merged to `preview`.
+4. The feature can merge to `preview` even when German review is pending.
+5. A German-only follow-up commit does not trigger web, mobile, or Vercel
+   deployment work.
+
+### English source changes
+
+| English change | German handling |
+| --- | --- |
+| New string | Generate a German suggestion; leave it unapproved. |
+| Meaningful source update | Clear German approval, regenerate using the glossary, and leave it unapproved. |
+| Source deletion | Remove the matching German key in the bot update. |
+
+Approval is reset for a changed English source even when the German value
+looks unchanged. This prevents a previously reviewed translation from being
+silently treated as valid for new meaning.
+
+## German review flow
+
+After a bot translation batch reaches `preview`, automation should create or
+update one GitHub issue assigned to `rizzek`. The issue must link to:
+
+- the originating feature PR;
+- the exact bot translation commit;
+- the German Weblate review filter; and
+- brief instructions for Git and Weblate review.
+
+The issue is pinned to a specific batch. Do not ask the translator to review
+the latest `preview` commit, because unrelated work might have arrived since
+the translation was generated.
+
+`rizzek` must be an accepted GitHub collaborator before GitHub can assign the
+queue issue to them. Until then, the workflow still creates the queue issue but
+leaves it unassigned.
+
+### Preferred Git-first review
+
+1. The translator checks out the commit linked from the review issue.
+2. They edit only the German locale files that need changes.
+3. They open a German-only PR targeting `preview`.
+4. When that PR is merged, trusted-review automation verifies the changed
+   values still match Weblate and marks those units approved.
+
+`rizzek` is a trusted author; the `translations-approved` label is the
+maintainer override for another approved reviewer.
+
+### Approving an unchanged suggestion
+
+An unchanged AI suggestion produces no JSON diff, so it cannot be approved by
+a normal content-only Git commit. On the matching queue issue, `rizzek` can
+post:
+
+```text
+/approve-translations <full Weblate commit SHA>
+```
+
+The workflow confirms that the referenced commit is an isolated Weblate German
+translation commit already contained in `preview`, verifies every value still
+matches Weblate, then marks only that batch approved. It posts a confirmation
+comment when finished.
+
+### Weblate fallback
+
+The translator can always use Weblate's saved German review queue to inspect
+source text, AI output, and context. Editing and clicking **Approve** there
+records the reviewer in Weblate and lets Weblate batch the resulting Git
+commit. This is the simplest option for a small correction or an unchanged
+suggestion.
+
+## Glossary and style baseline
+
+The initial glossary and informal-tone rules are a baseline, not a release
+blocker. The translator can improve them after reviewing real output. When a
+term changes:
+
+1. Add the preferred term to the Weblate glossary and translation-bot prompt.
+2. Regenerate only affected **unapproved** German suggestions when useful.
+3. Preserve every approved translation unless an English source change resets
+   that unit for review.
+
+The prompt must preserve placeholders, markup, measurements, brands, product
+names, yeast strains, and technical abbreviations. It must use informal German
+and the glossary's preferred terminology.
+
+## Deployment and CI behavior
+
+`scripts/app-impact.mjs` classifies files under
+`packages/i18n/locales/` as generated translation output. A commit that changes
+only those files skips web and mobile Quality jobs and Vercel app deployment.
+If a translation change is combined with an app, package, or shared-script
+change, normal checks and deployment run.
+
+## Before go-live
+
+- [ ] Have the German translator review and refine the provisional glossary.
+- [ ] Create real owner and translator accounts; retire pilot accounts only
+      after login verification.
+- [ ] Confirm `rizzek` has GitHub repository access for issue assignment and
+      trusted PR review.
+- [ ] Make the explicit source-of-truth cutover from i18nexus to the
+      repository/Weblate workflow.
+- [ ] Add the OpenAI key to GitHub Actions only when the same-PR bot is ready.
+- [ ] Implement and test same-PR translation generation.
+- [ ] Merge and live-test the assigned review issue and trusted
+      `/approve-translations` action.
+- [ ] Test a German-only PR approval and a Weblate UI approval.
+- [ ] Verify no translation-only commit starts a web, mobile, or Vercel job.
+- [ ] Run one normal feature cycle end to end.
+- [ ] Update source-of-truth instructions and remove i18nexus only after the
+      explicit cutover decision.
+
+## Recovery
+
+The Weblate host has daily encrypted off-site backups with retained daily,
+weekly, and monthly snapshots. Restore testing was completed during the pilot.
+If a translation batch is wrong, stop automatic translation, restore or reset
+only the affected unapproved units, and rerun after correcting the glossary or
+prompt. Never reset approved units as part of a bulk retry.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "start": "npm run start --workspace @meadtools/web",
     "start:i18n": "npm run start:i18n --workspace @meadtools/web",
     "test": "npm run test:workflows && npm run test:core && npm run test:schemas && npm run test:api-contract && npm run test:api-client && npm run test:brew-domain && npm run test:design-tokens && npm run test:i18n && npm test --workspace @meadtools/web",
-    "test:workflows": "node --test scripts/app-impact.test.mjs",
+    "test:workflows": "node --test scripts/app-impact.test.mjs scripts/approve-weblate-batch.test.mjs scripts/queue-weblate-review.test.mjs",
     "typecheck": "npm run prisma:generate --workspace @meadtools/web && npm run typecheck --workspaces --if-present",
     "openapi:generate": "npm run openapi:generate --workspace @meadtools/web",
     "contracts:generate": "node scripts/generate-api-contract-types.mjs",

--- a/scripts/approve-weblate-batch.mjs
+++ b/scripts/approve-weblate-batch.mjs
@@ -1,0 +1,171 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+import { getWeblateGermanComponents } from "./queue-weblate-review.mjs";
+
+const WEBLATE_URL = process.env.WEBLATE_URL?.replace(/\/$/, "");
+const WEBLATE_TOKEN = process.env.WEBLATE_APPROVAL_TOKEN;
+const trustedReviewer = "rizzek";
+const componentByFile = new Map([
+  ["packages/i18n/locales/de/default.json", "default"],
+  ["packages/i18n/locales/de/YeastTable.json", "yeast-table"],
+]);
+
+export function getApprovalCommit(body) {
+  const match = body.trim().match(/^\/approve-translations\s+([0-9a-f]{7,40})$/i);
+  return match?.[1] ?? null;
+}
+
+function git(...args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function flatten(value, prefix = "", entries = new Map()) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => flatten(item, `${prefix}[${index}]`, entries));
+    return entries;
+  }
+
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      flatten(child, prefix ? `${prefix}.${key}` : key, entries);
+    }
+    return entries;
+  }
+
+  entries.set(prefix, value);
+  return entries;
+}
+
+function readJson(revision, file) {
+  try {
+    return JSON.parse(git("show", `${revision}:${file}`));
+  } catch {
+    return {};
+  }
+}
+
+function targetMatches(candidate, target) {
+  const currentTarget = Array.isArray(candidate.target)
+    ? candidate.target[0]
+    : candidate.target;
+  return currentTarget === target;
+}
+
+async function commentOnIssue(event, body) {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!token || !repository) {
+    throw new Error("GITHUB_TOKEN and GITHUB_REPOSITORY are required to acknowledge approval.");
+  }
+
+  const response = await fetch(
+    `https://api.github.com/repos/${repository}/issues/${event.issue.number}/comments`,
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: JSON.stringify({ body }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Unable to acknowledge approval: ${response.status} ${await response.text()}`);
+  }
+}
+
+async function main() {
+  if (!WEBLATE_URL || !WEBLATE_TOKEN) {
+    throw new Error("WEBLATE_URL and WEBLATE_APPROVAL_TOKEN are required.");
+  }
+
+  const event = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+  const requestedCommit = getApprovalCommit(event.comment?.body ?? "");
+  if (
+    !requestedCommit ||
+    event.issue?.pull_request ||
+    event.comment?.user?.login !== trustedReviewer
+  ) {
+    console.log("Comment is not an eligible trusted translation approval.");
+    return;
+  }
+
+  git("fetch", "origin", "preview");
+  const commit = git("rev-parse", `${requestedCommit}^{commit}`);
+  try {
+    git("merge-base", "--is-ancestor", commit, "origin/preview");
+  } catch {
+    throw new Error(`${commit} is not contained in preview.`);
+  }
+
+  const parent = git("rev-parse", `${commit}^`);
+  const changedFiles = git("diff", "--name-only", parent, commit)
+    .split("\n")
+    .filter(Boolean);
+  const components = getWeblateGermanComponents(
+    git("log", "-1", "--format=%B", commit),
+    changedFiles,
+  );
+  if (components.length === 0) {
+    throw new Error(`${commit} is not an isolated Weblate German translation commit.`);
+  }
+
+  const changedUnits = [];
+  for (const file of changedFiles) {
+    const previousEntries = flatten(readJson(parent, file));
+    const currentEntries = flatten(readJson(commit, file));
+    for (const [context, target] of currentEntries) {
+      if (previousEntries.get(context) !== target) {
+        changedUnits.push({ component: componentByFile.get(file), context, target });
+      }
+    }
+  }
+  if (changedUnits.length === 0) {
+    throw new Error(`${commit} did not change any German translation values.`);
+  }
+
+  const headers = {
+    Accept: "application/json",
+    Authorization: `Token ${WEBLATE_TOKEN}`,
+  };
+  for (const { component, context, target } of changedUnits) {
+    const query = new URLSearchParams({
+      q: `component:${component} language:de context:${context}`,
+      page_size: "10",
+    });
+    const lookup = await fetch(`${WEBLATE_URL}/api/units/?${query}`, { headers });
+    if (!lookup.ok) {
+      throw new Error(`Unable to find Weblate unit for ${component}:${context}.`);
+    }
+    const { results } = await lookup.json();
+    const unit = results.find(
+      (candidate) => candidate.context === context && targetMatches(candidate, target),
+    );
+    if (!unit) {
+      throw new Error(
+        `Weblate no longer has the expected current value for ${component}:${context}.`,
+      );
+    }
+    const approval = await fetch(`${WEBLATE_URL}/api/units/${unit.id}/`, {
+      method: "PATCH",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({ state: 30 }),
+    });
+    if (!approval.ok) {
+      throw new Error(`Unable to approve Weblate unit ${unit.id}.`);
+    }
+  }
+
+  await commentOnIssue(
+    event,
+    `Approved ${changedUnits.length} Weblate German unit(s) from ${commit.slice(0, 7)}.`,
+  );
+  console.log(`Approved ${changedUnits.length} German Weblate unit(s).`);
+}
+
+if (import.meta.url === new URL(process.argv[1], "file:").href) {
+  await main();
+}

--- a/scripts/approve-weblate-batch.test.mjs
+++ b/scripts/approve-weblate-batch.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getApprovalCommit } from "./approve-weblate-batch.mjs";
+
+test("parses a full or abbreviated trusted batch approval command", () => {
+  assert.equal(
+    getApprovalCommit("/approve-translations 4bc98f5bfa12c52a47829ab59181b9a483bfb22a"),
+    "4bc98f5bfa12c52a47829ab59181b9a483bfb22a",
+  );
+  assert.equal(getApprovalCommit("/approve-translations 4bc98f5"), "4bc98f5");
+});
+
+test("rejects non-command comments", () => {
+  assert.equal(getApprovalCommit("/approve-translations"), null);
+  assert.equal(getApprovalCommit("please approve translations"), null);
+  assert.equal(getApprovalCommit("/approve-translations not-a-sha"), null);
+});

--- a/scripts/queue-weblate-review.mjs
+++ b/scripts/queue-weblate-review.mjs
@@ -1,0 +1,194 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const reviewLabel = "translation-review";
+const reviewIssueTitle = "German translation review queue";
+const reviewer = "rizzek";
+const componentByFile = new Map([
+  ["packages/i18n/locales/de/default.json", "default"],
+  ["packages/i18n/locales/de/YeastTable.json", "yeast-table"],
+]);
+
+export function getWeblateGermanComponents(message, changedFiles) {
+  if (!/^chore\(l10n\): update German translation$/m.test(message)) {
+    return [];
+  }
+
+  if (
+    changedFiles.length === 0 ||
+    changedFiles.some((file) => !componentByFile.has(file))
+  ) {
+    return [];
+  }
+
+  const components = changedFiles.map((file) => componentByFile.get(file));
+  const declaredComponents = [...message.matchAll(
+    /^Translation: MeadTools pilot\/([^\s]+)$/gm,
+  )].map(([, component]) => component);
+
+  return components.every((component) => declaredComponents.includes(component))
+    ? [...new Set(components)]
+    : [];
+}
+
+function git(...args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function githubUrl(path) {
+  return `https://api.github.com${path}`;
+}
+
+async function github(path, token, options = {}) {
+  const response = await fetch(githubUrl(path), {
+    ...options,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...(options.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API ${options.method ?? "GET"} ${path} failed: ${response.status} ${await response.text()}`,
+    );
+  }
+
+  return response.status === 204 ? null : response.json();
+}
+
+async function ensureLabel(owner, repository, token) {
+  try {
+    await github(`/repos/${owner}/${repository}/labels`, token, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: reviewLabel,
+        color: "5319E7",
+        description: "German AI translations awaiting review",
+      }),
+    });
+  } catch (error) {
+    if (!String(error).includes("422")) {
+      throw error;
+    }
+  }
+}
+
+async function getOrCreateQueueIssue(owner, repository, token) {
+  const issues = await github(
+    `/repos/${owner}/${repository}/issues?state=open&labels=${encodeURIComponent(reviewLabel)}&per_page=100`,
+    token,
+  );
+  const existing = issues.find(
+    (issue) => !issue.pull_request && issue.title === reviewIssueTitle,
+  );
+  if (existing) {
+    return existing;
+  }
+
+  const issue = await github(`/repos/${owner}/${repository}/issues`, token, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      title: reviewIssueTitle,
+      labels: [reviewLabel],
+      body: [
+        "This queue tracks AI-generated German translations that remain unapproved.",
+        "",
+        "Review the batch links below. Make corrections in a German-only PR to `preview`, or approve a correct suggestion in Weblate.",
+        "",
+        "Do not use the latest `preview` commit as the review target; use the pinned commit link for each batch.",
+      ].join("\n"),
+    }),
+  });
+
+  try {
+    await github(`/repos/${owner}/${repository}/issues/${issue.number}/assignees`, token, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ assignees: [reviewer] }),
+    });
+  } catch (error) {
+    console.warn(
+      `Created the review queue but could not assign ${reviewer}: ${error.message}`,
+    );
+  }
+
+  return issue;
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  const repositoryName = process.env.GITHUB_REPOSITORY;
+  if (!token || !eventPath || !repositoryName) {
+    throw new Error("GITHUB_TOKEN, GITHUB_EVENT_PATH, and GITHUB_REPOSITORY are required.");
+  }
+
+  const event = JSON.parse(readFileSync(eventPath, "utf8"));
+  if (event.ref !== "refs/heads/preview" || !event.head_commit) {
+    console.log("Push is not a preview commit.");
+    return;
+  }
+
+  const changedFiles = git("diff", "--name-only", event.before, event.after)
+    .split("\n")
+    .filter(Boolean);
+  const components = getWeblateGermanComponents(
+    event.head_commit.message,
+    changedFiles,
+  );
+  if (components.length === 0) {
+    console.log("Push is not an isolated Weblate German translation commit.");
+    return;
+  }
+
+  const [owner, repository] = repositoryName.split("/");
+  await ensureLabel(owner, repository, token);
+  const issue = await getOrCreateQueueIssue(owner, repository, token);
+  const marker = `<!-- weblate-review:${event.after} -->`;
+  const comments = await github(
+    `/repos/${owner}/${repository}/issues/${issue.number}/comments?per_page=100`,
+    token,
+  );
+  if (comments.some((comment) => comment.body.includes(marker))) {
+    console.log(`Review queue already contains ${event.after}.`);
+    return;
+  }
+
+  const componentLinks = components
+    .map((component) => {
+      const query = new URLSearchParams({ q: "state:<approved" });
+      return `- [${component} review queue](https://translations.meadtools.com/projects/meadtools-pilot/${component}/de/?${query})`;
+    })
+    .join("\n");
+  const commitUrl = `https://github.com/${repositoryName}/commit/${event.after}`;
+  const body = [
+    marker,
+    "## New German AI translation batch",
+    "",
+    `- Commit: [${event.after.slice(0, 7)}](${commitUrl})`,
+    `- Components: ${components.join(", ")}`,
+    "- Status: generated and **unapproved**",
+    "",
+    componentLinks,
+    "",
+    `To review in Git, branch from [this commit](${commitUrl}), edit only the German locale files, and open a PR to \`preview\`. A merged PR from @${reviewer} marks the changed units approved in Weblate.`,
+    "",
+    "For an unchanged suggestion, approve it in Weblate. The planned trusted `/approve-translations` issue command will provide a GitHub-only alternative.",
+  ].join("\n");
+  await github(`/repos/${owner}/${repository}/issues/${issue.number}/comments`, token, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ body }),
+  });
+
+  console.log(`Added Weblate translation batch ${event.after} to issue #${issue.number}.`);
+}
+
+if (import.meta.url === new URL(process.argv[1], "file:").href) {
+  await main();
+}

--- a/scripts/queue-weblate-review.test.mjs
+++ b/scripts/queue-weblate-review.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getWeblateGermanComponents } from "./queue-weblate-review.mjs";
+
+const message = `chore(l10n): update German translation
+
+Translation: MeadTools pilot/default
+Language: German`;
+
+test("recognizes isolated Weblate German locale commits", () => {
+  assert.deepEqual(
+    getWeblateGermanComponents(message, [
+      "packages/i18n/locales/de/default.json",
+    ]),
+    ["default"],
+  );
+});
+
+test("ignores non-Weblate and mixed commits", () => {
+  assert.deepEqual(
+    getWeblateGermanComponents("fix: improve German copy", [
+      "packages/i18n/locales/de/default.json",
+    ]),
+    [],
+  );
+  assert.deepEqual(
+    getWeblateGermanComponents(message, [
+      "packages/i18n/locales/de/default.json",
+      "apps/web/app/page.tsx",
+    ]),
+    [],
+  );
+});


### PR DESCRIPTION
## What changes
- Add the German translation workflow and initial translator-account setup guide.
- Create/update one GitHub review queue for isolated Weblate German commits on `preview`.
- Add trusted `/approve-translations <commit>` issue-command handling for unchanged AI suggestions.
- Cover the new workflow parsers with the workflow test suite.

## Why
This gives the German translator a Git-first review path while retaining exact Weblate approval state and avoiding issues for ordinary commits.

## Validation
- `npm run test:workflows`
- `git diff --check`

## Follow-up
- `rizzek` must accept a GitHub repository invitation before the queue can be assigned automatically.
- The same-PR translation bot remains a post-i18nexus-cutover change.