### PR TITLE
chore(i18n): complete Weblate cutover

### DIFF
--- a/.github/workflows/approve-weblate-issue.yml
+++ b/.github/workflows/approve-weblate-issue.yml
@@ -1,0 +1,35 @@
+name: Approve unchanged Weblate translations
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  approve-weblate-batch:
+    if: >-
+      github.event.issue.pull_request == null &&
+      contains(github.event.comment.body, '/approve-weblate')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: weblate-issue-approval-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Check out preview history
+        uses: actions/checkout@v4
+        with:
+          ref: preview
+          fetch-depth: 0
+
+      - name: Approve the exact Weblate batch named in the issue
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_TOKEN: ${{ github.token }}
+          WEBLATE_URL: https://translations.meadtools.com
+          WEBLATE_APPROVAL_TOKEN: ${{ secrets.WEBLATE_APPROVAL_TOKEN }}
+        run: node scripts/approve-weblate-issue.mjs

--- a/docs/translation-workflow.md
+++ b/docs/translation-workflow.md
@@ -1,8 +1,7 @@
 # Translation workflow
 
-> **Status: cutover in progress.** Weblate is the translation service and Git
-> is the source of truth. The temporary build-pause marker remains in place
-> until this flow passes a real feature cycle.
+> **Status: Weblate is the translation service and Git is the source of
+> truth.** Normal builds are enabled.
 
 ## Goals
 
@@ -32,8 +31,7 @@ through `https://translations.meadtools.com/accounts/reset/`.
 Both production components (`default` and `yeast-table`) use the `preview`
 branch and Weblate's write-enabled deploy key. GitHub has a `push` webhook to
 Weblate, so an update to `preview` is fetched promptly. **Push on commit** is
-temporarily disabled while the old local-only unconfirmed batch is cleared; it
-is re-enabled immediately before the controlled end-to-end test.
+enabled.
 
 The Automatic Translation add-on is configured per component as follows:
 
@@ -85,10 +83,22 @@ access; until then it is assigned to `ljreaux`.
 `rizzek` is trusted automatically. The `translations-approved` label is the
 maintainer override for another reviewer.
 
-### Weblate review or approval
+### No-op approval from the review issue
 
-For an unchanged suggestion, review and approve it directly in Weblate. For a
-small correction, editing in Weblate is also allowed; Weblate makes the
+For a batch that needs no changes, `rizzek` or `ljreaux` comments the command
+shown on the queue issue, for example:
+
+```
+/approve-weblate bd1cdb2
+```
+
+GitHub verifies that the commit is a German-only Weblate automatic-translation
+batch listed on that exact issue, verifies its values still match Weblate, and
+marks only those units approved. It then comments with the result. This does
+not create a Git commit or deployment. Reviewing and approving an individual
+unit directly in Weblate remains available as well.
+
+For a small correction, editing in Weblate is also allowed; Weblate makes the
 follow-up commit to `preview`. The GitHub issue is a queue, not a second source
 of truth.
 
@@ -106,11 +116,6 @@ affected unapproved strings when useful.
 
 ## CI and deployment behavior
 
-The temporary `ops/translation-migration.skip-builds` marker currently pauses
-web, mobile, desktop, Vercel, and EAS work while this is tested.
-
-After the marker is removed:
-
 - normal feature changes without English locale edits build normally;
 - a `preview` merge that changes English locale files waits for Weblate; and
 - only the marked `Translation-Batch: weblate-auto` follow-up releases the web
@@ -121,7 +126,7 @@ the generated German files. A German-only review correction after the initial
 batch remains a normal translation-only update and does not release a new app
 build by itself.
 
-## Before removing the migration pause
+## Cutover validation
 
 - [ ] Confirm `rizzek` can sign in to Weblate and has accepted GitHub access.
 - [ ] Verify an OpenAI suggestion uses the glossary and informal German.
@@ -131,7 +136,7 @@ build by itself.
 - [ ] Confirm one review issue points to that commit and source PR.
 - [ ] Confirm the original preview push is deferred and the Weblate commit
       releases exactly one web/mobile preview build.
-- [ ] Test one trusted German-only PR and one direct Weblate approval.
+- [ ] Test one trusted German-only PR and one no-op issue approval.
 - [ ] Confirm the latest approved migration baseline still matches Git.
 
 ## Recovery

--- a/docs/translation-workflow.md
+++ b/docs/translation-workflow.md
@@ -132,7 +132,7 @@ build by itself.
 - [ ] Confirm the original preview push is deferred and the Weblate commit
       releases exactly one web/mobile preview build.
 - [ ] Test one trusted German-only PR and one direct Weblate approval.
-- [ ] Confirm the latest approved i18nexus migration values still match Git.
+- [ ] Confirm the latest approved migration baseline still matches Git.
 
 ## Recovery
 

--- a/ops/translation-migration.skip-builds
+++ b/ops/translation-migration.skip-builds
@@ -1,7 +1,0 @@
-Translation-provider migration in progress.
-
-This checked-in marker makes scripts/app-impact.mjs report that no application
-build is needed. GitHub Actions and Vercel therefore skip web, mobile, and
-desktop builds while we validate the migration workflow.
-
-Remove this file in the cutover completion PR to restore normal builds.

--- a/ops/weblate/.env.example
+++ b/ops/weblate/.env.example
@@ -34,9 +34,6 @@ WEBLATE_EMAIL_HOST_PASSWORD=replace-with-the-mailbox-app-password
 WEBLATE_EMAIL_USE_TLS=1
 WEBLATE_EMAIL_USE_SSL=0
 
-# Required only when using the OpenAI automatic-translation engine.
-OPENAI_API_KEY=replace-with-an-api-key
-
 CLIENT_MAX_BODY_SIZE=1000M
 
 # Backup configuration belongs in the untracked /srv/meadtools-weblate/backup.env

--- a/ops/weblate/README.md
+++ b/ops/weblate/README.md
@@ -33,9 +33,10 @@ service and send a password-reset email to verify delivery.
 ## Permanent deployment
 
 The permanent host uses the same ignored `.env.local` file shape as the pilot,
-but it must contain production-specific passwords, `WEBLATE_SITE_DOMAIN`, and
-the optional `OPENAI_API_KEY`. Keep that file mode `0600`; it is intentionally
-ignored by Git.
+but it must contain production-specific passwords and `WEBLATE_SITE_DOMAIN`.
+Configure the OpenAI automatic-translation provider in Weblate's project
+settings rather than in this file. Keep the file mode `0600`; it is
+intentionally ignored by Git.
 
 On the Ubuntu host, store the deployment under `/srv/meadtools-weblate` and
 use the production configuration as its `compose.yml`:

--- a/scripts/approve-weblate-issue.mjs
+++ b/scripts/approve-weblate-issue.mjs
@@ -1,0 +1,191 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+import {
+  getIssueComments,
+  getWeblateTranslationBatch,
+  github,
+} from "./queue-weblate-review.mjs";
+
+const WEBLATE_URL = process.env.WEBLATE_URL?.replace(/\/$/, "");
+const WEBLATE_TOKEN = process.env.WEBLATE_APPROVAL_TOKEN;
+const trustedReviewers = new Set(["ljreaux", "rizzek"]);
+const componentByFile = new Map([
+  ["packages/i18n/locales/de/default.json", "default"],
+  ["packages/i18n/locales/de/YeastTable.json", "yeast-table"],
+]);
+
+export function getIssueApprovalCommit(comment) {
+  const match = comment.trim().match(/^\/approve-weblate\s+([a-f0-9]{7,40})$/i);
+  return match?.[1].toLowerCase() ?? null;
+}
+
+function git(...args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function gitLines(...args) {
+  const output = git(...args);
+  return output ? output.split("\n").filter(Boolean) : [];
+}
+
+function flatten(value, prefix = "", entries = new Map()) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => flatten(item, `${prefix}[${index}]`, entries));
+    return entries;
+  }
+
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      flatten(child, prefix ? `${prefix}.${key}` : key, entries);
+    }
+    return entries;
+  }
+
+  entries.set(prefix, value);
+  return entries;
+}
+
+function readJson(revision, file) {
+  try {
+    return JSON.parse(git("show", `${revision}:${file}`));
+  } catch {
+    return {};
+  }
+}
+
+function isAncestor(commit, branch) {
+  return (
+    spawnSync("git", ["merge-base", "--is-ancestor", commit, branch]).status === 0
+  );
+}
+
+function getChangedUnits(batch) {
+  const changedFiles = gitLines("diff", "--name-only", batch.parent, batch.commit);
+  const changedUnits = [];
+
+  for (const file of changedFiles) {
+    const component = componentByFile.get(file);
+    if (!component) {
+      throw new Error(`Batch includes an unexpected file: ${file}`);
+    }
+
+    const previousEntries = flatten(readJson(batch.parent, file));
+    const currentEntries = flatten(readJson(batch.commit, file));
+    for (const [context, target] of currentEntries) {
+      if (previousEntries.get(context) !== target) {
+        changedUnits.push({ component, context, target });
+      }
+    }
+  }
+
+  return changedUnits;
+}
+
+async function approveUnits(changedUnits) {
+  const headers = {
+    Accept: "application/json",
+    Authorization: `Token ${WEBLATE_TOKEN}`,
+  };
+
+  for (const { component, context, target } of changedUnits) {
+    const query = new URLSearchParams({
+      q: `component:${component} language:de context:${context}`,
+      page_size: "10",
+    });
+    const response = await fetch(`${WEBLATE_URL}/api/units/?${query}`, { headers });
+    if (!response.ok) {
+      throw new Error(`Unable to find Weblate unit for ${component}:${context}.`);
+    }
+
+    const { results } = await response.json();
+    const unit = results.find(
+      (candidate) => candidate.context === context && candidate.target?.[0] === target,
+    );
+    if (!unit) {
+      throw new Error(
+        `Weblate does not have the expected current value for ${component}:${context}.`,
+      );
+    }
+
+    const approval = await fetch(`${WEBLATE_URL}/api/units/${unit.id}/`, {
+      method: "PATCH",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({ state: 30 }),
+    });
+    if (!approval.ok) {
+      throw new Error(`Unable to approve Weblate unit ${unit.id}.`);
+    }
+  }
+}
+
+async function main() {
+  const token = process.env.GITHUB_TOKEN;
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  const repositoryName = process.env.GITHUB_REPOSITORY;
+  if (!token || !eventPath || !repositoryName) {
+    throw new Error(
+      "GITHUB_TOKEN, GITHUB_EVENT_PATH, and GITHUB_REPOSITORY are required.",
+    );
+  }
+
+  const event = JSON.parse(readFileSync(eventPath, "utf8"));
+  const commitPrefix = getIssueApprovalCommit(event.comment.body);
+  if (!commitPrefix || event.issue.pull_request) return;
+  if (!trustedReviewers.has(event.comment.user.login)) {
+    console.log(`Ignoring approval command from ${event.comment.user.login}.`);
+    return;
+  }
+  if (!WEBLATE_URL || !WEBLATE_TOKEN) {
+    throw new Error("WEBLATE_URL and WEBLATE_APPROVAL_TOKEN are required.");
+  }
+
+  const commit = git("rev-parse", `${commitPrefix}^{commit}`);
+  if (!isAncestor(commit, "origin/preview")) {
+    throw new Error(`Weblate batch ${commitPrefix} is not on preview.`);
+  }
+
+  const batch = getWeblateTranslationBatch(commit);
+  if (!batch) {
+    throw new Error(`${commitPrefix} is not an isolated Weblate German translation batch.`);
+  }
+
+  const [owner, repository] = repositoryName.split("/");
+  const comments = await getIssueComments(owner, repository, event.issue.number, token);
+  const queueMarker = `commit-${commit.slice(0, 7)}`;
+  if (!comments.some((comment) => comment.body.includes(queueMarker))) {
+    throw new Error(`This issue does not list Weblate batch ${commit.slice(0, 7)}.`);
+  }
+
+  const completionMarker = `<!-- translation-review-approved:commit-${commit} -->`;
+  if (comments.some((comment) => comment.body.includes(completionMarker))) {
+    console.log(`Weblate batch ${commit.slice(0, 7)} was already approved from this issue.`);
+    return;
+  }
+
+  const changedUnits = getChangedUnits(batch);
+  if (changedUnits.length === 0) {
+    throw new Error(`Weblate batch ${commit.slice(0, 7)} has no changed German values.`);
+  }
+
+  await approveUnits(changedUnits);
+  await github(
+    `/repos/${owner}/${repository}/issues/${event.issue.number}/comments`,
+    token,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        body: [
+          completionMarker,
+          `Approved ${changedUnits.length} German Weblate unit(s) from [${commit.slice(0, 7)}](https://github.com/${repositoryName}/commit/${commit}) based on @${event.comment.user.login}'s no-op review command. No translation commit was created.`,
+        ].join("\n\n"),
+      }),
+    },
+  );
+  console.log(`Approved ${changedUnits.length} German Weblate unit(s).`);
+}
+
+if (import.meta.url === new URL(process.argv[1], "file:").href) {
+  await main();
+}

--- a/scripts/queue-weblate-review.mjs
+++ b/scripts/queue-weblate-review.mjs
@@ -65,24 +65,50 @@ function githubUrl(path) {
   return `https://api.github.com${path}`;
 }
 
-async function github(path, token, options = {}) {
-  const response = await fetch(githubUrl(path), {
-    ...options,
-    headers: {
-      Accept: "application/vnd.github+json",
-      Authorization: `Bearer ${token}`,
-      "X-GitHub-Api-Version": "2022-11-28",
-      ...(options.headers ?? {}),
-    },
-  });
+const retryableGithubStatuses = new Set([429, 500, 502, 503, 504]);
+const githubRequestAttempts = 4;
 
-  if (!response.ok) {
-    throw new Error(
-      `GitHub API ${options.method ?? "GET"} ${path} failed: ${response.status} ${await response.text()}`,
+function wait(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function github(path, token, options = {}) {
+  for (let attempt = 1; attempt <= githubRequestAttempts; attempt += 1) {
+    const response = await fetch(githubUrl(path), {
+      ...options,
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        ...(options.headers ?? {}),
+      },
+    });
+
+    if (response.ok) {
+      return response.status === 204 ? null : response.json();
+    }
+
+    const body = await response.text();
+    if (
+      !retryableGithubStatuses.has(response.status) ||
+      attempt === githubRequestAttempts
+    ) {
+      throw new Error(
+        `GitHub API ${options.method ?? "GET"} ${path} failed: ${response.status} ${body}`,
+      );
+    }
+
+    const retryAfter = Number(response.headers.get("retry-after"));
+    const delay = Number.isFinite(retryAfter)
+      ? retryAfter * 1000
+      : 500 * 2 ** (attempt - 1);
+    console.warn(
+      `GitHub API ${options.method ?? "GET"} ${path} returned ${response.status}; retrying in ${delay}ms (${attempt}/${githubRequestAttempts}).`,
     );
+    await wait(delay);
   }
 
-  return response.status === 204 ? null : response.json();
+  throw new Error("GitHub request retry loop exited unexpectedly.");
 }
 
 async function getIssueComments(owner, repository, issueNumber, token) {

--- a/scripts/queue-weblate-review.mjs
+++ b/scripts/queue-weblate-review.mjs
@@ -72,7 +72,7 @@ function wait(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-async function github(path, token, options = {}) {
+export async function github(path, token, options = {}) {
   for (let attempt = 1; attempt <= githubRequestAttempts; attempt += 1) {
     const response = await fetch(githubUrl(path), {
       ...options,
@@ -111,7 +111,7 @@ async function github(path, token, options = {}) {
   throw new Error("GitHub request retry loop exited unexpectedly.");
 }
 
-async function getIssueComments(owner, repository, issueNumber, token) {
+export async function getIssueComments(owner, repository, issueNumber, token) {
   const comments = [];
   for (let page = 1; ; page += 1) {
     const response = await github(
@@ -266,7 +266,7 @@ async function main() {
       "",
       componentLinks,
       "",
-      "For corrections, open a German-only PR to `preview`; a merged trusted PR marks its changed units approved in Weblate. For an unchanged suggestion, approve it directly in Weblate.",
+      `For an unchanged batch, comment \`/approve-weblate ${batch.commit.slice(0, 7)}\` on this issue; it approves exactly that batch in Weblate without a Git commit. For corrections, open a German-only PR to \`preview\`; a merged trusted PR marks its changed units approved in Weblate.`,
     ].join("\n");
     await github(
       `/repos/${owner}/${repository}/issues/${issue.number}/comments`,

--- a/scripts/queue-weblate-review.test.mjs
+++ b/scripts/queue-weblate-review.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { getWeblateGermanComponents } from "./queue-weblate-review.mjs";
+import { getIssueApprovalCommit } from "./approve-weblate-issue.mjs";
 
 const message = `chore(l10n): update German translation
 
@@ -34,4 +35,14 @@ test("requires the Weblate batch marker and rejects mixed commits", () => {
     ]),
     [],
   );
+});
+
+test("accepts only an exact no-op approval command with a commit prefix", () => {
+  assert.equal(getIssueApprovalCommit("/approve-weblate bd1cdb2"), "bd1cdb2");
+  assert.equal(
+    getIssueApprovalCommit("  /approve-weblate BD1CDB2919441ECb4390A8dC8b72fa05c77e49E8  "),
+    "bd1cdb2919441ecb4390a8dc8b72fa05c77e49e8",
+  );
+  assert.equal(getIssueApprovalCommit("please /approve-weblate bd1cdb2"), null);
+  assert.equal(getIssueApprovalCommit("/approve-weblate not-a-commit"), null);
 });


### PR DESCRIPTION
Completes the Weblate migration after the native automatic-translation test.

- restores normal deployment/build behavior by removing the temporary migration pause
- retries transient GitHub API failures while creating the German review queue issue
- adds guarded `/approve-weblate <commit>` issue commands for unchanged translation batches
- removes stale i18nexus/OpenAI environment documentation

Validated: `npm run test:workflows` (16 passing).

Final human acceptance tests: rizzek can approve one unchanged batch from its queue issue and merge one German-only correction PR.