### PR TITLE
fix(ci): match Weblate units without search parsing

### DIFF
--- a/docs/ci-check-overrides.md
+++ b/docs/ci-check-overrides.md
@@ -1,14 +1,15 @@
 # PR check overrides
 
 Use these labels only when a known, unrelated failure should not block a pull
-request. They apply only to the pull request validation run; the normal
-`preview` or `main` push validation still runs after merge.
+request. The normal `preview` or `main` push validation still runs after merge.
 
-| Label | Skips |
-| --- | --- |
-| `skip-web-check` | Typecheck, test, and verify OpenAPI |
-| `skip-mobile-check` | Typecheck and export mobile |
+| Label               | Skips                                                  |
+| ------------------- | ------------------------------------------------------ |
+| `skip-web-check`    | Typecheck, test, and verify OpenAPI; Vercel PR preview |
+| `skip-mobile-check` | Typecheck and export mobile                            |
 
-The affected-app classification and Vercel preview are deliberately not
-skippable with these labels. Remove an override label once it is no longer
-needed.
+Vercel reads `skip-web-check` using its pull request and repository system
+environment variables. Ensure **Automatically expose System Environment
+Variables** is enabled in the Vercel project settings. If GitHub cannot be
+reached, Vercel builds the preview rather than skipping it. Remove an override
+label once it is no longer needed.

--- a/scripts/app-impact.mjs
+++ b/scripts/app-impact.mjs
@@ -102,10 +102,7 @@ export function classifyAppImpact(
   }
 
   const impact = Object.fromEntries(
-    TARGETS.map((target) => [
-      target,
-      isTargetAffected(target, changedPaths),
-    ]),
+    TARGETS.map((target) => [target, isTargetAffected(target, changedPaths)]),
   );
 
   if (changedPaths.includes(LOCKFILE)) {
@@ -154,6 +151,38 @@ export function hasWeblateTranslationBatch(batches) {
   );
 }
 
+export function hasSkipWebCheckLabel(labels) {
+  return labels.some(({ name }) => name === "skip-web-check");
+}
+
+export async function shouldSkipVercelWebPreview(
+  {
+    pullRequestId = process.env.VERCEL_GIT_PULL_REQUEST_ID,
+    repositoryOwner = process.env.VERCEL_GIT_REPO_OWNER,
+    repositorySlug = process.env.VERCEL_GIT_REPO_SLUG,
+  } = {},
+  request = fetch,
+) {
+  if (!pullRequestId || !repositoryOwner || !repositorySlug) return false;
+
+  try {
+    const response = await request(
+      `https://api.github.com/repos/${repositoryOwner}/${repositorySlug}/issues/${pullRequestId}`,
+      {
+        headers: { Accept: "application/vnd.github+json" },
+        signal: AbortSignal.timeout(3000),
+      },
+    );
+    if (!response.ok) return false;
+
+    const issue = await response.json();
+    return hasSkipWebCheckLabel(issue.labels || []);
+  } catch {
+    // If GitHub is unavailable, keep the safe default and build the preview.
+    return false;
+  }
+}
+
 function readChangedPaths(base, head) {
   const result = spawnSync(
     "git",
@@ -195,13 +224,20 @@ function readCommitMessage(head) {
 }
 
 function readRevisionCommits(base, head) {
-  const result = spawnSync("git", ["rev-list", "--reverse", `${base}..${head}`], {
-    encoding: "utf8",
-  });
+  const result = spawnSync(
+    "git",
+    ["rev-list", "--reverse", `${base}..${head}`],
+    {
+      encoding: "utf8",
+    },
+  );
   if (result.status !== 0) {
     throw new Error(result.stderr.trim() || "Unable to read revision commits.");
   }
-  return result.stdout.split("\n").map((commit) => commit.trim()).filter(Boolean);
+  return result.stdout
+    .split("\n")
+    .map((commit) => commit.trim())
+    .filter(Boolean);
 }
 
 function hasWeblateTranslationBatchInRange(base, head) {
@@ -239,6 +275,11 @@ async function run() {
       deferForWeblate: isPreviewBranch(),
       isWeblateTranslationBatch: hasWeblateTranslationBatchInRange(base, head),
     });
+
+    if (target === "web" && (await shouldSkipVercelWebPreview())) {
+      impact.web = false;
+      console.log("Vercel preview skipped by the skip-web-check PR label.");
+    }
   } catch (error) {
     console.warn(
       `Could not determine app impact for ${base}..${head}; running all checks as a safe fallback.`,

--- a/scripts/app-impact.test.mjs
+++ b/scripts/app-impact.test.mjs
@@ -4,8 +4,10 @@ import test from "node:test";
 import {
   classifyAppImpact,
   hasWeblateTranslationBatch,
+  hasSkipWebCheckLabel,
   isTargetAffected,
   isWeblateTranslationBatch,
+  shouldSkipVercelWebPreview,
 } from "./app-impact.mjs";
 
 test("app-local changes affect only their app", () => {
@@ -107,7 +109,8 @@ test("recognizes a Weblate batch anywhere in a multi-commit push", () => {
   assert.equal(
     hasWeblateTranslationBatch([
       {
-        message: "chore(l10n): update German translation\n\nTranslation-Batch: weblate-auto",
+        message:
+          "chore(l10n): update German translation\n\nTranslation-Batch: weblate-auto",
         changedPaths: ["packages/i18n/locales/de/default.json"],
         sourceChangedPaths: [],
       },
@@ -118,6 +121,38 @@ test("recognizes a Weblate batch anywhere in a multi-commit push", () => {
       },
     ]),
     true,
+  );
+});
+
+test("skip-web-check skips only the matching Vercel pull request preview", async () => {
+  assert.equal(hasSkipWebCheckLabel([{ name: "skip-web-check" }]), true);
+  assert.equal(hasSkipWebCheckLabel([{ name: "skip-mobile-check" }]), false);
+
+  assert.equal(
+    await shouldSkipVercelWebPreview(
+      {
+        pullRequestId: "383",
+        repositoryOwner: "ljreaux",
+        repositorySlug: "MeadTools",
+      },
+      async () => ({
+        ok: true,
+        json: async () => ({ labels: [{ name: "skip-web-check" }] }),
+      }),
+    ),
+    true,
+  );
+
+  assert.equal(
+    await shouldSkipVercelWebPreview(
+      {
+        pullRequestId: "383",
+        repositoryOwner: "ljreaux",
+        repositorySlug: "MeadTools",
+      },
+      async () => ({ ok: false }),
+    ),
+    false,
   );
 });
 
@@ -134,10 +169,7 @@ test("the migration build pause overrides every affected app", () => {
 
 test("an app manifest and lockfile change affect only that app", () => {
   assert.deepEqual(
-    classifyAppImpact([
-      "apps/mobile/package.json",
-      "package-lock.json",
-    ]),
+    classifyAppImpact(["apps/mobile/package.json", "package-lock.json"]),
     {
       web: false,
       mobile: true,

--- a/scripts/approve-weblate-issue.mjs
+++ b/scripts/approve-weblate-issue.mjs
@@ -6,7 +6,11 @@ import {
   getWeblateTranslationBatch,
   github,
 } from "./queue-weblate-review.mjs";
-import { approveWeblateUnit } from "./weblate-approval.mjs";
+import {
+  approveWeblateUnit,
+  findExpectedWeblateUnit,
+  loadWeblateComponentUnits,
+} from "./weblate-approval.mjs";
 
 const WEBLATE_URL = process.env.WEBLATE_URL?.replace(/\/$/, "");
 const WEBLATE_TOKEN = process.env.WEBLATE_APPROVAL_TOKEN;
@@ -88,20 +92,23 @@ async function approveUnits(changedUnits) {
     Accept: "application/json",
     Authorization: `Token ${WEBLATE_TOKEN}`,
   };
+  const unitsByComponent = new Map();
 
   for (const { component, context, target } of changedUnits) {
-    const query = new URLSearchParams({
-      q: `component:${component} language:de context:${context}`,
-      page_size: "10",
-    });
-    const response = await fetch(`${WEBLATE_URL}/api/units/?${query}`, { headers });
-    if (!response.ok) {
-      throw new Error(`Unable to find Weblate unit for ${component}:${context}.`);
+    if (!unitsByComponent.has(component)) {
+      unitsByComponent.set(
+        component,
+        await loadWeblateComponentUnits({
+          weblateUrl: WEBLATE_URL,
+          headers,
+          component,
+        }),
+      );
     }
 
-    const { results } = await response.json();
-    const unit = results.find(
-      (candidate) => candidate.context === context && candidate.target?.[0] === target,
+    const unit = findExpectedWeblateUnit(
+      unitsByComponent.get(component),
+      { context, target },
     );
     if (!unit) {
       throw new Error(

--- a/scripts/approve-weblate-pr.mjs
+++ b/scripts/approve-weblate-pr.mjs
@@ -3,7 +3,9 @@ import { readFileSync } from "node:fs";
 
 import {
   approveWeblateUnit,
+  findExpectedWeblateUnit,
   getPullRequestPayload,
+  loadWeblateComponentUnits,
 } from "./weblate-approval.mjs";
 
 const WEBLATE_URL = process.env.WEBLATE_URL?.replace(/\/$/, "");
@@ -103,20 +105,23 @@ const headers = {
   Accept: "application/json",
   Authorization: `Token ${WEBLATE_TOKEN}`,
 };
+const unitsByComponent = new Map();
 
 for (const { component, context, target } of changedUnits) {
-  const query = new URLSearchParams({
-    q: `component:${component} language:de context:${context}`,
-    page_size: "10",
-  });
-  const response = await fetch(`${WEBLATE_URL}/api/units/?${query}`, { headers });
-  if (!response.ok) {
-    throw new Error(`Unable to find Weblate unit for ${component}:${context}.`);
+  if (!unitsByComponent.has(component)) {
+    unitsByComponent.set(
+      component,
+      await loadWeblateComponentUnits({
+        weblateUrl: WEBLATE_URL,
+        headers,
+        component,
+      }),
+    );
   }
 
-  const { results } = await response.json();
-  const unit = results.find(
-    (candidate) => candidate.context === context && candidate.target?.[0] === target,
+  const unit = findExpectedWeblateUnit(
+    unitsByComponent.get(component),
+    { context, target },
   );
   if (!unit) {
     throw new Error(

--- a/scripts/weblate-approval.mjs
+++ b/scripts/weblate-approval.mjs
@@ -17,6 +17,30 @@ export function getPullRequestPayload(event) {
   return pullRequest;
 }
 
+export function findExpectedWeblateUnit(units, { context, target }) {
+  return units.find(
+    (candidate) => candidate.context === context && candidate.target?.[0] === target,
+  );
+}
+
+export async function loadWeblateComponentUnits({
+  weblateUrl,
+  headers,
+  component,
+}) {
+  const query = new URLSearchParams({
+    q: `component:${component} language:de`,
+    page_size: "10000",
+  });
+  const response = await fetch(`${weblateUrl}/api/units/?${query}`, { headers });
+  if (!response.ok) {
+    throw new Error(`Unable to load Weblate units for component ${component}.`);
+  }
+
+  const { results } = await response.json();
+  return results;
+}
+
 export async function approveWeblateUnit({ weblateUrl, headers, unit }) {
   const response = await fetch(`${weblateUrl}/api/units/${unit.id}/`, {
     method: "PATCH",

--- a/scripts/weblate-approval.test.mjs
+++ b/scripts/weblate-approval.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   buildUnitApprovalPayload,
+  findExpectedWeblateUnit,
   getPullRequestPayload,
 } from "./weblate-approval.mjs";
 
@@ -24,4 +25,15 @@ test("manual recovery uses the same pull request payload shape as an event", () 
   const pullRequest = { labels: [], user: { login: "rizzek" } };
   assert.equal(getPullRequestPayload({ pull_request: pullRequest }), pullRequest);
   assert.equal(getPullRequestPayload(pullRequest), pullRequest);
+});
+
+test("finds a unit with a search-reserved context name", () => {
+  const unit = { id: 2188, context: "error", target: ["Etwas ist schiefgelaufen"] };
+  assert.equal(
+    findExpectedWeblateUnit([unit], {
+      context: "error",
+      target: "Etwas ist schiefgelaufen",
+    }),
+    unit,
+  );
 });


### PR DESCRIPTION
## Summary
- resolve Weblate units from a component-local cache, avoiding query parsing conflicts such as the `error` context
- make `skip-web-check` skip the Vercel pull-request preview as well as the GitHub web Quality job
- document the Vercel system-environment-variable prerequisite

## Verification
- `npm run test:workflows` (23 passing)
- `node --check scripts/app-impact.mjs`
- `node --check scripts/app-impact.test.mjs`
- `git diff --check`