### PR TITLE
fix(i18n): correct unauthorized label

### DIFF
--- a/packages/i18n/locales/en/default.json
+++ b/packages/i18n/locales/en/default.json
@@ -1810,7 +1810,7 @@
     "redoTutorial": "Redo the tutorial at any time at"
   },
   "type": "Type",
-  "unathorized": "Unathorized",
+  "unathorized": "Unauthorized",
   "unit": "Unit",
   "UNITS": "Units",
   "units": {


### PR DESCRIPTION
Corrects the user-facing English typo `Unathorized` → `Unauthorized`.

This is the controlled live Weblate workflow check:

1. merge to `preview`;
2. verify the original source commit defers deployment;
3. verify Weblate creates one German needs-review commit;
4. verify #370 receives the exact batch comment and Discord tags rizzek;
5. verify only the Weblate follow-up triggers the preview build;
6. have rizzek use the no-op approval command if the German result needs no correction.

Validated: `npm run test:i18n`.