### PR TITLE
ci: queue AI translations from merged feature PRs

### DIFF
--- a/.github/workflows/approve-weblate-batch.yml
+++ b/.github/workflows/approve-weblate-batch.yml
@@ -1,4 +1,4 @@
-name: Approve trusted Weblate translation batch
+name: Approve trusted German AI translation batch
 
 on:
   issue_comment:
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Approve the exact Weblate batch
+      - name: Approve the exact German AI batch in Weblate
         env:
           GITHUB_EVENT_PATH: ${{ github.event_path }}
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/queue-weblate-review.yml
+++ b/.github/workflows/queue-weblate-review.yml
@@ -1,25 +1,31 @@
-name: Queue Weblate German translation review
+name: Queue German AI translation review
 
 on:
-  push:
+  pull_request:
     branches: [preview]
+    types: [closed]
 
 permissions:
   contents: read
   issues: write
+  pull-requests: read
 
 jobs:
   queue-review:
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
-      - name: Check out the pushed revision
+      - name: Check out the merged feature branch
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
-      - name: Add isolated Weblate German commits to the review queue
+      - name: Add AI German batches to the review queue
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/queue-weblate-review.mjs

--- a/docs/translation-workflow.md
+++ b/docs/translation-workflow.md
@@ -16,12 +16,12 @@
 
 ## Roles
 
-| Role | Purpose |
-| --- | --- |
-| Project owner | Manages Weblate, glossary rules, service configuration, and cutover. |
-| `rizzek` | German translator and trusted GitHub/Weblate reviewer. |
+| Role                          | Purpose                                                                 |
+| ----------------------------- | ----------------------------------------------------------------------- |
+| Project owner                 | Manages Weblate, glossary rules, service configuration, and cutover.    |
+| `rizzek`                      | German translator and trusted GitHub/Weblate reviewer.                  |
 | `github-translation-approver` | Weblate service account used only by GitHub Actions; not a human login. |
-| Translation bot | Creates unapproved German suggestions. |
+| Translation bot               | Creates unapproved German suggestions.                                  |
 
 Use real name/email accounts for the owner and translator. Keep public
 registration closed except for a short, supervised account-creation window;
@@ -33,11 +33,10 @@ The initial German reviewer account is `rizzek`. The account has the **Users**
 and **Reviewers** roles and is registered to the translator's approved email
 address.
 
-To set or replace its password, open
-`https://translations.meadtools.com/accounts/reset/`, enter that email address,
-and use the reset email to choose a password. Do not share a temporary password
-in chat, GitHub, or a repository file. Public registration should remain
-closed; an owner provisions any additional accounts.
+After outbound SMTP is configured and tested, the translator can set or replace
+their password at `https://translations.meadtools.com/accounts/reset/`. Do not
+share a temporary password in chat, GitHub, or a repository file. Public
+registration should remain closed; an owner provisions any additional accounts.
 
 ## Current source of truth
 
@@ -59,8 +58,10 @@ formally retired and their implementation has been reviewed. The glossary can
 evolve over time; a bot must never auto-approve its own output.
 
 1. A feature PR adds, changes, or removes English strings.
-2. The translation bot detects the English locale change and updates the
-   German JSON in **that same PR**.
+2. The translation bot detects the English locale change and adds a separate,
+   isolated German-only commit to **that same PR**. Its commit must be titled
+   `chore(l10n): add German AI translations` and include the trailer
+   `Translation-Batch: ai-generated`.
 3. Bot-created German values are marked unapproved in Weblate after the PR is
    merged to `preview`.
 4. The feature can merge to `preview` even when German review is pending.
@@ -69,11 +70,11 @@ evolve over time; a bot must never auto-approve its own output.
 
 ### English source changes
 
-| English change | German handling |
-| --- | --- |
-| New string | Generate a German suggestion; leave it unapproved. |
+| English change           | German handling                                                                |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| New string               | Generate a German suggestion; leave it unapproved.                             |
 | Meaningful source update | Clear German approval, regenerate using the glossary, and leave it unapproved. |
-| Source deletion | Remove the matching German key in the bot update. |
+| Source deletion          | Remove the matching German key in the bot update.                              |
 
 Approval is reset for a changed English source even when the German value
 looks unchanged. This prevents a previously reviewed translation from being
@@ -81,8 +82,9 @@ silently treated as valid for new meaning.
 
 ## German review flow
 
-After a bot translation batch reaches `preview`, automation should create or
-update one GitHub issue assigned to `rizzek`. The issue must link to:
+After a feature PR containing a bot translation commit merges to `preview`,
+automation creates or updates one GitHub issue assigned to `rizzek`. The issue
+must link to:
 
 - the originating feature PR;
 - the exact bot translation commit;
@@ -99,8 +101,9 @@ leaves it unassigned.
 
 ### Preferred Git-first review
 
-1. The translator checks out the commit linked from the review issue.
-2. They edit only the German locale files that need changes.
+1. The translator inspects the bot commit linked from the review issue.
+2. They branch from current `preview` and edit only the German locale files
+   that need changes.
 3. They open a German-only PR targeting `preview`.
 4. When that PR is merged, trusted-review automation verifies the changed
    values still match Weblate and marks those units approved.
@@ -115,21 +118,21 @@ a normal content-only Git commit. On the matching queue issue, `rizzek` can
 post:
 
 ```text
-/approve-translations <full Weblate commit SHA>
+/approve-translations <full bot commit SHA>
 ```
 
-The workflow confirms that the referenced commit is an isolated Weblate German
-translation commit already contained in `preview`, verifies every value still
-matches Weblate, then marks only that batch approved. It posts a confirmation
-comment when finished.
+The workflow accepts the command only on the matching queue issue, confirms
+that the referenced commit is the isolated AI batch from the linked feature PR
+that merged to `preview`, verifies every value still matches Weblate, then
+marks only that batch approved. It posts a confirmation comment when finished.
 
 ### Weblate fallback
 
 The translator can always use Weblate's saved German review queue to inspect
-source text, AI output, and context. Editing and clicking **Approve** there
-records the reviewer in Weblate and lets Weblate batch the resulting Git
-commit. This is the simplest option for a small correction or an unchanged
-suggestion.
+source text, AI output, context, and approval state. During this workflow,
+Weblate is review-only: Git is the only system allowed to change locale JSON.
+Use a German-only PR for corrections or the trusted issue command for an
+unchanged accepted AI suggestion.
 
 ## Glossary and style baseline
 
@@ -151,8 +154,13 @@ and the glossary's preferred terminology.
 `scripts/app-impact.mjs` classifies files under
 `packages/i18n/locales/` as generated translation output. A commit that changes
 only those files skips web and mobile Quality jobs and Vercel app deployment.
-If a translation change is combined with an app, package, or shared-script
-change, normal checks and deployment run.
+EAS preview builds have a separate workflow and pause check.
+
+While this rollout is being tested,
+`ops/translation-migration.skip-builds` deliberately pauses web, mobile,
+desktop, Vercel, and EAS builds. Remove that marker only in the final
+cutover-completion PR. Once removed, a change that combines translation output
+with an app, package, or shared-script change runs normal checks and deployment.
 
 ## Before go-live
 
@@ -161,6 +169,7 @@ change, normal checks and deployment run.
       after login verification.
 - [ ] Confirm `rizzek` has GitHub repository access for issue assignment and
       trusted PR review.
+- [ ] Configure and test Weblate SMTP before relying on password-reset email.
 - [ ] Make the explicit source-of-truth cutover from i18nexus to the
       repository/Weblate workflow.
 - [ ] Add the OpenAI key to GitHub Actions only when the same-PR bot is ready.

--- a/scripts/approve-weblate-batch.mjs
+++ b/scripts/approve-weblate-batch.mjs
@@ -1,7 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
-import { getWeblateGermanComponents } from "./queue-weblate-review.mjs";
+import { getAiGermanComponents } from "./queue-weblate-review.mjs";
 
 const WEBLATE_URL = process.env.WEBLATE_URL?.replace(/\/$/, "");
 const WEBLATE_TOKEN = process.env.WEBLATE_APPROVAL_TOKEN;
@@ -12,7 +12,9 @@ const componentByFile = new Map([
 ]);
 
 export function getApprovalCommit(body) {
-  const match = body.trim().match(/^\/approve-translations\s+([0-9a-f]{7,40})$/i);
+  const match = body
+    .trim()
+    .match(/^\/approve-translations\s+([0-9a-f]{7,40})$/i);
   return match?.[1] ?? null;
 }
 
@@ -22,7 +24,9 @@ function git(...args) {
 
 function flatten(value, prefix = "", entries = new Map()) {
   if (Array.isArray(value)) {
-    value.forEach((item, index) => flatten(item, `${prefix}[${index}]`, entries));
+    value.forEach((item, index) =>
+      flatten(item, `${prefix}[${index}]`, entries),
+    );
     return entries;
   }
 
@@ -52,11 +56,87 @@ function targetMatches(candidate, target) {
   return currentTarget === target;
 }
 
+async function github(path, token) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API GET ${path} failed: ${response.status} ${await response.text()}`,
+    );
+  }
+  return response.json();
+}
+
+async function getIssueComments(repository, issueNumber, token) {
+  const comments = [];
+  for (let page = 1; ; page += 1) {
+    const response = await github(
+      `/repos/${repository}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
+      token,
+    );
+    comments.push(...response);
+    if (response.length < 100) {
+      return comments;
+    }
+  }
+}
+
+async function getReviewBatch(event, requestedCommit) {
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  if (!token || !repository) {
+    throw new Error(
+      "GITHUB_TOKEN and GITHUB_REPOSITORY are required for batch approval.",
+    );
+  }
+
+  const comments = await getIssueComments(
+    repository,
+    event.issue.number,
+    token,
+  );
+  const marker = comments
+    .map((comment) => comment.body)
+    .find(
+      (body) =>
+        body.includes(`<!-- translation-review:pr-`) &&
+        body.includes(`:commit-${requestedCommit}`),
+    );
+  const match = marker?.match(
+    /<!-- translation-review:pr-(\d+):commit-([0-9a-f]{40}) -->/i,
+  );
+  if (!match) {
+    throw new Error(
+      "The requested commit is not a batch pinned to this review issue.",
+    );
+  }
+
+  const [, pullRequestNumber, commit] = match;
+  const pullRequest = await github(
+    `/repos/${repository}/pulls/${pullRequestNumber}`,
+    token,
+  );
+  if (!pullRequest.merged_at || pullRequest.base?.ref !== "preview") {
+    throw new Error(
+      `Feature PR #${pullRequestNumber} is not merged into preview.`,
+    );
+  }
+
+  return { commit, pullRequestNumber };
+}
+
 async function commentOnIssue(event, body) {
   const token = process.env.GITHUB_TOKEN;
   const repository = process.env.GITHUB_REPOSITORY;
   if (!token || !repository) {
-    throw new Error("GITHUB_TOKEN and GITHUB_REPOSITORY are required to acknowledge approval.");
+    throw new Error(
+      "GITHUB_TOKEN and GITHUB_REPOSITORY are required to acknowledge approval.",
+    );
   }
 
   const response = await fetch(
@@ -73,7 +153,9 @@ async function commentOnIssue(event, body) {
     },
   );
   if (!response.ok) {
-    throw new Error(`Unable to acknowledge approval: ${response.status} ${await response.text()}`);
+    throw new Error(
+      `Unable to acknowledge approval: ${response.status} ${await response.text()}`,
+    );
   }
 }
 
@@ -93,24 +175,31 @@ async function main() {
     return;
   }
 
-  git("fetch", "origin", "preview");
-  const commit = git("rev-parse", `${requestedCommit}^{commit}`);
+  const { commit: pinnedCommit, pullRequestNumber } = await getReviewBatch(
+    event,
+    requestedCommit,
+  );
+  const pullRequestRef = `refs/remotes/origin/translation-review-pr-${pullRequestNumber}`;
+  git("fetch", "origin", `pull/${pullRequestNumber}/head:${pullRequestRef}`);
+  const commit = git("rev-parse", `${pinnedCommit}^{commit}`);
   try {
-    git("merge-base", "--is-ancestor", commit, "origin/preview");
+    git("merge-base", "--is-ancestor", commit, pullRequestRef);
   } catch {
-    throw new Error(`${commit} is not contained in preview.`);
+    throw new Error(`${commit} is not contained in the queued feature PR.`);
   }
 
   const parent = git("rev-parse", `${commit}^`);
   const changedFiles = git("diff", "--name-only", parent, commit)
     .split("\n")
     .filter(Boolean);
-  const components = getWeblateGermanComponents(
+  const components = getAiGermanComponents(
     git("log", "-1", "--format=%B", commit),
     changedFiles,
   );
   if (components.length === 0) {
-    throw new Error(`${commit} is not an isolated Weblate German translation commit.`);
+    throw new Error(
+      `${commit} is not an isolated German AI translation commit.`,
+    );
   }
 
   const changedUnits = [];
@@ -119,7 +208,11 @@ async function main() {
     const currentEntries = flatten(readJson(commit, file));
     for (const [context, target] of currentEntries) {
       if (previousEntries.get(context) !== target) {
-        changedUnits.push({ component: componentByFile.get(file), context, target });
+        changedUnits.push({
+          component: componentByFile.get(file),
+          context,
+          target,
+        });
       }
     }
   }
@@ -136,13 +229,18 @@ async function main() {
       q: `component:${component} language:de context:${context}`,
       page_size: "10",
     });
-    const lookup = await fetch(`${WEBLATE_URL}/api/units/?${query}`, { headers });
+    const lookup = await fetch(`${WEBLATE_URL}/api/units/?${query}`, {
+      headers,
+    });
     if (!lookup.ok) {
-      throw new Error(`Unable to find Weblate unit for ${component}:${context}.`);
+      throw new Error(
+        `Unable to find Weblate unit for ${component}:${context}.`,
+      );
     }
     const { results } = await lookup.json();
     const unit = results.find(
-      (candidate) => candidate.context === context && targetMatches(candidate, target),
+      (candidate) =>
+        candidate.context === context && targetMatches(candidate, target),
     );
     if (!unit) {
       throw new Error(

--- a/scripts/queue-weblate-review.mjs
+++ b/scripts/queue-weblate-review.mjs
@@ -9,8 +9,14 @@ const componentByFile = new Map([
   ["packages/i18n/locales/de/YeastTable.json", "yeast-table"],
 ]);
 
-export function getWeblateGermanComponents(message, changedFiles) {
-  if (!/^chore\(l10n\): update German translation$/m.test(message)) {
+// This is the commit contract the post-cutover translation bot will use. The
+// marker keeps a normal German-only correction from being mistaken for an AI
+// batch, while the file check prevents a mixed feature commit from qualifying.
+export function getAiGermanComponents(message, changedFiles) {
+  if (
+    !/^chore\(l10n\): add German AI translations$/m.test(message) ||
+    !/^Translation-Batch: ai-generated$/m.test(message)
+  ) {
     return [];
   }
 
@@ -21,18 +27,32 @@ export function getWeblateGermanComponents(message, changedFiles) {
     return [];
   }
 
-  const components = changedFiles.map((file) => componentByFile.get(file));
-  const declaredComponents = [...message.matchAll(
-    /^Translation: MeadTools pilot\/([^\s]+)$/gm,
-  )].map(([, component]) => component);
-
-  return components.every((component) => declaredComponents.includes(component))
-    ? [...new Set(components)]
-    : [];
+  return [...new Set(changedFiles.map((file) => componentByFile.get(file)))];
 }
 
 function git(...args) {
   return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function gitLines(...args) {
+  const output = git(...args);
+  return output ? output.split("\n").filter(Boolean) : [];
+}
+
+export function getAiTranslationBatches(base, head) {
+  const mergeBase = git("merge-base", base, head);
+  const commits = gitLines("rev-list", "--reverse", `${mergeBase}..${head}`);
+
+  return commits.flatMap((commit) => {
+    const parent = git("rev-parse", `${commit}^`);
+    const changedFiles = gitLines("diff", "--name-only", parent, commit);
+    const components = getAiGermanComponents(
+      git("log", "-1", "--format=%B", commit),
+      changedFiles,
+    );
+
+    return components.length > 0 ? [{ commit, components }] : [];
+  });
 }
 
 function githubUrl(path) {
@@ -57,6 +77,20 @@ async function github(path, token, options = {}) {
   }
 
   return response.status === 204 ? null : response.json();
+}
+
+async function getIssueComments(owner, repository, issueNumber, token) {
+  const comments = [];
+  for (let page = 1; ; page += 1) {
+    const response = await github(
+      `/repos/${owner}/${repository}/issues/${issueNumber}/comments?per_page=100&page=${page}`,
+      token,
+    );
+    comments.push(...response);
+    if (response.length < 100) {
+      return comments;
+    }
+  }
 }
 
 async function ensureLabel(owner, repository, token) {
@@ -98,19 +132,21 @@ async function getOrCreateQueueIssue(owner, repository, token) {
       body: [
         "This queue tracks AI-generated German translations that remain unapproved.",
         "",
-        "Review the batch links below. Make corrections in a German-only PR to `preview`, or approve a correct suggestion in Weblate.",
-        "",
-        "Do not use the latest `preview` commit as the review target; use the pinned commit link for each batch.",
+        "Each batch below is pinned to its feature PR and exact bot commit. Review in Git or Weblate; do not use the latest `preview` commit as the review target.",
       ].join("\n"),
     }),
   });
 
   try {
-    await github(`/repos/${owner}/${repository}/issues/${issue.number}/assignees`, token, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ assignees: [reviewer] }),
-    });
+    await github(
+      `/repos/${owner}/${repository}/issues/${issue.number}/assignees`,
+      token,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ assignees: [reviewer] }),
+      },
+    );
   } catch (error) {
     console.warn(
       `Created the review queue but could not assign ${reviewer}: ${error.message}`,
@@ -125,68 +161,81 @@ async function main() {
   const eventPath = process.env.GITHUB_EVENT_PATH;
   const repositoryName = process.env.GITHUB_REPOSITORY;
   if (!token || !eventPath || !repositoryName) {
-    throw new Error("GITHUB_TOKEN, GITHUB_EVENT_PATH, and GITHUB_REPOSITORY are required.");
+    throw new Error(
+      "GITHUB_TOKEN, GITHUB_EVENT_PATH, and GITHUB_REPOSITORY are required.",
+    );
   }
 
   const event = JSON.parse(readFileSync(eventPath, "utf8"));
-  if (event.ref !== "refs/heads/preview" || !event.head_commit) {
-    console.log("Push is not a preview commit.");
+  const pullRequest = event.pull_request;
+  if (
+    !pullRequest?.merged ||
+    pullRequest.base?.ref !== "preview" ||
+    pullRequest.head?.repo?.full_name !== repositoryName
+  ) {
+    console.log("Pull request is not an eligible merged feature PR.");
     return;
   }
 
-  const changedFiles = git("diff", "--name-only", event.before, event.after)
-    .split("\n")
-    .filter(Boolean);
-  const components = getWeblateGermanComponents(
-    event.head_commit.message,
-    changedFiles,
+  const batches = getAiTranslationBatches(
+    pullRequest.base.sha,
+    pullRequest.head.sha,
   );
-  if (components.length === 0) {
-    console.log("Push is not an isolated Weblate German translation commit.");
+  if (batches.length === 0) {
+    console.log("Feature PR has no isolated German AI translation batch.");
     return;
   }
 
   const [owner, repository] = repositoryName.split("/");
   await ensureLabel(owner, repository, token);
   const issue = await getOrCreateQueueIssue(owner, repository, token);
-  const marker = `<!-- weblate-review:${event.after} -->`;
-  const comments = await github(
-    `/repos/${owner}/${repository}/issues/${issue.number}/comments?per_page=100`,
+  const comments = await getIssueComments(
+    owner,
+    repository,
+    issue.number,
     token,
   );
-  if (comments.some((comment) => comment.body.includes(marker))) {
-    console.log(`Review queue already contains ${event.after}.`);
-    return;
+
+  for (const { commit, components } of batches) {
+    const marker = `<!-- translation-review:pr-${pullRequest.number}:commit-${commit} -->`;
+    if (comments.some((comment) => comment.body.includes(marker))) {
+      console.log(`Review queue already contains ${commit}.`);
+      continue;
+    }
+
+    const componentLinks = components
+      .map((component) => {
+        const query = new URLSearchParams({ q: "state:<approved" });
+        return `- [${component} review queue](https://translations.meadtools.com/projects/meadtools-pilot/${component}/de/?${query})`;
+      })
+      .join("\n");
+    const commitUrl = `https://github.com/${repositoryName}/commit/${commit}`;
+    const body = [
+      marker,
+      "## New German AI translation batch",
+      "",
+      `- Feature PR: [#${pullRequest.number}](${pullRequest.html_url})`,
+      `- Bot commit: [${commit.slice(0, 7)}](${commitUrl})`,
+      `- Components: ${components.join(", ")}`,
+      "- Status: generated and **unapproved**",
+      "",
+      componentLinks,
+      "",
+      `For corrections, open a German-only PR to \`preview\`; a merged trusted PR marks its changed units approved in Weblate. For an unchanged accepted suggestion, comment \`/approve-translations ${commit}\` on this issue.`,
+    ].join("\n");
+    await github(
+      `/repos/${owner}/${repository}/issues/${issue.number}/comments`,
+      token,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body }),
+      },
+    );
+    console.log(
+      `Added AI translation batch ${commit} to issue #${issue.number}.`,
+    );
   }
-
-  const componentLinks = components
-    .map((component) => {
-      const query = new URLSearchParams({ q: "state:<approved" });
-      return `- [${component} review queue](https://translations.meadtools.com/projects/meadtools-pilot/${component}/de/?${query})`;
-    })
-    .join("\n");
-  const commitUrl = `https://github.com/${repositoryName}/commit/${event.after}`;
-  const body = [
-    marker,
-    "## New German AI translation batch",
-    "",
-    `- Commit: [${event.after.slice(0, 7)}](${commitUrl})`,
-    `- Components: ${components.join(", ")}`,
-    "- Status: generated and **unapproved**",
-    "",
-    componentLinks,
-    "",
-    `To review in Git, branch from [this commit](${commitUrl}), edit only the German locale files, and open a PR to \`preview\`. A merged PR from @${reviewer} marks the changed units approved in Weblate.`,
-    "",
-    "For an unchanged suggestion, approve it in Weblate. The planned trusted `/approve-translations` issue command will provide a GitHub-only alternative.",
-  ].join("\n");
-  await github(`/repos/${owner}/${repository}/issues/${issue.number}/comments`, token, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ body }),
-  });
-
-  console.log(`Added Weblate translation batch ${event.after} to issue #${issue.number}.`);
 }
 
 if (import.meta.url === new URL(process.argv[1], "file:").href) {

--- a/scripts/queue-weblate-review.test.mjs
+++ b/scripts/queue-weblate-review.test.mjs
@@ -1,31 +1,34 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { getWeblateGermanComponents } from "./queue-weblate-review.mjs";
+import { getAiGermanComponents } from "./queue-weblate-review.mjs";
 
-const message = `chore(l10n): update German translation
+const message = `chore(l10n): add German AI translations
 
-Translation: MeadTools pilot/default
-Language: German`;
+Translation-Batch: ai-generated`;
 
-test("recognizes isolated Weblate German locale commits", () => {
+test("recognizes isolated German AI locale commits", () => {
   assert.deepEqual(
-    getWeblateGermanComponents(message, [
-      "packages/i18n/locales/de/default.json",
-    ]),
+    getAiGermanComponents(message, ["packages/i18n/locales/de/default.json"]),
     ["default"],
   );
 });
 
-test("ignores non-Weblate and mixed commits", () => {
+test("requires the AI batch marker and rejects mixed commits", () => {
   assert.deepEqual(
-    getWeblateGermanComponents("fix: improve German copy", [
+    getAiGermanComponents("fix: improve German copy", [
       "packages/i18n/locales/de/default.json",
     ]),
     [],
   );
   assert.deepEqual(
-    getWeblateGermanComponents(message, [
+    getAiGermanComponents("chore(l10n): add German AI translations", [
+      "packages/i18n/locales/de/default.json",
+    ]),
+    [],
+  );
+  assert.deepEqual(
+    getAiGermanComponents(message, [
       "packages/i18n/locales/de/default.json",
       "apps/web/app/page.tsx",
     ]),


### PR DESCRIPTION
Replaces the Weblate direct-push workflow with the agreed PR-based review flow.

- Queue review batches after a same-repository feature PR with an explicitly marked AI-only German commit merges into `preview`.
- Pin each queue entry to its source PR and exact bot commit.
- Restrict `/approve-translations` to that exact queue entry and its merged PR.
- Document Weblate as review-only and record SMTP as a go-live prerequisite.

Verification: `npm run test:workflows`; Prettier check.