### PR TITLE
fix(ci): deploy reviewed German corrections

### DIFF
--- a/.github/workflows/approve-translator-pr.yml
+++ b/.github/workflows/approve-translator-pr.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches: [preview]
     types: [closed]
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Merged trusted German translation PR to approve in Weblate
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -11,20 +17,33 @@ permissions:
 
 jobs:
   approve-weblate-units:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
+      - name: Load manually requested pull request
+        id: pull-request
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}" > "${RUNNER_TEMP}/pull-request.json"
+          merge_commit_sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}" --jq .merge_commit_sha)"
+          echo "merge_commit_sha=${merge_commit_sha}" >> "$GITHUB_OUTPUT"
+          echo "payload_path=${RUNNER_TEMP}/pull-request.json" >> "$GITHUB_OUTPUT"
+
       - name: Check out the merged commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && steps.pull-request.outputs.merge_commit_sha || github.event.pull_request.merge_commit_sha }}
           fetch-depth: 2
 
       - name: Approve trusted German translation changes in Weblate
         env:
           GITHUB_EVENT_PATH: ${{ github.event_path }}
+          WEBLATE_APPROVAL_PR_PATH: ${{ steps.pull-request.outputs.payload_path }}
           WEBLATE_URL: https://translations.meadtools.com
           WEBLATE_APPROVAL_TOKEN: ${{ secrets.WEBLATE_APPROVAL_TOKEN }}
         run: node scripts/approve-weblate-pr.mjs

--- a/docs/translation-workflow.md
+++ b/docs/translation-workflow.md
@@ -81,6 +81,8 @@ access; until then it is assigned to `ljreaux`.
 3. Open a German-only PR targeting `preview`.
 4. When a trusted German-only PR merges, GitHub verifies the changed values are
    current in Weblate and marks only those units approved.
+5. The German correction releases a fresh preview build so the reviewed copy is
+   available for verification.
 
 `rizzek` is trusted automatically. The `translations-approved` label is the
 maintainer override for another reviewer.
@@ -120,14 +122,14 @@ affected unapproved strings when useful.
 
 - normal feature changes without English locale edits build normally;
 - a `preview` merge that changes English locale files waits for Weblate; and
-- only the recognized Weblate German follow-up releases the web deployment and
-  EAS preview builds.
+- the recognized Weblate German follow-up releases the web deployment and EAS
+  preview builds; and
+- a German-only human correction also releases a fresh web deployment and EAS
+  preview builds.
 
 This avoids duplicate builds and prevents the deployed artifact from missing
-the generated German files. A German-only review correction after the initial
-batch remains a normal translation-only update and does not release a new app
-build by itself. If Weblate flushes other language commits in the same push,
-the gate scans the full push range for the German release batch.
+the generated German files. If Weblate flushes other language commits in the
+same push, the gate scans the full push range for the German release batch.
 
 ## Cutover validation
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "vercel-build": "npm run vercel-build --workspace @meadtools/web",
     "start": "npm run start --workspace @meadtools/web",
     "test": "npm run test:workflows && npm run test:core && npm run test:schemas && npm run test:api-contract && npm run test:api-client && npm run test:brew-domain && npm run test:design-tokens && npm run test:i18n && npm test --workspace @meadtools/web",
-    "test:workflows": "node --test scripts/app-impact.test.mjs scripts/queue-weblate-review.test.mjs",
+    "test:workflows": "node --test scripts/app-impact.test.mjs scripts/queue-weblate-review.test.mjs scripts/weblate-approval.test.mjs",
     "typecheck": "npm run prisma:generate --workspace @meadtools/web && npm run typecheck --workspaces --if-present",
     "openapi:generate": "npm run openapi:generate --workspace @meadtools/web",
     "contracts:generate": "node scripts/generate-api-contract-types.mjs",

--- a/scripts/app-impact.mjs
+++ b/scripts/app-impact.mjs
@@ -18,11 +18,12 @@ const SHARED_PATHS = [
   "tsconfig.base.json",
 ];
 
-// Most translation-only commits do not need a new application build. A
-// German-only Weblate follow-up immediately after an English source change is
-// the exception: it releases the single deferred preview build.
+// Most translation-only commits do not need a new application build. German is
+// bundled by every shipped app, though, so both Weblate follow-ups and human
+// German review corrections must release an updated artifact.
 const GENERATED_TRANSLATION_PATH = "packages/i18n/locales/";
 const ENGLISH_TRANSLATION_PATH = "packages/i18n/locales/en/";
+const GERMAN_TRANSLATION_PATH = "packages/i18n/locales/de/";
 const WEBLATE_BATCH_MARKER = "Translation-Batch: weblate-auto";
 
 const LOCKFILE = "package-lock.json";
@@ -90,6 +91,14 @@ export function classifyAppImpact(
     )
   ) {
     return Object.fromEntries(TARGETS.map((target) => [target, false]));
+  }
+
+  if (
+    changedPaths.some((changedPath) =>
+      changedPath.startsWith(GERMAN_TRANSLATION_PATH),
+    )
+  ) {
+    return Object.fromEntries(TARGETS.map((target) => [target, true]));
   }
 
   const impact = Object.fromEntries(

--- a/scripts/app-impact.test.mjs
+++ b/scripts/app-impact.test.mjs
@@ -36,21 +36,21 @@ test("shared packages and root dependencies affect every app", () => {
   }
 });
 
-test("generated translation-only changes do not rebuild apps", () => {
+test("German translation corrections rebuild every app", () => {
   assert.deepEqual(
     classifyAppImpact([
       "packages/i18n/locales/de/default.json",
       "packages/i18n/locales/de/YeastTable.json",
     ]),
     {
-      web: false,
-      mobile: false,
-      desktop: false,
+      web: true,
+      mobile: true,
+      desktop: true,
     },
   );
 });
 
-test("translation updates deploy when combined with an app change", () => {
+test("German translation corrections rebuild every app even with an app-local change", () => {
   assert.deepEqual(
     classifyAppImpact([
       "apps/web/app/page.tsx",
@@ -58,8 +58,8 @@ test("translation updates deploy when combined with an app change", () => {
     ]),
     {
       web: true,
-      mobile: false,
-      desktop: false,
+      mobile: true,
+      desktop: true,
     },
   );
 });

--- a/scripts/approve-weblate-issue.mjs
+++ b/scripts/approve-weblate-issue.mjs
@@ -6,6 +6,7 @@ import {
   getWeblateTranslationBatch,
   github,
 } from "./queue-weblate-review.mjs";
+import { approveWeblateUnit } from "./weblate-approval.mjs";
 
 const WEBLATE_URL = process.env.WEBLATE_URL?.replace(/\/$/, "");
 const WEBLATE_TOKEN = process.env.WEBLATE_APPROVAL_TOKEN;
@@ -108,14 +109,7 @@ async function approveUnits(changedUnits) {
       );
     }
 
-    const approval = await fetch(`${WEBLATE_URL}/api/units/${unit.id}/`, {
-      method: "PATCH",
-      headers: { ...headers, "Content-Type": "application/json" },
-      body: JSON.stringify({ state: 30 }),
-    });
-    if (!approval.ok) {
-      throw new Error(`Unable to approve Weblate unit ${unit.id}.`);
-    }
+    await approveWeblateUnit({ weblateUrl: WEBLATE_URL, headers, unit });
   }
 }
 

--- a/scripts/approve-weblate-pr.mjs
+++ b/scripts/approve-weblate-pr.mjs
@@ -1,10 +1,14 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
+import { approveWeblateUnit } from "./weblate-approval.mjs";
+
 const WEBLATE_URL = process.env.WEBLATE_URL?.replace(/\/$/, "");
 const WEBLATE_TOKEN = process.env.WEBLATE_APPROVAL_TOKEN;
-const event = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
-const pullRequest = event.pull_request;
+const pullRequestPath =
+  process.env.WEBLATE_APPROVAL_PR_PATH || process.env.GITHUB_EVENT_PATH;
+const event = JSON.parse(readFileSync(pullRequestPath, "utf8"));
+const pullRequest = event.pull_request || event;
 const approvalLabel = "translations-approved";
 const trustedAuthor = "rizzek";
 const componentByFile = new Map([
@@ -117,14 +121,7 @@ for (const { component, context, target } of changedUnits) {
     );
   }
 
-  const approval = await fetch(`${WEBLATE_URL}/api/units/${unit.id}/`, {
-    method: "PATCH",
-    headers: { ...headers, "Content-Type": "application/json" },
-    body: JSON.stringify({ state: 30 }),
-  });
-  if (!approval.ok) {
-    throw new Error(`Unable to approve Weblate unit ${unit.id}.`);
-  }
+  await approveWeblateUnit({ weblateUrl: WEBLATE_URL, headers, unit });
 }
 
 console.log(`Approved ${changedUnits.length} German Weblate unit(s).`);

--- a/scripts/weblate-approval.mjs
+++ b/scripts/weblate-approval.mjs
@@ -1,0 +1,25 @@
+export function buildUnitApprovalPayload(unit) {
+  if (!Array.isArray(unit.target) || unit.target.length === 0) {
+    throw new Error(`Weblate unit ${unit.id} has no translation target to approve.`);
+  }
+
+  return {
+    state: 30,
+    target: unit.target,
+  };
+}
+
+export async function approveWeblateUnit({ weblateUrl, headers, unit }) {
+  const response = await fetch(`${weblateUrl}/api/units/${unit.id}/`, {
+    method: "PATCH",
+    headers: { ...headers, "Content-Type": "application/json" },
+    body: JSON.stringify(buildUnitApprovalPayload(unit)),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(
+      `Unable to approve Weblate unit ${unit.id} (${response.status}): ${detail}`,
+    );
+  }
+}

--- a/scripts/weblate-approval.test.mjs
+++ b/scripts/weblate-approval.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildUnitApprovalPayload } from "./weblate-approval.mjs";
+
+test("approving a Weblate unit preserves its target value", () => {
+  assert.deepEqual(
+    buildUnitApprovalPayload({ id: 1460, target: ["Nicht autorisiert"] }),
+    { state: 30, target: ["Nicht autorisiert"] },
+  );
+});
+
+test("approving a Weblate unit requires a target value", () => {
+  assert.throws(
+    () => buildUnitApprovalPayload({ id: 1460, target: [] }),
+    /has no translation target/,
+  );
+});


### PR DESCRIPTION
## Summary
- make German-only translation corrections trigger web, mobile, and desktop preview artifacts
- retain the English-source wait for Weblate
- fix trusted-PR and no-op Weblate approvals by sending the required target value with the approval state
- add a guarded manual recovery trigger for a previously failed trusted German PR
- document the corrected deployment behavior

## Verification
- npm run test:workflows (20 passing)
- node --check for both Weblate approval scripts
- actionlint for the approval workflow
- replayed PR #376 merge range through `scripts/app-impact.mjs`; it now reports web/mobile/desktop as affected
- confirmed against Weblate 2026.7.1 API implementation that an approval update requires both `state` and `target`