### PR TITLE
fix(i18n): recognize native Weblate follow-ups

### DIFF
--- a/docs/translation-workflow.md
+++ b/docs/translation-workflow.md
@@ -40,7 +40,9 @@ The Automatic Translation add-on is configured per component as follows:
 - mode: **Needs editing** (`fuzzy`), never auto-approved;
 - filter: German strings below the translated state;
 - threshold: 90; and
-- commit trailer: `Translation-Batch: weblate-auto`.
+- a German-only native Weblate follow-up directly after an English source
+  update is recognized as the release batch (the legacy
+  `Translation-Batch: weblate-auto` trailer remains supported).
 
 The OpenAI key stays in Weblate's untracked server configuration. It is not a
 GitHub Actions secret. The provider uses the project glossary, informal German
@@ -118,8 +120,8 @@ affected unapproved strings when useful.
 
 - normal feature changes without English locale edits build normally;
 - a `preview` merge that changes English locale files waits for Weblate; and
-- only the marked `Translation-Batch: weblate-auto` follow-up releases the web
-  deployment and EAS preview builds.
+- only the recognized Weblate German follow-up releases the web deployment and
+  EAS preview builds.
 
 This avoids duplicate builds and prevents the deployed artifact from missing
 the generated German files. A German-only review correction after the initial

--- a/scripts/app-impact.mjs
+++ b/scripts/app-impact.mjs
@@ -18,9 +18,9 @@ const SHARED_PATHS = [
   "tsconfig.base.json",
 ];
 
-// Most translation-only commits do not need a new application build. A marked
-// Weblate automatic-translation commit is the exception: it releases the
-// single deferred preview build after an English source change.
+// Most translation-only commits do not need a new application build. A
+// German-only Weblate follow-up immediately after an English source change is
+// the exception: it releases the single deferred preview build.
 const GENERATED_TRANSLATION_PATH = "packages/i18n/locales/";
 const ENGLISH_TRANSLATION_PATH = "packages/i18n/locales/en/";
 const WEBLATE_BATCH_MARKER = "Translation-Batch: weblate-auto";
@@ -114,6 +114,31 @@ export function classifyAppImpact(
   return impact;
 }
 
+export function isWeblateTranslationBatch(
+  message,
+  changedPaths,
+  sourceChangedPaths = [],
+) {
+  const isGermanOnly =
+    changedPaths.length > 0 &&
+    changedPaths.every(
+      (changedPath) =>
+        changedPath.startsWith(GENERATED_TRANSLATION_PATH) &&
+        !changedPath.startsWith(ENGLISH_TRANSLATION_PATH),
+    );
+  if (!isGermanOnly) return false;
+
+  // Keep recognizing the migration-era marker, but native Weblate commits use
+  // the normal component template. Their position directly after an English
+  // source update is the reliable signal.
+  return (
+    message.includes(WEBLATE_BATCH_MARKER) ||
+    sourceChangedPaths.some((changedPath) =>
+      changedPath.startsWith(ENGLISH_TRANSLATION_PATH),
+    )
+  );
+}
+
 function readChangedPaths(base, head) {
   const result = spawnSync(
     "git",
@@ -172,11 +197,15 @@ async function run() {
 
   try {
     changedPaths = readChangedPaths(base, head);
+    const commitChangedPaths = readChangedPaths(`${head}^`, head);
+    const sourceChangedPaths = readChangedPaths(`${head}^^`, `${head}^`);
     impact = classifyAppImpact(changedPaths, {
       buildsPaused: existsSync(MIGRATION_BUILD_PAUSE_MARKER),
       deferForWeblate: isPreviewBranch(),
-      isWeblateTranslationBatch: readCommitMessage(head).includes(
-        WEBLATE_BATCH_MARKER,
+      isWeblateTranslationBatch: isWeblateTranslationBatch(
+        readCommitMessage(head),
+        commitChangedPaths,
+        sourceChangedPaths,
       ),
     });
   } catch (error) {

--- a/scripts/app-impact.test.mjs
+++ b/scripts/app-impact.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { classifyAppImpact, isTargetAffected } from "./app-impact.mjs";
+import {
+  classifyAppImpact,
+  isTargetAffected,
+  isWeblateTranslationBatch,
+} from "./app-impact.mjs";
 
 test("app-local changes affect only their app", () => {
   assert.deepEqual(classifyAppImpact(["apps/mobile/app/index.tsx"]), {
@@ -69,13 +73,32 @@ test("a preview source change waits for Weblate when English changes", () => {
   );
 });
 
-test("the marked Weblate follow-up releases one complete build", () => {
+test("a Weblate follow-up releases one complete build", () => {
   assert.deepEqual(
     classifyAppImpact(["packages/i18n/locales/de/default.json"], {
       deferForWeblate: true,
       isWeblateTranslationBatch: true,
     }),
     { web: true, mobile: true, desktop: true },
+  );
+});
+
+test("recognizes native Weblate batches after an English source update", () => {
+  assert.equal(
+    isWeblateTranslationBatch(
+      "chore(l10n): update German translation",
+      ["packages/i18n/locales/de/default.json"],
+      ["packages/i18n/locales/en/default.json"],
+    ),
+    true,
+  );
+  assert.equal(
+    isWeblateTranslationBatch(
+      "fix: adjust German copy",
+      ["packages/i18n/locales/de/default.json"],
+      [],
+    ),
+    false,
   );
 });
 

--- a/scripts/queue-weblate-review.mjs
+++ b/scripts/queue-weblate-review.mjs
@@ -5,24 +5,32 @@ const reviewLabel = "translation-review";
 const reviewIssueTitle = "German translation review queue";
 const reviewer = "rizzek";
 const fallbackReviewer = "ljreaux";
+const englishTranslationPath = "packages/i18n/locales/en/";
 const componentByFile = new Map([
   ["packages/i18n/locales/de/default.json", "default"],
   ["packages/i18n/locales/de/YeastTable.json", "yeast-table"],
 ]);
 
-// Weblate writes this trailer into automatic-translation commits. The file
-// check prevents an unrelated commit from being added to the review queue.
-export function getWeblateGermanComponents(message, changedFiles) {
-  if (!/^Translation-Batch: weblate-auto$/m.test(message)) {
-    return [];
-  }
-
+// The migration-era marker remains supported, but native Weblate commits use
+// the component's normal commit template. A German-only commit immediately
+// following an English source update is the reliable native-Weblate signal.
+export function getWeblateGermanComponents(
+  message,
+  changedFiles,
+  sourceChangedFiles = [],
+) {
   if (
     changedFiles.length === 0 ||
     changedFiles.some((file) => !componentByFile.has(file))
   ) {
     return [];
   }
+
+  const hasMarker = /^Translation-Batch: weblate-auto$/m.test(message);
+  const followsEnglishSource = sourceChangedFiles.some((file) =>
+    file.startsWith(englishTranslationPath),
+  );
+  if (!hasMarker && !followsEnglishSource) return [];
 
   return [...new Set(changedFiles.map((file) => componentByFile.get(file)))];
 }
@@ -39,9 +47,11 @@ function gitLines(...args) {
 export function getWeblateTranslationBatch(commit = "HEAD") {
   const parent = git("rev-parse", `${commit}^`);
   const changedFiles = gitLines("diff", "--name-only", parent, commit);
+  const sourceChangedFiles = gitLines("diff", "--name-only", `${parent}^`, parent);
   const components = getWeblateGermanComponents(
     git("log", "-1", "--format=%B", commit),
     changedFiles,
+    sourceChangedFiles,
   );
 
   return components.length > 0 ? { commit, parent, components } : null;

--- a/scripts/queue-weblate-review.test.mjs
+++ b/scripts/queue-weblate-review.test.mjs
@@ -15,7 +15,7 @@ test("recognizes isolated German Weblate locale commits", () => {
   );
 });
 
-test("requires the Weblate batch marker and rejects mixed commits", () => {
+test("recognizes native Weblate commits after English source changes and rejects mixed commits", () => {
   assert.deepEqual(
     getWeblateGermanComponents("fix: improve German copy", [
       "packages/i18n/locales/de/default.json",
@@ -23,10 +23,12 @@ test("requires the Weblate batch marker and rejects mixed commits", () => {
     [],
   );
   assert.deepEqual(
-    getWeblateGermanComponents("chore(l10n): update German translation", [
-      "packages/i18n/locales/de/default.json",
-    ]),
-    [],
+    getWeblateGermanComponents(
+      "chore(l10n): update German translation",
+      ["packages/i18n/locales/de/default.json"],
+      ["packages/i18n/locales/en/default.json"],
+    ),
+    ["default"],
   );
   assert.deepEqual(
     getWeblateGermanComponents(message, [


### PR DESCRIPTION
Native Weblate automatic-translation commits use the component commit template, not a custom `Translation-Batch` trailer.

Recognize a German-only Weblate commit immediately following an English source update as the deferred release batch, while preserving compatibility with the older marker. This restores the review issue, Discord notification, and one-build flow.

The live Weblate filter now selects unfinished German strings that are not already automatically translated. A source change clears that flag, so changed strings are selected again; the 20 legacy empty entries are held out temporarily with the `migration-backlog` label.

Validated: `npm run test:workflows` (17 passing).

After merge, run the already-imported `unathorized` unit through Weblate as a one-unit automatic translation to finish the live test.