### PR TITLE
fix(ci): add review recovery and check overrides

### DIFF
--- a/.github/workflows/approve-translator-pr.yml
+++ b/.github/workflows/approve-translator-pr.yml
@@ -29,7 +29,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number }}
         run: |
-          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}" > "${RUNNER_TEMP}/pull-request.json"
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}" --jq '{pull_request: .}' > "${RUNNER_TEMP}/pull-request.json"
           merge_commit_sha="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PULL_REQUEST_NUMBER}" --jq .merge_commit_sha)"
           echo "merge_commit_sha=${merge_commit_sha}" >> "$GITHUB_OUTPUT"
           echo "payload_path=${RUNNER_TEMP}/pull-request.json" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,6 +2,7 @@ name: Quality
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   push:
     branches:
       - main
@@ -40,7 +41,9 @@ jobs:
   test:
     name: Typecheck, test, and verify OpenAPI
     needs: impact
-    if: needs.impact.outputs.web == 'true'
+    # Add the skip-web-check label to bypass this one job for a PR. Pushes to
+    # preview/main intentionally ignore PR-only overrides.
+    if: needs.impact.outputs.web == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-web-check')
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -81,7 +84,9 @@ jobs:
   mobile:
     name: Typecheck and export mobile
     needs: impact
-    if: needs.impact.outputs.mobile == 'true'
+    # Add the skip-mobile-check label to bypass this one job for a PR. Pushes
+    # to preview/main intentionally ignore PR-only overrides.
+    if: needs.impact.outputs.mobile == 'true' && !contains(github.event.pull_request.labels.*.name, 'skip-mobile-check')
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/docs/ci-check-overrides.md
+++ b/docs/ci-check-overrides.md
@@ -1,0 +1,14 @@
+# PR check overrides
+
+Use these labels only when a known, unrelated failure should not block a pull
+request. They apply only to the pull request validation run; the normal
+`preview` or `main` push validation still runs after merge.
+
+| Label | Skips |
+| --- | --- |
+| `skip-web-check` | Typecheck, test, and verify OpenAPI |
+| `skip-mobile-check` | Typecheck and export mobile |
+
+The affected-app classification and Vercel preview are deliberately not
+skippable with these labels. Remove an override label once it is no longer
+needed.

--- a/scripts/approve-weblate-pr.mjs
+++ b/scripts/approve-weblate-pr.mjs
@@ -1,14 +1,17 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 
-import { approveWeblateUnit } from "./weblate-approval.mjs";
+import {
+  approveWeblateUnit,
+  getPullRequestPayload,
+} from "./weblate-approval.mjs";
 
 const WEBLATE_URL = process.env.WEBLATE_URL?.replace(/\/$/, "");
 const WEBLATE_TOKEN = process.env.WEBLATE_APPROVAL_TOKEN;
 const pullRequestPath =
   process.env.WEBLATE_APPROVAL_PR_PATH || process.env.GITHUB_EVENT_PATH;
 const event = JSON.parse(readFileSync(pullRequestPath, "utf8"));
-const pullRequest = event.pull_request || event;
+const pullRequest = getPullRequestPayload(event);
 const approvalLabel = "translations-approved";
 const trustedAuthor = "rizzek";
 const componentByFile = new Map([

--- a/scripts/weblate-approval.mjs
+++ b/scripts/weblate-approval.mjs
@@ -9,6 +9,14 @@ export function buildUnitApprovalPayload(unit) {
   };
 }
 
+export function getPullRequestPayload(event) {
+  const pullRequest = event?.pull_request || event;
+  if (!pullRequest?.labels || !pullRequest?.user?.login) {
+    throw new Error("Expected a GitHub pull request payload.");
+  }
+  return pullRequest;
+}
+
 export async function approveWeblateUnit({ weblateUrl, headers, unit }) {
   const response = await fetch(`${weblateUrl}/api/units/${unit.id}/`, {
     method: "PATCH",

--- a/scripts/weblate-approval.test.mjs
+++ b/scripts/weblate-approval.test.mjs
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildUnitApprovalPayload } from "./weblate-approval.mjs";
+import {
+  buildUnitApprovalPayload,
+  getPullRequestPayload,
+} from "./weblate-approval.mjs";
 
 test("approving a Weblate unit preserves its target value", () => {
   assert.deepEqual(
@@ -15,4 +18,10 @@ test("approving a Weblate unit requires a target value", () => {
     () => buildUnitApprovalPayload({ id: 1460, target: [] }),
     /has no translation target/,
   );
+});
+
+test("manual recovery uses the same pull request payload shape as an event", () => {
+  const pullRequest = { labels: [], user: { login: "rizzek" } };
+  assert.equal(getPullRequestPayload({ pull_request: pullRequest }), pullRequest);
+  assert.equal(getPullRequestPayload(pullRequest), pullRequest);
 });


### PR DESCRIPTION
## Summary
- repair the manual Weblate approval recovery payload
- add per-PR `skip-web-check` and `skip-mobile-check` labels
- rerun PR quality automatically when either override label changes
- document the overrides and their scope

## Verification
- npm run test:workflows (21 passing)
- node --check scripts/approve-weblate-pr.mjs
- exact GitHub API payload shape verified against PR #376
- git diff --check