### PR TITLE
ci: pause EAS preview builds during translation migration

### DIFF
--- a/apps/mobile/.eas/workflows/create-preview-builds.yml
+++ b/apps/mobile/.eas/workflows/create-preview-builds.yml
@@ -8,14 +8,29 @@ on:
     paths:
       - apps/mobile/**
       - packages/**
-      - scripts/**
       - package.json
       - package-lock.json
       - tsconfig.base.json
 
 jobs:
+  migration_build_pause:
+    name: Check temporary migration build pause
+    outputs:
+      builds_enabled: ${{ steps.pause_check.outputs.builds_enabled }}
+    steps:
+      - uses: eas/checkout
+      - id: pause_check
+        run: |
+          if [ -f ../../ops/translation-migration.skip-builds ]; then
+            set-output builds_enabled "false"
+          else
+            set-output builds_enabled "true"
+          fi
+
   quality:
     name: Typecheck mobile app
+    needs: [migration_build_pause]
+    if: ${{ needs.migration_build_pause.outputs.builds_enabled == 'true' }}
     steps:
       - uses: eas/checkout
       - uses: eas/install_node_modules
@@ -23,7 +38,8 @@ jobs:
 
   build_android:
     name: Build Android preview
-    needs: [quality]
+    needs: [migration_build_pause, quality]
+    if: ${{ needs.migration_build_pause.outputs.builds_enabled == 'true' }}
     type: build
     params:
       platform: android
@@ -31,7 +47,8 @@ jobs:
 
   build_ios:
     name: Build iOS preview
-    needs: [quality]
+    needs: [migration_build_pause, quality]
+    if: ${{ needs.migration_build_pause.outputs.builds_enabled == 'true' }}
     type: build
     params:
       platform: ios


### PR DESCRIPTION
Uses the existing checked-in translation-migration pause marker to skip EAS preview quality and native build jobs.

Also removes `scripts/**` from EAS triggers; scripts do not change the mobile runtime, and that path caused the prior migration PR to start an unnecessary build.

Validation: EAS workflow schema validator.