### PR TITLE
fix(ci): scan complete Weblate push range

### DIFF
--- a/docs/translation-workflow.md
+++ b/docs/translation-workflow.md
@@ -126,7 +126,8 @@ affected unapproved strings when useful.
 This avoids duplicate builds and prevents the deployed artifact from missing
 the generated German files. A German-only review correction after the initial
 batch remains a normal translation-only update and does not release a new app
-build by itself.
+build by itself. If Weblate flushes other language commits in the same push,
+the gate scans the full push range for the German release batch.
 
 ## Cutover validation
 

--- a/scripts/app-impact.mjs
+++ b/scripts/app-impact.mjs
@@ -139,6 +139,12 @@ export function isWeblateTranslationBatch(
   );
 }
 
+export function hasWeblateTranslationBatch(batches) {
+  return batches.some(({ message, changedPaths, sourceChangedPaths }) =>
+    isWeblateTranslationBatch(message, changedPaths, sourceChangedPaths),
+  );
+}
+
 function readChangedPaths(base, head) {
   const result = spawnSync(
     "git",
@@ -179,6 +185,28 @@ function readCommitMessage(head) {
   return result.stdout;
 }
 
+function readRevisionCommits(base, head) {
+  const result = spawnSync("git", ["rev-list", "--reverse", `${base}..${head}`], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr.trim() || "Unable to read revision commits.");
+  }
+  return result.stdout.split("\n").map((commit) => commit.trim()).filter(Boolean);
+}
+
+function hasWeblateTranslationBatchInRange(base, head) {
+  const batches = readRevisionCommits(base, head).map((commit) => {
+    const parent = `${commit}^`;
+    return {
+      message: readCommitMessage(commit),
+      changedPaths: readChangedPaths(parent, commit),
+      sourceChangedPaths: readChangedPaths(`${commit}^^`, parent),
+    };
+  });
+  return hasWeblateTranslationBatch(batches);
+}
+
 function isPreviewBranch() {
   return (
     process.env.APP_IMPACT_DEFER_FOR_WEBLATE === "true" ||
@@ -197,16 +225,10 @@ async function run() {
 
   try {
     changedPaths = readChangedPaths(base, head);
-    const commitChangedPaths = readChangedPaths(`${head}^`, head);
-    const sourceChangedPaths = readChangedPaths(`${head}^^`, `${head}^`);
     impact = classifyAppImpact(changedPaths, {
       buildsPaused: existsSync(MIGRATION_BUILD_PAUSE_MARKER),
       deferForWeblate: isPreviewBranch(),
-      isWeblateTranslationBatch: isWeblateTranslationBatch(
-        readCommitMessage(head),
-        commitChangedPaths,
-        sourceChangedPaths,
-      ),
+      isWeblateTranslationBatch: hasWeblateTranslationBatchInRange(base, head),
     });
   } catch (error) {
     console.warn(

--- a/scripts/app-impact.test.mjs
+++ b/scripts/app-impact.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   classifyAppImpact,
+  hasWeblateTranslationBatch,
   isTargetAffected,
   isWeblateTranslationBatch,
 } from "./app-impact.mjs";
@@ -99,6 +100,24 @@ test("recognizes native Weblate batches after an English source update", () => {
       [],
     ),
     false,
+  );
+});
+
+test("recognizes a Weblate batch anywhere in a multi-commit push", () => {
+  assert.equal(
+    hasWeblateTranslationBatch([
+      {
+        message: "chore(l10n): update German translation\n\nTranslation-Batch: weblate-auto",
+        changedPaths: ["packages/i18n/locales/de/default.json"],
+        sourceChangedPaths: [],
+      },
+      {
+        message: "chore(l10n): update Lithuanian translation",
+        changedPaths: ["packages/i18n/locales/lt/default.json"],
+        sourceChangedPaths: [],
+      },
+    ]),
+    true,
   );
 });
 


### PR DESCRIPTION
Weblate can flush another language commit in the same push after the German automatic-translation commit.

Scan every commit in the received push range for the German release batch, rather than inspecting only the final commit. This preserves the single deferred-build release even when another translation commit follows it.

Validated: `npm run test:workflows` (18 passing).

The current Weblate test already created its German review comment; this fixes the build-gate edge case for the next live batch.